### PR TITLE
Add docs & clean package commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2956,6 +2956,10 @@
       "resolved": "packages/maps",
       "link": true
     },
+    "node_modules/@ldn-viz/themes": {
+      "resolved": "packages/themes",
+      "link": true
+    },
     "node_modules/@ldn-viz/ui": {
       "resolved": "packages/ui",
       "link": true
@@ -14462,6 +14466,15 @@
       },
       "engines": {
         "node": ">=12.20"
+      }
+    },
+    "packages/themes": {
+      "version": "0.0.1",
+      "devDependencies": {
+        "eslint": "^8.28.0",
+        "eslint-config-prettier": "^8.5.0",
+        "prettier": "^2.8.0",
+        "publint": "^0.1.9"
       }
     },
     "packages/ui": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "private": true,
   "scripts": {
+    "clean": "rm -rf packages/*/.svelte-kit packages/*/.turbo packages/*/dist",
+    "docs": "npm run storybook -w apps/docs",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "scripts": {
-    "clean": "rm -rf packages/*/.svelte-kit packages/*/.turbo packages/*/dist",
     "docs": "npm run storybook -w apps/docs",
     "build": "turbo run build",
     "dev": "turbo run dev",

--- a/packages/charts/src/data/dataScatter.d.ts
+++ b/packages/charts/src/data/dataScatter.d.ts
@@ -1,0 +1,7 @@
+declare const _default: {
+    year: number;
+    value: number;
+    alt: number;
+    group: string;
+}[];
+export default _default;


### PR DESCRIPTION
I'm adding these because I had trouble getting things running yesterday afternoon. These commands were useful.

`packages/charts/src/data/dataScatter.d.ts` keeps getting created when building. I assume it is meant to be, but no one has yet to pushed it.