### PR TITLE
Fix sizes of radio buttons when number of options is not 3

### DIFF
--- a/.changeset/thirty-boats-yell.md
+++ b/.changeset/thirty-boats-yell.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGE - fix sizing of `RadioButtonSolid` when the number of buttons in a group is not 3

--- a/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.stories.svelte
+++ b/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.stories.svelte
@@ -61,3 +61,39 @@
 	</RadioButtonGroupSolid>
 	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">Selected id: {selectedId}</p>
 </Story>
+
+<Story name="With 2 options">
+    <RadioButtonGroupSolid name="station-type" bind:selectedId>
+        <RadioButtonSolid id="bus" name="station-type-bus">
+            <FilterIcon class="w-6 h-6 mb-1" aria-hidden="true"/>
+            Bus
+        </RadioButtonSolid>
+        <RadioButtonSolid id="train" name="station-type-train">
+            <MapIcon class="w-6 h-6 mb-1" aria-hidden="true"/>
+            Train
+        </RadioButtonSolid>
+    </RadioButtonGroupSolid>
+    <p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">Selected id: {selectedId}</p>
+</Story>
+
+<Story name="With 4 options">
+    <RadioButtonGroupSolid name="station-type" bind:selectedId>
+        <RadioButtonSolid id="bus" name="station-type-bus">
+            <FilterIcon class="w-6 h-6 mb-1" aria-hidden="true"/>
+            Bus
+        </RadioButtonSolid>
+        <RadioButtonSolid id="train" name="station-type-train">
+            <MapIcon class="w-6 h-6 mb-1" aria-hidden="true"/>
+            Train
+        </RadioButtonSolid>
+        <RadioButtonSolid id="plane" name="station-type-plane">
+            <PresentationChartLineIcon class="w-6 h-6 mb-1" aria-hidden="true"/>
+            Plane
+        </RadioButtonSolid>
+        <RadioButtonSolid id="plane" name="station-type-plane">
+            <PresentationChartLineIcon class="w-6 h-6 mb-1" aria-hidden="true"/>
+            This_label_is_far_too_long
+        </RadioButtonSolid>
+    </RadioButtonGroupSolid>
+    <p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">Selected id: {selectedId}</p>
+</Story>

--- a/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.svelte
+++ b/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.svelte
@@ -14,7 +14,7 @@
 	const { selectedId } = getContext<{ selectedId: Writable<string> }>('selectedId');
 </script>
 
-<div class="w-1/3 flex">
+<div class="w-2 flex flex-grow flex-shrink">
 	<input
 		id={inputID}
 		type="radio"

--- a/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.svelte
+++ b/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.svelte
@@ -14,7 +14,7 @@
 	const { selectedId } = getContext<{ selectedId: Writable<string> }>('selectedId');
 </script>
 
-<div class="w-2 flex flex-grow flex-shrink">
+<div class="w-full flex">
 	<input
 		id={inputID}
 		type="radio"


### PR DESCRIPTION
Currently:

* when there only 2 options, the buttons do not increase beyond their initial size of 1/3 of the total space, so the button group only occupies 2/3 of the space that it should

* when there are more than 3 options, a button with a longer label can end up larger than the others

This PR fixes the first problem by allowing the elements to grow, and fixes the second by setting the initial size to a value smaller than the eventual size of each button will be.