### PR TITLE
rename 'style' prop of button to 'variant'

### DIFF
--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	export let style: 'primary' | 'secondary' | 'ghost' = 'primary';
+	export let variant: 'primary' | 'secondary' | 'ghost' = 'primary';
 	export let size: 'xs' | 'sm' | 'base' | 'lg' | 'xl' = 'base';
 	export let disabled = false;
 	export let href = '';
@@ -32,8 +32,8 @@
 	$: buttonClass = classNames(
 		'px-4 py-2 inline-flex justify-center',
 		sizeClasses[size],
-		styleClasses[style],
-		disabled === true ? disabledClasses[style] : '',
+		styleClasses[variant],
+		disabled === true ? disabledClasses[variant] : '',
 		href && disabled === true ? 'pointer-events-none' : '',
 		$$props.class
 	);

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -35,12 +35,12 @@
 <div>
 	{#if !buttonsHidden}
 		<Button
-			style="ghost"
+			variant="ghost"
 			on:click={selectAll}
 			disabled={numAvailableOptionsSelected === numAvailableOptions}
 			>Select all
 		</Button>
-		<Button style="ghost" on:click={clearAll} disabled={numAvailableOptionsSelected === 0}
+		<Button style="variant" on:click={clearAll} disabled={numAvailableOptionsSelected === 0}
 			>Clear all</Button
 		>
 	{/if}

--- a/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.stories.svelte
+++ b/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.stories.svelte
@@ -23,13 +23,13 @@
 </Story>
 
 <Story name="Button types">
-	<DataDownloadButton {data} filename="download" format="CSV" style="primary">
+	<DataDownloadButton {data} filename="download" format="CSV" variant="primary">
 		Primary<ArrowCircleDownIcon class="ml-2 w-6 h-6" aria-hidden="true" />
 	</DataDownloadButton>
-	<DataDownloadButton {data} filename="download" format="CSV" style="secondary">
+	<DataDownloadButton {data} filename="download" format="CSV" variant="secondary">
 		Secondary<DocumentDownloadIcon class="ml-2 w-6 h-6" aria-hidden="true" />
 	</DataDownloadButton>
-	<DataDownloadButton {data} filename="download" format="CSV" style="ghost">
+	<DataDownloadButton {data} filename="download" format="CSV" variant="ghost">
 		Ghost<svg
 			xmlns="http://www.w3.org/2000/svg"
 			fill="none"

--- a/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.stories.svelte
+++ b/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.stories.svelte
@@ -32,15 +32,15 @@
 		<circle cx="10" cy="10" r="10" fill="blue" />
 	</svg>
 
-	<ImageDownloadButton svgNode={svgRef} filename="download" style="primary">
+	<ImageDownloadButton svgNode={svgRef} filename="download" variant="primary">
 		Primary
 		<CameraIcon class="ml-2 w-6 h-6" aria-hidden="true" />
 	</ImageDownloadButton>
-	<ImageDownloadButton svgNode={svgRef} filename="download" style="secondary">
+	<ImageDownloadButton svgNode={svgRef} filename="download" variant="secondary">
 		Secondary
 		<CameraIcon class="ml-2 w-6 h-6" aria-hidden="true" />
 	</ImageDownloadButton>
-	<ImageDownloadButton svgNode={svgRef} filename="download" style="ghost">
+	<ImageDownloadButton svgNode={svgRef} filename="download" variant="ghost">
 		Ghost
 		<CameraIcon class="ml-2 w-6 h-6" aria-hidden="true" />
 	</ImageDownloadButton>

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
@@ -9,7 +9,7 @@
 
 <div>
 	{#if !buttonsHidden}
-		<Button style="ghost" on:click={() => (selectedId = '')}>Clear</Button>
+		<Button variant="ghost" on:click={() => (selectedId = '')}>Clear</Button>
 	{/if}
 	{#each options as option}
 		<RadioButton


### PR DESCRIPTION
We shouldn't use `style` as the name of a prop - it should be reserved for applying CSS styling.