### PR TITLE
set name attribute for checkboxes (fix #205)

### DIFF
--- a/.changeset/kiui-jrioe-ner.md
+++ b/.changeset/kiui-jrioe-ner.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+CHANGE checkbox - set name attribute on generated input element

--- a/packages/ui/src/lib/checkBox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.svelte
@@ -24,6 +24,7 @@
 <label class="flex items-center">
 	<input
 		id={inputID}
+		name={id}
 		class="form-checkbox"
 		type="checkbox"
 		bind:checked


### PR DESCRIPTION
**What does this change?**

This sets the `name` attribute on the `input` elements generated by the `Checkbox` component.