### PR TITLE
allow some checkboxes in a CheckboxGroup to be initially checked

### DIFF
--- a/packages/ui/src/lib/checkBox/Checkbox.stories.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.stories.svelte
@@ -5,7 +5,7 @@
 
 	let checked = false;
 
-	let selectedOptions: string[] = [];
+	let selectedOptions: string[] = ['bus', 'underground'];
 
 	let optionsForGroup = [
 		{ id: 'bus', label: 'Bus stops', color: '#00AEEF' },

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -7,7 +7,7 @@
 	export let buttonsHidden = false;
 
 	export let selectedOptions: string[] = [];
-	let selectionState = Object.fromEntries(options.map((o) => [o.id, false]));
+	let selectionState = Object.fromEntries(options.map((o) => [o.id, selectedOptions.includes(o.id)]));
 
 	const numAvailableOptions = options.filter((o) => !o.disabled).length;
 	let numAvailableOptionsSelected: number;


### PR DESCRIPTION
Previously, all checkboxes were initially unchecked, regardless of whether or not the `selectedOptions` prop was empty.