### PR TITLE
add a link card component based on Survey of Londoners

### DIFF
--- a/.changeset/late-buttons-obey.md
+++ b/.changeset/late-buttons-obey.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+ADDED - added `CardLink` component

--- a/packages/ui/src/lib/cardLink/CardLink.stories.svelte
+++ b/packages/ui/src/lib/cardLink/CardLink.stories.svelte
@@ -1,0 +1,18 @@
+<script>
+	import { Meta, Story } from '@storybook/addon-svelte-csf';
+
+	import CardLink from './CardLink.svelte';
+</script>
+
+<Meta title="Ui/CardLink" component={CardLink} />
+
+<Story name="Default">
+	<CardLink>
+		<span slot="body">
+			The full dataset that this explorer is based on is available for download from the London
+			Datastore, along with other documents like the Technical Report, which contains the
+			questionnaires from the survey.
+		</span>
+		<span slot="footer">The Survey of Londoners on London Datastore</span>
+	</CardLink>
+</Story>

--- a/packages/ui/src/lib/cardLink/CardLink.stories.svelte
+++ b/packages/ui/src/lib/cardLink/CardLink.stories.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { DocumentDownloadIcon } from '@rgossiaux/svelte-heroicons/solid';
 	import { Meta, Story } from '@storybook/addon-svelte-csf';
 
 	import CardLink from './CardLink.svelte';
@@ -14,5 +15,21 @@
 			questionnaires from the survey.
 		</span>
 		<span slot="footer">The Survey of Londoners on London Datastore</span>
+	</CardLink>
+</Story>
+
+<Story name="Rounded">
+	<CardLink rounded>
+		<span slot="body" class="text-3xl font-serif mb-2"> Download the User Guide. </span>
+		<span slot="footer">PDF</span>
+		<span slot="icon"><DocumentDownloadIcon class="h-6 w-6" /></span>
+	</CardLink>
+</Story>
+
+<Story name="Green Rounded">
+	<CardLink rounded green>
+		<span slot="body" class="text-3xl font-serif mb-2"> Download the User Guide. </span>
+		<span slot="footer">PDF</span>
+		<span slot="icon"><DocumentDownloadIcon class="h-6 w-6" /></span>
 	</CardLink>
 </Story>

--- a/packages/ui/src/lib/cardLink/CardLink.svelte
+++ b/packages/ui/src/lib/cardLink/CardLink.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-		import { ArrowRightIcon } from '@rgossiaux/svelte-heroicons/solid';
+	import { ArrowRightIcon } from '@rgossiaux/svelte-heroicons/solid';
 
 	import { classNames } from '../utils/classNames';
 
 	export let href = '';
 	export let newWindow = false;
+	export let rounded = false;
+
+	export let green = false;
 </script>
 
 <a
@@ -12,9 +15,12 @@
 	target={newWindow ? '_blank' : '_self'}
 	rel={newWindow ? 'noopener noreferrer' : ''}
 	class={classNames(
-		'bg-core-grey-700 hover:bg-core-grey-800 text-white',
-		'dark:bg-core-grey-200 dark:group dark:hover:bg-core-grey-300 dark:text-black',
-		'group transition h-full flex flex-col max-w-xl'
+		green
+			? 'bg-core-green-600 hover:bg-core-green-700 text-white'
+			: 'bg-core-grey-700 hover:bg-core-grey-800 text-white',
+		green ? '' : 'dark:bg-core-grey-200 dark:group dark:hover:bg-core-grey-300 dark:text-black',
+		'group transition h-full flex flex-col max-w-xl',
+		rounded ? 'rounded-lg' : ''
 	)}
 >
 	<div class="p-4 max-w-xl h-full">
@@ -22,12 +28,15 @@
 	</div>
 	<div
 		class={classNames(
-			'bg-core-grey-800 group-hover:bg-core-blue-600',
-			'dark:bg-core-grey-300 group-hover:bg-core-blue-600',
-			'p-4 mt-4 flex justify-between  transition'
+			green ? 'bg-core-green-800' : 'bg-core-grey-800 group-hover:bg-core-blue-600',
+			green ? '' : 'dark:bg-core-grey-300 dark:group-hover:bg-core-blue-600',
+			'p-4 mt-4 flex justify-between  transition',
+			rounded ? 'rounded-b-lg' : ''
 		)}
 	>
 		<slot name="footer" />
-		<ArrowRightIcon class="h-6 w-6" />
+		<slot name="icon">
+			<ArrowRightIcon class="h-6 w-6" />
+		</slot>
 	</div>
 </a>

--- a/packages/ui/src/lib/cardLink/CardLink.svelte
+++ b/packages/ui/src/lib/cardLink/CardLink.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+		import { ArrowRightIcon } from '@rgossiaux/svelte-heroicons/solid';
+
+	import { classNames } from '../utils/classNames';
+
+	export let href = '';
+	export let newWindow = false;
+</script>
+
+<a
+	{href}
+	target={newWindow ? '_blank' : '_self'}
+	rel={newWindow ? 'noopener noreferrer' : ''}
+	class={classNames(
+		'bg-core-grey-700 hover:bg-core-grey-800 text-white',
+		'dark:bg-core-grey-200 dark:group dark:hover:bg-core-grey-300 dark:text-black',
+		'group transition h-full flex flex-col max-w-xl'
+	)}
+>
+	<div class="p-4 max-w-xl h-full">
+		<slot name="body" />
+	</div>
+	<div
+		class={classNames(
+			'bg-core-grey-800 group-hover:bg-core-blue-600',
+			'dark:bg-core-grey-300 group-hover:bg-core-blue-600',
+			'p-4 mt-4 flex justify-between  transition'
+		)}
+	>
+		<slot name="footer" />
+		<ArrowRightIcon class="h-6 w-6" />
+	</div>
+</a>

--- a/packages/ui/src/lib/index.js
+++ b/packages/ui/src/lib/index.js
@@ -1,6 +1,8 @@
 // Reexport your entry components here
 export { default as Button } from './button/Button.svelte';
 
+export { default as CardLink } from "./cardLink/CardLink.svelte";
+
 export { default as Checkbox } from './checkBox/Checkbox.svelte';
 export { default as CheckboxGroup } from './checkBox/CheckboxGroup.svelte';
 


### PR DESCRIPTION
**What does this change?**

This adds a Card component that is acts as a link. It is based on those in th Survey of Londoners.

**Why?**

This pattern has been used in a few places so far ([Survey of Londoners](apps.london.gov.uk/survey-of-londoners/) and [Wellbeing Explorer](https://apps.london.gov.uk/wellbeing)), and I want to use it on the multivariate census explorer too,

**Does this introduce new dependencies?**

No.

**How is it tested?**

**How is it documented?**

**Are light and dark themes considered?**

**Is it complete?**
- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
