### PR TITLE
Fix MapApp & Map layouts

### DIFF
--- a/.changeset/abc-efg-hij.md
+++ b/.changeset/abc-efg-hij.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+Fix MapApp layout sizing.

--- a/.changeset/abc-efg-hij.md
+++ b/.changeset/abc-efg-hij.md
@@ -1,5 +1,5 @@
 ---
-'@ldn-viz/ui': minor
+'@ldn-viz/ui': patch
 ---
 
 Fix MapApp layout sizing and lack of overflow hidden for Map.

--- a/.changeset/abc-efg-hij.md
+++ b/.changeset/abc-efg-hij.md
@@ -2,4 +2,4 @@
 '@ldn-viz/ui': minor
 ---
 
-Fix MapApp layout sizing.
+Fix MapApp layout sizing and lack of overflow hidden for Map.

--- a/packages/maps/src/lib/map/Map.svelte
+++ b/packages/maps/src/lib/map/Map.svelte
@@ -37,6 +37,8 @@
 	export let whenMapLoads = null;
 	export let whenMapUnloads = null;
 
+	export let classes = '';
+
 	const defaultOptions = {
 		style: os_light_vts,
 		bounds: GREATER_LONDON_BOUNDS,
@@ -80,8 +82,7 @@
 
 <section
 	bind:this={container}
-	id="ldn-viz-map-container"
-	class="w-full h-full relative"
+	class="w-full h-full relative overflow-hidden {classes}"
 	{...$$restProps}
 >
 	<slot />

--- a/packages/maps/src/lib/map/MapApp.svelte
+++ b/packages/maps/src/lib/map/MapApp.svelte
@@ -1,6 +1,8 @@
 <script>
 	import { onMount } from 'svelte';
 
+	export let classes = '';
+
 	const dev = import.meta.env.DEV;
 	let noscript = true;
 
@@ -9,7 +11,7 @@
 	});
 </script>
 
-<div class="bg-core-grey-800 w-[100dvw] h-[100dvh] overflow-hidden flex flex-col">
+<div class="bg-core-grey-800 w-[100dvw] h-[100dvh] overflow-hidden flex flex-col {classes}">
 	<slot name="header" />
 
 	<main class="grow overflow-hidden flex flex-col">

--- a/packages/maps/src/lib/map/MapApp.svelte
+++ b/packages/maps/src/lib/map/MapApp.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount } from 'svelte';
 
+	const dev = import.meta.env.DEV;
 	let noscript = true;
 
 	onMount(() => {
@@ -8,17 +9,30 @@
 	});
 </script>
 
-<main class="bg-core-grey-800 w-[100dvw] h-[100dvh] overflow-hidden flex flex-col">
-	{#if noscript}
-		<section
-			class="bg-core-grey-800 w-full h-full flex justify-center items-center text-center ldn-viz-map-app-noscript-animation"
-		>
-			<p>Please enable JavaScript to explore this map.</p>
-		</section>
-	{:else}
-		<slot />
-	{/if}
-</main>
+<div class="bg-core-grey-800 w-[100dvw] h-[100dvh] overflow-hidden flex flex-col">
+	<slot name="header" />
+
+	<main class="grow overflow-hidden flex flex-col">
+		{#if noscript}
+			<section
+				class="bg-core-grey-800 w-full h-full flex justify-center items-center text-center ldn-viz-map-app-noscript-animation"
+			>
+				{#if dev}
+					<p>
+						<b>Dev mode:</b> Please wait as the initial load is the longest. Reloading may occur due
+						to dependency optimisation. Please ensure JavaScript is enabled.
+					</p>
+				{:else}
+					<p>Please enable JavaScript to explore this map.</p>
+				{/if}
+			</section>
+		{:else}
+			<slot />
+		{/if}
+	</main>
+
+	<slot name="footer" />
+</div>
 
 <style>
 	.ldn-viz-map-app-noscript-animation {


### PR DESCRIPTION
**What does this change?**

1. Fixed _MapApp_ not able to accommodate full width headers and footers.
2. Fixed _Map_ not hiding overflow caused by popups and tooltips on the map.

Also removed `id` from _Map_ as to accommodate multiple maps per page.

**Why?**

It broken.

- [x] Have you included changeset file?
