### PR TITLE
Modal sizes

### DIFF
--- a/.changeset/flat-phones-stare.md
+++ b/.changeset/flat-phones-stare.md
@@ -1,0 +1,6 @@
+---
+'@ldn-viz/ui': minor
+'@ldn-viz/docs': patch
+---
+
+Added a width prop to the modal component

--- a/.changeset/flat-phones-stare.md
+++ b/.changeset/flat-phones-stare.md
@@ -3,4 +3,4 @@
 '@ldn-viz/docs': patch
 ---
 
-Added a width prop to the modal component
+CHANGED - Added a `width` prop to the `Modal` component

--- a/packages/ui/src/lib/modal/Modal.stories.svelte
+++ b/packages/ui/src/lib/modal/Modal.stories.svelte
@@ -3,6 +3,8 @@
 
 	import Modal from './Modal.svelte';
 
+	import Button from '../button/Button.svelte';
+
 	let isOpen = true;
 </script>
 
@@ -15,9 +17,7 @@
 <Story name="Default" args={{ title: 'Title', description: 'Description', isOpen: true }} />
 
 <Story name="Description only">
-	<button class="btn bg-core-grey-500 text-core-grey-50 p-4" on:click={() => (isOpen = true)}
-		>Open modal!</button
-	>
+	<Button on:click={() => (isOpen = true)}>Open modal!</Button>
 
 	<Modal
 		bind:isOpen
@@ -27,9 +27,7 @@
 </Story>
 
 <Story name="Description and Contents">
-	<button class="btn bg-core-grey-500 text-core-grey-50 p-4" on:click={() => (isOpen = true)}
-		>Open modal!</button
-	>
+	<Button on:click={() => (isOpen = true)}>Open modal!</Button>
 
 	<Modal
 		bind:isOpen
@@ -46,9 +44,7 @@
 </Story>
 
 <Story name="Contents without description">
-	<button class="btn bg-core-grey-500 text-core-grey-50 p-4" on:click={() => (isOpen = true)}
-		>Open modal!</button
-	>
+	<Button on:click={() => (isOpen = true)}>Open modal!</Button>
 
 	<Modal bind:isOpen title="A modal with contents!">
 		<p>A list</p>
@@ -61,19 +57,18 @@
 </Story>
 
 <Story name="Modal with close button">
-	<button class="btn bg-core-grey-500 p-4" on:click={() => (isOpen = true)}>Open modal!</button>
+	<Button on:click={() => (isOpen = true)}>Open modal!</Button>
 
 	<Modal bind:isOpen title="A modal with close button!">
-		<div class="p-4">
+		<div class="mb-4">
 			In a real example, these buttons would be appropriately styled, and potentially perform some
 			action in addition to closing the modal.
 		</div>
 
-		<button class="btn bg-core-grey-500 text-core-grey-50 p-4" on:click={() => (isOpen = false)}
-			>Accept</button
+		<Button variant="ghost" class="bg-core-green-400" on:click={() => (isOpen = false)}
+			>Accept</Button
 		>
-		<button class="btn bg-core-grey-500 text-core-grey-50 p-4" on:click={() => (isOpen = false)}
-			>Cancel</button
+		<Button variant="ghost" class="bg-core-red-400" on:click={() => (isOpen = false)}>Cancel</Button
 		>
 	</Modal>
 </Story>

--- a/packages/ui/src/lib/modal/Modal.stories.svelte
+++ b/packages/ui/src/lib/modal/Modal.stories.svelte
@@ -80,6 +80,6 @@
 		bind:isOpen
 		width="6xl"
 		title="A wider modal!"
-		description="We can use the width prop to set differetn max-widths from xs though 7xl and full. Default is md"
+		description="We can use the width prop to set different max-widths from xs though 7xl and full. Default is md"
 	/>
 </Story>

--- a/packages/ui/src/lib/modal/Modal.stories.svelte
+++ b/packages/ui/src/lib/modal/Modal.stories.svelte
@@ -72,3 +72,14 @@
 		>
 	</Modal>
 </Story>
+
+<Story name="Modal width">
+	<Button on:click={() => (isOpen = true)}>Open modal!</Button>
+
+	<Modal
+		bind:isOpen
+		width="6xl"
+		title="A wider modal!"
+		description="We can use the width prop to set differetn max-widths from xs though 7xl and full. Default is md"
+	/>
+</Story>

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -5,12 +5,46 @@
 		DialogOverlay,
 		DialogTitle
 	} from '@rgossiaux/svelte-headlessui';
+	import { classNames } from '../utils/classNames';
 
 	export let isOpen = false;
 	export let title: string;
 	export let description: string;
+	export let width:
+		| 'xs'
+		| 'sm'
+		| 'md'
+		| 'lg'
+		| 'xl'
+		| '2xl'
+		| '3xl'
+		| '4xl'
+		| '5xl'
+		| '6xl'
+		| '7xl'
+		| 'full' = 'md';
 
 	const hasChildren = Object.keys($$slots).length > 0;
+
+	const widthClasses = {
+		xs: 'max-w-xs',
+		sm: 'max-w-sm',
+		md: 'max-w-md',
+		lg: 'max-w-lg',
+		xl: 'max-w-xl',
+		'2xl': 'max-w-2xl',
+		'3xl': 'max-w-3xl',
+		'4xl': 'max-w-4xl',
+		'5xl': 'max-w-5xl',
+		'6xl': 'max-w-6xl',
+		'7xl': 'max-w-7xl',
+		full: 'max-w-full'
+	};
+
+	$: modalClass = classNames(
+		'inline-block w-full my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl space-y-2 pb-4 pointer-events-auto',
+		widthClasses[width]
+	);
 </script>
 
 <Dialog open={isOpen} on:close={() => (isOpen = false)} class="relative z-10 overflow-y-auto">
@@ -18,9 +52,7 @@
 
 	<!--Full-screen container to center the panel -->
 	<div class="fixed inset-0 flex items-center justify-center p-4 pointer-events-none">
-		<div
-			class="inline-block w-full max-w-md my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl space-y-2 pb-4 pointer-events-auto"
-		>
+		<div class={modalClass}>
 			<div class="bg-core-grey-600 text-white p-2 relative">
 				<DialogTitle>{title}</DialogTitle>
 				<button


### PR DESCRIPTION
**What does this change?**
This adds a width prop to the modal component to control the max width of said component

**Why?**
This allows greater flexibility for things such as charts, videos, in modals where wider content is desirable

**How?**
Using the classnames utility the component now accepts a 'width' prop mapped from xs - 7xl + full tailwind classes

**Related issues**:
https://github.com/Greater-London-Authority/ldn-viz-tools/issues/77

**Does this introduce new dependencies?**
no

**How is it tested?**
storybook

**How is it documented?**
storybook

**Are light and dark themes considered?**
n/a

**Is it complete?**
- [y] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
