### PR TITLE
Simple sidebar

### DIFF
--- a/packages/ui/src/lib/index.js
+++ b/packages/ui/src/lib/index.js
@@ -24,6 +24,11 @@ export { default as RadioButtonGroup } from './radioButton/RadioButtonGroup.svel
 export { default as RadioButtonGroupSolid } from './radioButtonSolid/RadioButtonGroupSolid.svelte';
 export { default as RadioButtonSolid } from './radioButtonSolid/RadioButtonSolid.svelte';
 export { default as Select } from './select/Select.svelte';
+export { default as Sidebar } from './sidebar/Sidebar.svelte';
+export { default as SidebarContainer } from './sidebar/SidebarContainer.svelte';
+export { default as SidebarHeader } from './sidebar/SidebarHeader.svelte';
+export { default as SidebarToggle } from './sidebar/SidebarToggle.svelte';
+export { default as SidebarSection } from './sidebar/SidebarSection.svelte';
 export { default as Spinner } from './spinners/Spinner.svelte';
 export { default as TabbedSidebar } from './tabbedSidebar/TabbedSidebar.svelte';
 export { default as TabbedSidebarTabLabel } from './tabbedSidebar/TabbedSidebarTabLabel.svelte';

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -47,7 +47,7 @@
 	);
 </script>
 
-<Dialog open={isOpen} on:close={() => (isOpen = false)} class="relative z-10 overflow-y-auto">
+<Dialog open={isOpen} on:close={() => (isOpen = false)} class="relative z-40 overflow-y-auto">
 	<DialogOverlay class="fixed inset-0 bg-black bg-opacity-40" />
 
 	<!--Full-screen container to center the panel -->

--- a/packages/ui/src/lib/sidebar/DefaultSidebarContent.svelte
+++ b/packages/ui/src/lib/sidebar/DefaultSidebarContent.svelte
@@ -38,20 +38,21 @@
 
 <SidebarSection title="State Management Store">
 	<p>
-		You can bind on the <i><code>open</code></i> prop to access the writable Svelte store managing the
-		sidebar's open/closed state.
+		You can bind on the <i><code>isOpen</code></i> prop to access the writable Svelte store managing
+		the sidebar's open/closed state. Adding the <i><code>startOpen</code></i> flag will set the sidebar
+		as open on load.
 	</p>
 	<div class="italic flex flex-col [&_code]:text-perceptual-orange-100">
-		<code>&lt;SidebarContainer startOpen bind:open={'{isOpen}'} /&gt;</code>
+		<code>&lt;SidebarContainer startOpen bind:isOpen /&gt;</code>
 	</div>
 </SidebarSection>
 
 <SidebarSection title="Svelte Context">
 	<p>
-		You can acces the <i><code>open</code></i> prop via Svelte context too:
+		You can acces the <i><code>isOpen</code></i> prop via Svelte context too:
 	</p>
 	<div class="italic flex flex-col [&_code]:text-perceptual-orange-100">
-		<code>getContext('sidebarOpen')</code>
+		<code>getContext('sidebarIsOpen')</code>
 	</div>
 
 	<p>

--- a/packages/ui/src/lib/sidebar/DefaultSidebarContent.svelte
+++ b/packages/ui/src/lib/sidebar/DefaultSidebarContent.svelte
@@ -1,0 +1,64 @@
+<script>
+	import SidebarHeader from './SidebarHeader.svelte';
+	import SidebarSection from './SidebarSection.svelte';
+</script>
+
+<SidebarHeader title="Hello there,">
+	<p>It looks like you're building a new app.</p>
+</SidebarHeader>
+
+<SidebarSection title="Boilerplate">
+	<div class="italic flex flex-col [&_code]:text-perceptual-orange-100">
+		<code>&lt;SidebarContainer&gt;</code>
+		<code class="pl-4">&lt;... slot="content" /&gt;</code>
+		<code class="pl-4">&lt;Sidebar slot="sidebar"&gt;</code>
+		<code class="pl-8">&lt;... /&gt;</code>
+		<code class="pl-8">&lt;... slot="footer" /&gt;</code>
+		<code class="pl-4">&lt;Sidebar&gt;</code>
+		<code>&lt;/SidebarContainer&gt;</code>
+	</div>
+</SidebarSection>
+
+<SidebarSection title="Custom sizing">
+	<p>
+		When in horizontal mode (desktop) the <code>sidebarWidth</code> property will be applied.
+		Defaults to <code>408px</code>.
+	</p>
+	<div class="italic flex flex-col [&_code]:text-perceptual-orange-100">
+		<code>&lt;SidebarContainer sidebarWidth="600px" /&gt;</code>
+	</div>
+	<p>
+		When in vertical mode (mobile) the <code>sidebarHeight</code> property will be applied. Defaults
+		to <code>calc(100% - 8rem)</code> to account for the map geocoder.
+	</p>
+	<div class="italic flex flex-col [&_code]:text-perceptual-orange-100">
+		<code>&lt;SidebarContainer sidebarHeight="400px" /&gt;</code>
+	</div>
+</SidebarSection>
+
+<SidebarSection title="State Management Store">
+	<p>
+		You can bind on the <i><code>open</code></i> prop to access the writable Svelte store managing the
+		sidebar's open/closed state.
+	</p>
+	<div class="italic flex flex-col [&_code]:text-perceptual-orange-100">
+		<code>&lt;SidebarContainer startOpen bind:open={'{isOpen}'} /&gt;</code>
+	</div>
+</SidebarSection>
+
+<SidebarSection title="Svelte Context">
+	<p>
+		You can acces the <i><code>open</code></i> prop via Svelte context too:
+	</p>
+	<div class="italic flex flex-col [&_code]:text-perceptual-orange-100">
+		<code>getContext('sidebarOpen')</code>
+	</div>
+
+	<p>
+		You can also access a derived store holding the sidebar container's layout configuration. You
+		can query it if you want the current viewing mode (horizontal or vertical) or dimensions:
+	</p>
+	<div class="italic flex flex-col [&_code]:text-perceptual-orange-100">
+		<code>getContext('sidebarContainer')</code>
+	</div>
+</SidebarSection>

--- a/packages/ui/src/lib/sidebar/ExampleOverview.svelte
+++ b/packages/ui/src/lib/sidebar/ExampleOverview.svelte
@@ -1,0 +1,36 @@
+<script>
+	import SidebarContainer from './SidebarContainer.svelte';
+	import Sidebar from './Sidebar.svelte';
+	import SidebarHeader from './SidebarHeader.svelte';
+	import SidebarSection from './SidebarSection.svelte';
+
+	/*
+		import {
+			SidebarContainer,
+			Sidebar,
+			SidebarHeader,
+			SidebarSection
+		} from '@ldn-viz/ui'
+	*/
+
+	import exampleCode from './ExampleOverview.svelte?raw';
+</script>
+
+<SidebarContainer>
+	<!-- Miain content -->
+	<div slot="content" class="p-6 text-white">
+		<pre><code>{exampleCode}</code></pre>
+	</div>
+
+	<!-- Sidebar -->
+	<Sidebar slot="sidebar">
+		<SidebarHeader title="Sidebar Overview" infoTitle="More info">
+			<p>Introductory paragraph or two.</p>
+			<p slot="info">More info content.</p>
+		</SidebarHeader>
+		<SidebarSection title="Section" infoTitle="More section info">
+			<p>Section content.</p>
+			<p slot="info">More section info content.</p>
+		</SidebarSection>
+	</Sidebar>
+</SidebarContainer>

--- a/packages/ui/src/lib/sidebar/ExampleOverview.svelte
+++ b/packages/ui/src/lib/sidebar/ExampleOverview.svelte
@@ -12,22 +12,19 @@
 			SidebarSection
 		} from '@ldn-viz/ui'
 	*/
-
-	import exampleCode from './ExampleOverview.svelte?raw';
 </script>
 
 <SidebarContainer>
-	<!-- Miain content -->
 	<div slot="content" class="p-6 text-white">
-		<pre><code>{exampleCode}</code></pre>
+		<slot />
 	</div>
 
-	<!-- Sidebar -->
 	<Sidebar slot="sidebar">
 		<SidebarHeader title="Sidebar Overview" infoTitle="More info">
 			<p>Introductory paragraph or two.</p>
 			<p slot="info">More info content.</p>
 		</SidebarHeader>
+
 		<SidebarSection title="Section" infoTitle="More section info">
 			<p>Section content.</p>
 			<p slot="info">More section info content.</p>

--- a/packages/ui/src/lib/sidebar/Sidebar.stories.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.stories.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	import { Meta, Story } from '@storybook/addon-svelte-csf';
+
+	import SidebarContainer from './SidebarContainer.svelte';
+	import Sidebar from './Sidebar.svelte';
+	import Button from '../button/Button.svelte';
+
+	import ExampleOverview from './ExampleOverview.svelte';
+
+	let isOpen;
+	const toggleSidebar = () => isOpen.update((v) => !v);
+</script>
+
+<Meta
+	title="Ui/Sidebar"
+	component={Sidebar}
+	parameters={{
+		layout: 'full'
+	}}
+/>
+
+<Story name="Default">
+	<SidebarContainer>
+		<Sidebar slot="sidebar" />
+	</SidebarContainer>
+</Story>
+
+<Story name="Getting Started">
+	<ExampleOverview />
+</Story>
+
+<Story name="Custom Sizing">
+	<SidebarContainer sidebarWidth="500px" sidebarHeight="400px">
+		<div slot="content" class="p-6 text-white space-y-2">
+			<p>Custom sidebar width for desktop and height for mobile:</p>
+			<pre><code
+					>{[`<SidebarContainer`, `\tidebarWidth="500px" `, `\tsidebarHeight="400px"`].join(
+						'\n'
+					)}</code
+				></pre>
+		</div>
+		<Sidebar slot="sidebar" />
+	</SidebarContainer>
+</Story>
+
+<Story name="Open State Store">
+	<SidebarContainer startOpen bind:open={isOpen}>
+		<div slot="content" class="p-6 text-white space-y-2">
+			<p>
+				You can bind on the <i><code>open</code></i> prop to access the writable Svelte store managing
+				the sidebar's open/closed state.
+			</p>
+
+			<p>
+				<Button type="secondary" variant="outline" on:click={toggleSidebar}>
+					Is open:&nbsp;<span class="text-core-red-300" class:text-core-green-400={$isOpen}
+						>{$isOpen}</span
+					>
+				</Button>
+			</p>
+
+			<pre><code>{[`<SidebarContainer`, `\tstartOpen`, `\tbind:open={isOpen}`].join('\n')}</code
+				></pre>
+		</div>
+		<Sidebar slot="sidebar" />
+	</SidebarContainer>
+</Story>
+
+<Story name="Sidebar Context">
+	<SidebarContainer>
+		<div slot="content" class="p-6 text-white space-y-2">
+			<p>
+				Every Svelte component inside the <code>SidebarContainer</code> or one of it's children can access
+				two context objects:
+			</p>
+
+			<pre><code
+					>{[
+						`\timport { getContext } from 'svelte'`,
+						`\tgetContext('sidebarOpen')`,
+						`\tgetContext('sidebarContainer')`
+					].join('\n')}</code
+				></pre>
+
+			<p>
+				The first returns the writable open store presented in the previous story. The latter
+				returns a derived store holding the sidebar container's layout configuration. It's required
+				to layout the <code>Sidebar</code> component.
+			</p>
+
+			<p>
+				You can query it if the content layout is dependent on the viewing mode (horizontal or
+				vertical). For example:
+			</p>
+
+			<pre><code
+					>{[
+						`\tconst con = getContext('sidebarContainer')`,
+						`\tconst isDesktop = $con.mode === $con.MODE_HORIZONTAL`
+					].join('\n')}</code
+				></pre>
+		</div>
+		<Sidebar slot="sidebar" />
+	</SidebarContainer>
+</Story>

--- a/packages/ui/src/lib/sidebar/Sidebar.stories.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.stories.svelte
@@ -6,6 +6,7 @@
 	import Button from '../button/Button.svelte';
 
 	import ExampleOverview from './ExampleOverview.svelte';
+	import exampleCode from './ExampleOverview.svelte?raw';
 
 	let isOpen;
 	const toggleSidebar = () => isOpen.update((v) => !v);
@@ -26,7 +27,10 @@
 </Story>
 
 <Story name="Getting Started">
-	<ExampleOverview />
+	<ExampleOverview>
+		<p class="mb-2 font-bold">This is the code for this story:</p>
+		<pre><code>{exampleCode}</code></pre>
+	</ExampleOverview>
 </Story>
 
 <Story name="Custom Sizing">
@@ -34,7 +38,7 @@
 		<div slot="content" class="p-6 text-white space-y-2">
 			<p>Custom sidebar width for desktop and height for mobile:</p>
 			<pre><code
-					>{[`<SidebarContainer`, `\tidebarWidth="500px" `, `\tsidebarHeight="400px"`].join(
+					>{[`<SidebarContainer`, `\tsidebarWidth="500px" `, `\tsidebarHeight="400px"`].join(
 						'\n'
 					)}</code
 				></pre>
@@ -44,7 +48,7 @@
 </Story>
 
 <Story name="Open State Store">
-	<SidebarContainer startOpen bind:open={isOpen}>
+	<SidebarContainer startOpen bind:isOpen>
 		<div slot="content" class="p-6 text-white space-y-2">
 			<p>
 				You can bind on the <i><code>open</code></i> prop to access the writable Svelte store managing
@@ -59,8 +63,7 @@
 				</Button>
 			</p>
 
-			<pre><code>{[`<SidebarContainer`, `\tstartOpen`, `\tbind:open={isOpen}`].join('\n')}</code
-				></pre>
+			<pre><code>{`<SidebarContainer startOpen bind:isOpen />`}</code></pre>
 		</div>
 		<Sidebar slot="sidebar" />
 	</SidebarContainer>
@@ -77,7 +80,7 @@
 			<pre><code
 					>{[
 						`\timport { getContext } from 'svelte'`,
-						`\tgetContext('sidebarOpen')`,
+						`\tgetContext('sidebarIsOpen')`,
 						`\tgetContext('sidebarContainer')`
 					].join('\n')}</code
 				></pre>
@@ -90,13 +93,13 @@
 
 			<p>
 				You can query it if the content layout is dependent on the viewing mode (horizontal or
-				vertical). For example:
+				vertical) and access the containers diemensions. For example:
 			</p>
 
 			<pre><code
 					>{[
-						`\tconst con = getContext('sidebarContainer')`,
-						`\tconst isDesktop = $con.mode === $con.MODE_HORIZONTAL`
+						`\tconst container = getContext('sidebarContainer')`,
+						`\tconst isDesktop = $container.isAlignedRight()`
 					].join('\n')}</code
 				></pre>
 		</div>

--- a/packages/ui/src/lib/sidebar/Sidebar.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.svelte
@@ -7,7 +7,7 @@
 	export let classes = '';
 
 	const sidebarContainer = getContext('sidebarContainer');
-	$: slidesFromRight = $sidebarContainer.mode === $sidebarContainer.MODE_HORIZONTAL;
+	$: isAlignedRight = $sidebarContainer.isAlignedRight();
 </script>
 
 <section
@@ -15,10 +15,10 @@
 >
 	<div
 		class="absolute"
-		style:top={slidesFromRight ? '0' : 'unset'}
-		style:right={slidesFromRight ? '100%' : 'unset'}
-		style:bottom={slidesFromRight ? 'unset' : '100%'}
-		style:left={slidesFromRight ? 'unset' : '0'}
+		style:top={isAlignedRight ? '0' : 'unset'}
+		style:right={isAlignedRight ? '100%' : 'unset'}
+		style:bottom={isAlignedRight ? 'unset' : '100%'}
+		style:left={isAlignedRight ? 'unset' : '0'}
 	>
 		<slot name="toggle">
 			<SidebarToggle />

--- a/packages/ui/src/lib/sidebar/Sidebar.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.svelte
@@ -1,0 +1,35 @@
+<script>
+	import { getContext } from 'svelte';
+
+	import SidebarToggle from './SidebarToggle.svelte';
+	import DefaultSidebarContent from './DefaultSidebarContent.svelte';
+
+	export let classes = '';
+
+	const sidebarContainer = getContext('sidebarContainer');
+	$: slidesFromRight = $sidebarContainer.mode === $sidebarContainer.MODE_HORIZONTAL;
+</script>
+
+<section
+	class="relative bg-core-grey-800 w-full h-full flex flex-col text-white text-sm z-30 {classes}"
+>
+	<div
+		class="absolute"
+		style:top={slidesFromRight ? '0' : 'unset'}
+		style:right={slidesFromRight ? '100%' : 'unset'}
+		style:bottom={slidesFromRight ? 'unset' : '100%'}
+		style:left={slidesFromRight ? 'unset' : '0'}
+	>
+		<slot name="toggle">
+			<SidebarToggle />
+		</slot>
+	</div>
+
+	<div class="dark grow overflow-y-auto overscroll-contain p-6 pb-2 flex flex-col gap-6">
+		<slot>
+			<DefaultSidebarContent />
+		</slot>
+	</div>
+
+	<slot name="footer" />
+</section>

--- a/packages/ui/src/lib/sidebar/SidebarContainer.svelte
+++ b/packages/ui/src/lib/sidebar/SidebarContainer.svelte
@@ -1,0 +1,112 @@
+<script context="module">
+	export const MODE_VERTICAL = 'vertical';
+	export const MODE_HORIZONTAL = 'horizontal';
+</script>
+
+<script>
+	import { setContext } from 'svelte';
+	import { writable, derived } from 'svelte/store';
+	import Sidebar from './Sidebar.svelte';
+
+	const ssr = import.meta.env.SSR;
+
+	export let containerWidth = '100dvw';
+	export let containerHeight = '100dvh';
+
+	export let sidebarWidth = '408px';
+	export let sidebarHeight = 'calc(100% - 8rem)';
+
+	export let startOpen = false;
+	export const open = writable(startOpen);
+
+	const refresher = writable(false);
+	const refresh = () => refresher.update((v) => !v);
+
+	const isSmallScreen = () => {
+		return window.matchMedia('(max-width: 639px)').matches;
+	};
+
+	const identifyMode = () => {
+		return ssr || isSmallScreen() ? MODE_VERTICAL : MODE_HORIZONTAL;
+	};
+
+	const generateConfig = ([isOpen, refresher]) => {
+		const mode = identifyMode();
+		const slideFromRight = mode === MODE_HORIZONTAL;
+
+		const ctd = isOpen ? '150ms' : '0ms';
+
+		const cw = !slideFromRight || !isOpen ? '100%' : `calc(100% - ${sidebarWidth})`;
+		const sw = slideFromRight ? sidebarWidth : '100%';
+		const sr = !slideFromRight || isOpen ? 0 : `-${sidebarWidth}`;
+
+		const ch = slideFromRight || !isOpen ? '100%' : `calc(100% - ${sidebarHeight})`;
+		const sh = slideFromRight ? '100%' : sidebarHeight;
+		const sb = slideFromRight || isOpen ? 0 : `calc(0px - ${sidebarHeight})`;
+
+		const c = {
+			MODE_VERTICAL,
+			MODE_HORIZONTAL,
+			mode,
+			// Container
+			containerWidth,
+			containerHeight,
+			// Content
+			contentWidth: cw,
+			contentHeight: ch,
+			contentTransitionDelay: ctd,
+			// Sidebar
+			sidebarWidth: sw,
+			sidebarHeight: sh,
+			sidebarRight: sr,
+			sidebarBottom: sb,
+			sidebarOpen: isOpen
+		};
+
+		return c;
+	};
+
+	export const config = derived(
+		[open, refresher], //
+		generateConfig, //
+		generateConfig([startOpen, refresher]) //
+	);
+
+	setContext('sidebarOpen', open);
+	setContext('sidebarContainer', config);
+</script>
+
+<svelte:window on:resize={refresh} />
+
+<div
+	class="relative bg-core-grey-600 overflow-hidden"
+	style:width={$config.containerWidth}
+	style:height={$config.containerHeight}
+	{...$$restProps}
+>
+	<div
+		class="absolute top-0 left-0"
+		style:width={$config.contentWidth}
+		style:height={$config.contentHeight}
+		style:transition-property={'width, height'}
+		style:transition-duration={'0ms'}
+		style:transition-delay={$config.contentTransitionDelay}
+	>
+		<slot name="content" />
+	</div>
+
+	<div
+		class="absolute"
+		style:right={$config.sidebarRight}
+		style:bottom={$config.sidebarBottom}
+		style:width={$config.sidebarWidth}
+		style:height={$config.sidebarHeight}
+		style:transition-property={'bottom, right'}
+		style:transition-duration={'150ms'}
+		style:transition-timing-function={'ease-out'}
+	>
+		<slot name="sidebar">
+			<Sidebar />
+		</slot>
+	</div>
+</div>

--- a/packages/ui/src/lib/sidebar/SidebarContainer.svelte
+++ b/packages/ui/src/lib/sidebar/SidebarContainer.svelte
@@ -1,6 +1,6 @@
 <script context="module">
-	export const MODE_VERTICAL = 'vertical';
-	export const MODE_HORIZONTAL = 'horizontal';
+	export const ALIGNMENT_BOTTOM = 'bottom';
+	export const ALIGNMENT_RIGHT = 'right';
 </script>
 
 <script>
@@ -17,7 +17,7 @@
 	export let sidebarHeight = 'calc(100% - 8rem)';
 
 	export let startOpen = false;
-	export const open = writable(startOpen);
+	export const isOpen = writable(startOpen);
 
 	const refresher = writable(false);
 	const refresh = () => refresher.update((v) => !v);
@@ -26,53 +26,47 @@
 		return window.matchMedia('(max-width: 639px)').matches;
 	};
 
-	const identifyMode = () => {
-		return ssr || isSmallScreen() ? MODE_VERTICAL : MODE_HORIZONTAL;
+	const identifyAlignment = () => {
+		return ssr || isSmallScreen() ? ALIGNMENT_BOTTOM : ALIGNMENT_RIGHT;
 	};
 
-	const generateConfig = ([isOpen, refresher]) => {
-		const mode = identifyMode();
-		const slideFromRight = mode === MODE_HORIZONTAL;
-
-		const ctd = isOpen ? '150ms' : '0ms';
-
-		const cw = !slideFromRight || !isOpen ? '100%' : `calc(100% - ${sidebarWidth})`;
-		const sw = slideFromRight ? sidebarWidth : '100%';
-		const sr = !slideFromRight || isOpen ? 0 : `-${sidebarWidth}`;
-
-		const ch = slideFromRight || !isOpen ? '100%' : `calc(100% - ${sidebarHeight})`;
-		const sh = slideFromRight ? '100%' : sidebarHeight;
-		const sb = slideFromRight || isOpen ? 0 : `calc(0px - ${sidebarHeight})`;
+	const generateConfig = ([open, refresher]) => {
+		const alignment = identifyAlignment();
+		const rightAligned = alignment === ALIGNMENT_RIGHT;
+		const botAligned = alignment === ALIGNMENT_BOTTOM;
 
 		const c = {
-			MODE_VERTICAL,
-			MODE_HORIZONTAL,
-			mode,
+			ALIGNMENT_BOTTOM,
+			ALIGNMENT_RIGHT,
+			alignment,
 			// Container
 			containerWidth,
 			containerHeight,
 			// Content
-			contentWidth: cw,
-			contentHeight: ch,
-			contentTransitionDelay: ctd,
+			contentWidth: botAligned || !open ? '100%' : `calc(100% - ${sidebarWidth})`,
+			contentHeight: rightAligned || !open ? '100%' : `calc(100% - ${sidebarHeight})`,
+			contentTransitionDelay: open ? '150ms' : '0ms',
 			// Sidebar
-			sidebarWidth: sw,
-			sidebarHeight: sh,
-			sidebarRight: sr,
-			sidebarBottom: sb,
-			sidebarOpen: isOpen
+			sidebarWidth: rightAligned ? sidebarWidth : '100%',
+			sidebarHeight: rightAligned ? '100%' : sidebarHeight,
+			sidebarRight: botAligned || open ? 0 : `-${sidebarWidth}`,
+			sidebarBottom: rightAligned || open ? 0 : `calc(0px - ${sidebarHeight})`,
+			sidebarIsOpen: isOpen
 		};
+
+		c.isAlignedBottom = () => c.alignment === c.ALIGNMENT_BOTTOM;
+		c.isAlignedRight = () => c.alignment === c.ALIGNMENT_RIGHT;
 
 		return c;
 	};
 
 	export const config = derived(
-		[open, refresher], //
+		[isOpen, refresher], //
 		generateConfig, //
 		generateConfig([startOpen, refresher]) //
 	);
 
-	setContext('sidebarOpen', open);
+	setContext('sidebarIsOpen', isOpen);
 	setContext('sidebarContainer', config);
 </script>
 

--- a/packages/ui/src/lib/sidebar/SidebarHeader.svelte
+++ b/packages/ui/src/lib/sidebar/SidebarHeader.svelte
@@ -1,0 +1,36 @@
+<script>
+	import SidebarMoreInfoModal from './SidebarMoreInfoModal.svelte';
+
+	export let title;
+	export let infoTitle = title;
+	export let classes = '';
+</script>
+
+<header
+	class="relative text-white flex flex-col gap-4 pl-4 before:absolute before:top-0 before:left-0 before:bg-core-blue-500 before:w-1 before:h-full pb-1 {classes}"
+	{...$$restProps}
+>
+	{#if title || $$slots.info}
+		<div>
+			{#if $$slots.info}
+				<SidebarMoreInfoModal title={infoTitle}>
+					<slot name="info" />
+				</SidebarMoreInfoModal>
+			{/if}
+
+			{#if title}
+				<h1 class="text-2xl uppercase leading-tight font-bold">
+					{@html title}
+				</h1>
+			{/if}
+		</div>
+	{/if}
+
+	<slot />
+</header>
+
+<style>
+	header {
+		@apply before:content-[''];
+	}
+</style>

--- a/packages/ui/src/lib/sidebar/SidebarMoreInfoModal.svelte
+++ b/packages/ui/src/lib/sidebar/SidebarMoreInfoModal.svelte
@@ -1,0 +1,24 @@
+<script>
+	import { InformationCircle } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import Modal from '../modal/Modal.svelte';
+
+	export let title = undefined;
+
+	let modalOpen = false;
+	const openModal = () => (modalOpen = true);
+	const keyHandler = (e) => (e.key === 'Enter' ? openModal() : null);
+</script>
+
+<button
+	on:click={openModal}
+	on:keypress={keyHandler}
+	class="w-20 mt-1 text-xs text-core-grey-200 flex gap-1 cursor-pointer align-top float-right"
+>
+	<span class="ml-auto">more info</span>
+	<Icon src={InformationCircle} class="h-4 w-4 fill-current stroke-black" />
+</button>
+
+<Modal bind:isOpen={modalOpen} {title}>
+	<slot />
+</Modal>

--- a/packages/ui/src/lib/sidebar/SidebarSection.svelte
+++ b/packages/ui/src/lib/sidebar/SidebarSection.svelte
@@ -1,0 +1,27 @@
+<script>
+	import SidebarMoreInfoModal from './SidebarMoreInfoModal.svelte';
+
+	export let title = '';
+	export let infoTitle = title;
+	export let classes = '';
+</script>
+
+<section class="relative text-white flex flex-col gap-4 {classes}" {...$$restProps}>
+	{#if title || $$slots.info}
+		<div class="-mb-2">
+			{#if $$slots.info}
+				<SidebarMoreInfoModal title={infoTitle}>
+					<slot name="info" />
+				</SidebarMoreInfoModal>
+			{/if}
+
+			{#if title}
+				<h2 class="text-lg font-bold">
+					{@html title}
+				</h2>
+			{/if}
+		</div>
+	{/if}
+
+	<slot />
+</section>

--- a/packages/ui/src/lib/sidebar/SidebarToggle.svelte
+++ b/packages/ui/src/lib/sidebar/SidebarToggle.svelte
@@ -4,9 +4,9 @@
 	import { Icon } from '@steeze-ui/svelte-icon';
 	import Button from '../button/Button.svelte';
 
-	const sidebarOpen = getContext('sidebarOpen');
+	const sidebarIsOpen = getContext('sidebarIsOpen');
 	const toggleOpen = () => {
-		sidebarOpen.update((isOpen) => !isOpen);
+		sidebarIsOpen.update((isOpen) => !isOpen);
 	};
 </script>
 

--- a/packages/ui/src/lib/sidebar/SidebarToggle.svelte
+++ b/packages/ui/src/lib/sidebar/SidebarToggle.svelte
@@ -1,0 +1,30 @@
+<script>
+	import { getContext } from 'svelte';
+	import { Bars3 } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import Button from '../button/Button.svelte';
+
+	const sidebarOpen = getContext('sidebarOpen');
+	const toggleOpen = () => {
+		sidebarOpen.update((isOpen) => !isOpen);
+	};
+</script>
+
+<div class:ldn-viz-sidebar-toggle={true} {...$$restProps}>
+	<Button title="Toggle sidebar" variant="square" emphasis="secondary" on:click={toggleOpen}>
+		<Icon
+			src={Bars3}
+			class="w-full h-full p-1 stroke-1 bg-core-grey-800 stroke-white hover:bg-core-grey-500"
+			aria-hidden="true"
+		/>
+	</Button>
+</div>
+
+<style>
+	.ldn-viz-sidebar-toggle {
+		--size: clamp(40px, 2.5rem, 80px);
+
+		width: var(--size);
+		height: var(--size);
+	}
+</style>


### PR DESCRIPTION
**What does this change?**

Adds a sidebar and a few inner sidebar components.

**How?**

- Sidebar and main content is contained within a `<SidebarContainer>`.
- Everything is instance scoped, i.e. there are no global Svelte stores, only bindable instance stores and Svelte context.

**How is it tested?**

Storybook + currently being tested in map apps.

**How is it documented?**

Storybook + default sidebar content.

**Are light and dark themes considered?**

No.

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
