### PR TITLE
After release, push update to different branch

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -32,6 +32,9 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+          
+          git checkout -b release-msg
+          
           git add -A .changeset
           git add packages/*/CHANGELOG.md
           git add packages/*/package.json
@@ -42,3 +45,4 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: release-msg


### PR DESCRIPTION
Currently, the workflow tries to push the auto-updated `CHANGELOG .md` and `package.json` files to the `main` branch, but this fails as the branch is protected.

The inability to push from an Action to a protected branch is apparently a common frustration:

* https://github.com/orgs/community/discussions/13836
* https://github.com/orgs/community/discussions/25305

This work-around is to automatically  push to a separate branch, then manually create/review/merge a PR.