### PR TITLE
export style files from map package

### DIFF
--- a/.changeset/quick-llamas-share.md
+++ b/.changeset/quick-llamas-share.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': minor
+---
+
+expose the style files from maps package

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -14,13 +14,8 @@
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
 		"format": "prettier --plugin-search-dir . --write ."
 	},
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
-		}
-	},
 	"files": [
+		"themes",
 		"dist",
 		"!dist/**/*.test.*",
 		"!dist/**/*.spec.*"


### PR DESCRIPTION
Currently the style files in `themes/` aren't currently being published to npm; this PR should fix this.