### PR TITLE
Rename columns for download

### DIFF
--- a/.changeset/famou-pears-wink.md
+++ b/.changeset/famou-pears-wink.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: `DataDownloadButton` now accepts a prop defining a mapping from the names of fields in the provided data object, and the names that should be used in the downloaded file

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 This is a mono-repo containing several components:
 
-- the [`@ldn-viz/charts`](https://www.npmjs.com/package/@ldn-viz/charts) package is in [charts](./packages/charts); it contains components for visualizing data
-- the [`@ldn-viz/maps`](https://www.npmjs.com/package/@ldn-viz/maps) package is in [maps](./packages/maps); it contains components for rendering maps
-- the [`@ldn-viz/ui`](https://www.npmjs.com/package/@ldn-viz/ui) package is in [ui](./packages/ui); it contains general UI components like modals or sidebars
-- the [`@ldn-viz/themes`](https://www.npmjs.com/package/@ldn-viz/themes) package is in [theme](./packages/themes); it contains CSS and design tokens that are used by other components
+- the [`@ldn-viz/charts`](https://www.npmjs.com/package/@ldn-viz/charts) package is in [`charts/`](./packages/charts); it contains components for visualizing data
+- the [`@ldn-viz/maps`](https://www.npmjs.com/package/@ldn-viz/maps) package is in [`maps/`](./packages/maps); it contains components for rendering maps
+- the [`@ldn-viz/ui`](https://www.npmjs.com/package/@ldn-viz/ui) package is in [`ui/`](./packages/ui); it contains general UI components like modals or sidebars
+- the [`@ldn-viz/themes`](https://www.npmjs.com/package/@ldn-viz/themes) package is in [`theme/`](./packages/themes); it contains CSS and design tokens that are used by other components
 
 These packages are intended primarily for use in projects created by [Greater London Authority](https://london.gov.uk/)'s [City Intelligence Unit](https://www.london.gov.uk/programmes-strategies/research-and-analysis).
 

--- a/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.stories.svelte
+++ b/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.stories.svelte
@@ -24,6 +24,17 @@
 	</DataDownloadButton>
 </Story>
 
+<Story name="Rename Columns">
+	<DataDownloadButton
+		{data}
+		filename="download"
+		format="CSV"
+		columnMapping={{ A: 'foo', B: 'bar', C: 'baz' }}
+	>
+		<Icon src={ArrowDownCircle} theme="solid" class="w-6 h-6" aria-hidden="true" />
+	</DataDownloadButton>
+</Story>
+
 <Story name="Button types">
 	<DataDownloadButton {data} filename="download" format="CSV" emphasis="primary">
 		Primary <Icon src={ArrowDownCircle} theme="solid" class="ml-2 w-6 h-6" aria-hidden="true" />

--- a/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.svelte
+++ b/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.svelte
@@ -4,10 +4,15 @@
 	import { csvFormat } from 'd3-dsv';
 
 	export let format: 'CSV' | 'JSON' | undefined;
-	export let data: any;
+	export let data: Record<string, number | string>[];
 	export let filename: string;
 
 	export let disabled = false;
+	export let columnMapping: undefined | { [oldName: string]: string };
+
+	const enforceExtension = (name: string, extension: string) => {
+		return name.toLocaleLowerCase().endsWith(extension) ? name : `name${extension}`;
+	}
 
 	const downloadFromURL = (url: string, name: string) => {
 		const link = document.createElement('a');
@@ -18,15 +23,30 @@
 	};
 
 	const downloadJSON = () => {
-		const dataString = JSON.stringify(data, null, 4);
+		const dataString = JSON.stringify(renameColumns(), null, 4);
 		const dataURL = 'data:application/json;base64,' + window.btoa(dataString);
-		downloadFromURL(dataURL, filename || `data.json`);
+		downloadFromURL(dataURL, enforceExtension(filename || 'data', '.json'));
 	};
 
 	const downloadCSV = () => {
-		const dataString = csvFormat(data);
+		const dataString = csvFormat(renameColumns());
 		const dataURL = 'data:application/csv;base64,' + window.btoa(dataString);
-		downloadFromURL(dataURL, filename || `data.csv`);
+		downloadFromURL(dataURL, enforceExtension(filename || 'data', '.csv'));
+	};
+
+	const renameColumns = () => {
+		return data.map((datum) => {
+			if (!columnMapping) {
+				return datum;
+			} else {
+				const reshapedDatum: { [newName: string]: string | number } = {};
+
+				for (const oldColName of Object.keys(columnMapping)) {
+					reshapedDatum[columnMapping[oldColName]] = datum[oldColName];
+				}
+				return reshapedDatum;
+			}
+		});
 	};
 
 	const download = format === 'JSON' ? downloadJSON : downloadCSV;


### PR DESCRIPTION
`DataDownloadButton` now accepts a prop defining a mapping from the names of fields in the provided data object, and the names that should be used in the downloaded file.


**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
