### PR TITLE
Update Checkbox so name prop required and id is optional

### DIFF
--- a/.changeset/jjj-kkk-lll.md
+++ b/.changeset/jjj-kkk-lll.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+Add 'name' attribute to Checkbox and set 'id' as optional.

--- a/packages/charts/src/data/dataScatter.d.ts
+++ b/packages/charts/src/data/dataScatter.d.ts
@@ -1,7 +1,7 @@
 declare const _default: {
-    year: number;
-    value: number;
-    alt: number;
-    group: string;
+	year: number;
+	value: number;
+	alt: number;
+	group: string;
 }[];
 export default _default;

--- a/packages/charts/src/data/dataScatter.d.ts
+++ b/packages/charts/src/data/dataScatter.d.ts
@@ -1,7 +1,7 @@
 declare const _default: {
-	year: number;
-	value: number;
-	alt: number;
-	group: string;
+    year: number;
+    value: number;
+    alt: number;
+    group: string;
 }[];
 export default _default;

--- a/packages/ui/src/lib/checkBox/Checkbox.stories.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.stories.svelte
@@ -16,7 +16,7 @@
 					type: { summary: 'string' }
 				}
 			},
-			id: {
+			name: {
 				control: { type: 'text' },
 				table: {
 					defaultValue: { summary: '' },
@@ -38,10 +38,10 @@
 	let selectedOptions: string[] = ['bus', 'underground'];
 
 	let optionsForGroup = [
-		{ id: 'bus', label: 'Bus stops', color: '#00AEEF' },
-		{ id: 'train', label: 'Train stations', color: '#008D48' },
-		{ id: 'underground', label: 'Underground stations', color: '#9E0059' },
-		{ id: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
+		{ name: 'bus', label: 'Bus stops', color: '#00AEEF' },
+		{ name: 'train', label: 'Train stations', color: '#008D48' },
+		{ name: 'underground', label: 'Underground stations', color: '#9E0059' },
+		{ name: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
 	];
 </script>
 

--- a/packages/ui/src/lib/checkBox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.svelte
@@ -4,7 +4,8 @@
 		checked: boolean;
 		indeterminate: boolean;
 		label: string;
-		id: string;
+		id?: string;
+		name: string;
 		disabled: boolean;
 	}
 </script>
@@ -15,14 +16,16 @@
 	export let checked: CheckboxProps['checked'] = false;
 	export let indeterminate: CheckboxProps['indeterminate'] = false;
 	export let label: CheckboxProps['label'];
-	export let id: CheckboxProps['id'];
+	export let id: CheckboxProps['id'] = undefined;
+	export let name: CheckboxProps['name'];
 	export let disabled: CheckboxProps['disabled'] = false;
 
-	let inputID = `input-${id}`;
+	let inputID = id ? `input-${id}` : undefined;
 </script>
 
 <label class="flex items-center">
 	<input
+		{name}
 		id={inputID}
 		class="form-checkbox"
 		type="checkbox"

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -1,20 +1,26 @@
 <script lang="ts">
 	import Checkbox from './Checkbox.svelte';
 
-	export let options: { id: string; label: string; disabled?: boolean; color?: string }[] = [];
+	export let options: {
+		id: string;
+		name: string;
+		label: string;
+		disabled?: boolean;
+		color?: string;
+	}[] = [];
 
 	export let buttonsHidden = false;
 
 	export let selectedOptions: string[] = [];
-	$: selectedOptions = options.map((o) => o.id).filter((id) => selectionState[id]);
+	$: selectedOptions = options.map((o) => o.name).filter((name) => selectionState[name]);
 
 	let selectionState = Object.fromEntries(
-		options.map((o) => [o.id, selectedOptions.includes(o.id)])
+		options.map((o) => [o.name, selectedOptions.includes(o.name)])
 	);
 
 	let allCheckboxesCheckedOrDisabled;
 	$: allCheckboxesCheckedOrDisabled = options.every((o) =>
-		o.disabled ? true : selectionState[o.id]
+		o.disabled ? true : selectionState[o.name]
 	);
 
 	let noCheckboxesChecked;
@@ -22,13 +28,13 @@
 
 	const selectAll = () => {
 		selectionState = Object.fromEntries(
-			options.map((o) => [o.id, o.disabled ? selectionState[o.id] : true])
+			options.map((o) => [o.name, o.disabled ? selectionState[o.name] : true])
 		);
 	};
 
 	const clearAll = () => {
 		selectionState = Object.fromEntries(
-			options.map((o) => [o.id, o.disabled ? selectionState[o.id] : false])
+			options.map((o) => [o.name, o.disabled ? selectionState[o.name] : false])
 		);
 	};
 
@@ -58,10 +64,11 @@
 		{#each options as option}
 			<Checkbox
 				id={option.id}
+				name={option.name}
 				label={option.label}
 				color={option.color}
 				disabled={option.disabled}
-				bind:checked={selectionState[option.id]}
+				bind:checked={selectionState[option.name]}
 			/>
 		{/each}
 	</div>


### PR DESCRIPTION
**What does this change?**

Regarding _Checkbox_ component:

1. Adds a required `name` prop.
2. Promotes `name` prop to primary identifier.
3. Demotes `id` prop to optional.

**Why?**

HTML form fields must have a `name` attribute as it is paired with the field value during submission, e.g. `name1=value1&name2=value2`. `name` must be unique within its `<form>`.

The `id` is not used by the form but still useful for general element stuff, e.g. CSS & JS selector.

**Related issues**:

Resolves #205.

**How is it tested?**

Storybook.

**How is it documented?**

Storybook.

- [x] Have you included changeset file?
