### PR TITLE
fix formatting of button in CheckboxGroup

### DIFF
--- a/.changeset/breezy-otters-exercise.md
+++ b/.changeset/breezy-otters-exercise.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+fix styling of buttons in CheckboxGroup

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -44,7 +44,11 @@
 			>Select all
 		</Button>
 
-		<Button style="variant" on:click={clearAll} disabled={numAvailableOptionsSelected === 0}
+		<Button
+			size="sm" 
+			variant="ghost" 
+			on:click={clearAll}
+			disabled={numAvailableOptionsSelected === 0}
 			>Clear all</Button
 		>
 	{/if}


### PR DESCRIPTION
This fixes the formatting of the "Clear All" button in the `CheckboxGroup` component - I accidentally mangled this when the `style` prop was renamed to `variant`.