### PR TITLE
Create GitHub Action deployment workflow

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,50 @@
+name: Deploy Storybook site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+          
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: npm
+          
+      - name: Install dependencies
+        run: npm install
+        
+      - name: Build
+        run: npm run build-storybook -w apps/docs
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./apps/docs/storybook-static
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This builds the Storybook site and deploys to GitHub Pages.

It deploys from the `main` branch.

For this to work, 3 things will need to happen:

 * [this PR](https://github.com/Greater-London-Authority/ldn-viz-tools/pull/16) needs to be merged so the site can build under Ubuntu (which uses a case-sensitive filesystem)

* the new monorepo structure needs to be merged from the `dev` branch into `main`

* `Source` needs to be set to `GitHub Actions` on the `Pages` tab of the repository settings:

![page-settings](https://github.com/Greater-London-Authority/ldn-viz-tools/assets/338833/0458a4be-5de1-41d7-ba90-d0d9d7d66b1b)