### PR TITLE
update storybook config to not throw errors after build

### DIFF
--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -5,9 +5,9 @@ const config: StorybookConfig = {
     '../src/**/*.stories.@(js|jsx|ts|tsx|svelte)',
     '../../../packages/ui/src/**/*.mdx',
     '../../../packages/ui/src/**/*.stories.@(js|jsx|ts|tsx|svelte)',
-    '../../../packages/charts/**/*.mdx',
+    '../../../packages/charts/src/**/*.mdx',
     '../../../packages/charts/src/**/*.stories.@(js|jsx|ts|tsx|svelte)',
-    '../../../packages/maps/**/*.mdx',
+    '../../../packages/maps/src/**/*.mdx',
     '../../../packages/maps/src/**/*.stories.@(js|jsx|ts|tsx|svelte)'
   ],
   addons: [


### PR DESCRIPTION
This fixes #38: it makes the patterns used to find storybook stories mroe restrictive, so that they do not include the contents of `dist/` folders.