### PR TITLE
Toaster

### DIFF
--- a/.changeset/lll-lll-mmm.md
+++ b/.changeset/lll-lll-mmm.md
@@ -1,0 +1,6 @@
+---
+'@ldn-viz/ui': minor
+---
+
+ADDED `Toaster` component for toast messages
+ADDED `newToastMessage` creating and posting toasts

--- a/packages/charts/src/data/dataScatter.d.ts
+++ b/packages/charts/src/data/dataScatter.d.ts
@@ -1,7 +1,7 @@
 declare const _default: {
-    year: number;
-    value: number;
-    alt: number;
-    group: string;
+	year: number;
+	value: number;
+	alt: number;
+	group: string;
 }[];
 export default _default;

--- a/packages/charts/src/data/dataScatter.d.ts
+++ b/packages/charts/src/data/dataScatter.d.ts
@@ -1,7 +1,7 @@
 declare const _default: {
-	year: number;
-	value: number;
-	alt: number;
-	group: string;
+    year: number;
+    value: number;
+    alt: number;
+    group: string;
 }[];
 export default _default;

--- a/packages/ui/src/lib/index.js
+++ b/packages/ui/src/lib/index.js
@@ -31,5 +31,8 @@ export { default as TabbedSidebarTabList } from './tabbedSidebar/TabbedSidebarTa
 export { default as TabbedSidebarWrapper } from './tabbedSidebar/TabbedSidebarWrapper.svelte';
 export { default as TabLabel } from './tabs/TabLabel.svelte';
 export { default as TabList } from './tabs/TabList.svelte';
+export { default as Toaster } from './toaster/Toaster.svelte';
+export * from './toaster/toaster';
+export * from './toaster/types';
 
 export { classNames } from './utils/classNames';

--- a/packages/ui/src/lib/toaster/README.md
+++ b/packages/ui/src/lib/toaster/README.md
@@ -1,0 +1,151 @@
+# Temporary documentation
+
+**Author**: Paul Williams
+
+If this component can be integrated into application shells then the post message function can be an instance property, e.g. `export const newToast`, which can be bound `<Toaster bind:newToast />`. Then we can do something like `setContext('toaster', toasterStore )` in the application shell making toasting an application shell feature. `toasterStore` will need to be a store (preferred) or object, holding the Toaster's functions, as context can only be set during component initialisation.
+
+This might be needed if toasting layout and styling needs to differ based upon the kind of application, i.e. map vs dashboard vs story scroller. I think this is quite likely.
+
+This may require some guards in the user component in some cases but it's unavoidable if instance binding on `newToast` is used with Svelte contexts (a static `newToast` won't have this problem):
+
+```js
+const toaster = getContext('toaster');
+let errorMsg = '';
+
+$: if ($toaster && errorMsg) {
+	$toaster.newToast(errorMsg).post();
+}
+```
+
+Current component works as follows.
+
+## Usage
+
+**Step 1**: Put the toaster somewhere. This can be almost anywhere but within the `+layout.svelte` or applied via the application shell is best.
+
+```svelte
+<script lang="ts">
+	import Toaster from '@ldn-viz/ui';
+	import { ToasterPosition } from '@ldn-viz/ui';
+</script>
+
+<!-- Example 1 -->
+<Toaster />
+
+<!-- Example 2 -->
+<Toaster position="BottomRight" classes="max-w-[250px]" />
+
+<!-- Example 3 -->
+<Toaster
+	position={ToasterPosition.TopCenter}
+	title="Additional attributes applied via ...$$restProps"
+/>
+```
+
+**Step 2**: Create and post a message.
+
+```svelte
+<script lang="ts">
+	import { newToastMessage, ToastType, ToastMessageOptions } from '@ldn-viz/ui';
+
+	const staticToast = newToastMessage('This is a warning!', {
+		// Type: ToastMessageOptions
+		// An id is rarely needed but prevents HMR duplicates.
+		id: 'a-warning-toast',
+		type: ToastType.Warning,
+		closeButton: true
+	});
+
+	const fireAndForget = () => {
+		newToastMessage('I just want you to know that...').post();
+	};
+</script>
+
+<!-- Repeated clicks will refresh the toast -->
+<button on:click={staticToast.post}> Give warning </button>
+
+<!-- Repeated clicks will create duplicate toasts -->
+<button on:click={fireAndForget}> Give notice </button>
+```
+
+## Props
+
+```js
+import { ToasterPosition } from '@ldn-viz/ui'
+
+// position is used to layout the Toaster. You can specify your own classes
+// for positioning via the classes property if you want something bespoke.
+export let position = "TopCenter" | ToasterPosition.TopCenter;
+
+// classes for applying additional classes. These are appended to the class
+// string so they have implicit but weak priority over other styles.
+export let classes = ""
+
+// ...$$restProps applied to the top level element.
+export let ...$$restProps
+```
+
+## Slots
+
+No slots.
+
+## Context
+
+No context values.
+
+## Static
+
+### (Function) `newToastMessage`
+
+**JavaScript**
+
+```js
+import { newToastMessage } from '@ldn-viz/ui';
+
+const toast = newToastMessage('The message', {
+	id: 'my-id',
+	type: 'Success',
+	timeToLive: 10000, // 10 seconds
+	closeButton: true
+});
+```
+
+**TypeScript**
+
+```ts
+import { newToastMessage, ToastType, ToastMessageOptions, ToastMessage } from '@ldn-viz/ui';
+
+const toastOptions: ToastMessageOptions = {
+	id: 'my-id',
+	type: ToastType.Success,
+	timeToLive: 10000, // 10 seconds
+	closeButton: true
+};
+
+const toast: ToastMessage = newToastMessage('The message', toastOptions);
+```
+
+**Usage**
+
+```ts
+import { newToastMessage } from '@ldn-viz/ui';
+
+const toast = newToastMessage('I just want you to know that...');
+
+// Post then manually remove after 1 second.
+toast.post();
+setTimeout(toast.remove, 1000);
+```
+
+## Types
+
+```ts
+// TODO: It'd be nice if we could render the ./types file here!
+// TODO: Which is completely possible.
+import type {
+	ToasterPosition,     // enum
+	ToastType,           // enum
+	ToastMessage,        // interface
+	ToastMessageOptions, // interface
+}
+```

--- a/packages/ui/src/lib/toaster/Toast.svelte
+++ b/packages/ui/src/lib/toaster/Toast.svelte
@@ -1,0 +1,63 @@
+<script lang="ts" context="module">
+	interface TypeClasses {
+		[key: string]: string;
+	}
+
+	const typeClasses: TypeClasses = {
+		Notice: 'bg-core-blue-100 text-core-blue-700 border-blue-700',
+		Success: 'bg-core-green-100 text-core-green-800 border-green-800',
+		Warning: 'bg-core-orange-100 text-core-orange-800 border-orange-800',
+		Error: 'bg-core-red-50 text-core-red-800 border-red-800'
+	};
+</script>
+
+<script lang="ts">
+	import { fade } from 'svelte/transition';
+	import { XMark } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import { Button } from '@ldn-viz/ui';
+	import type { ToastMessage } from './types';
+
+	export let message: ToastMessage;
+	let classes = typeClasses[message.type];
+
+	if (!classes) {
+		classes = 'bg-core-grey-100 text-core-grey-800 border-core-grey-700';
+	}
+</script>
+
+<div
+	role="dialog"
+	id={message.id}
+	class="border p-2 pl-4 pr-4 max-h-24 {classes}"
+	out:fade={{ duration: 100 }}
+>
+	<div class="text-lg font-bold flex justify-between items-center">
+		{message.type}
+		{#if message.closeButton}
+			<Button
+				emphasis="secondary"
+				variant="square"
+				class="cursor-pointer w-6 h-6"
+				on:click={message.remove}
+			>
+				<Icon src={XMark} class="stroke-2 w-4 h-4" />
+			</Button>
+		{/if}
+	</div>
+	<div class="text-sm">{message.text}</div>
+</div>
+
+<style>
+	div[role='dialog'] {
+		width: clamp(200px, 24rem, calc(100vw - 1rem));
+		/* 
+			Because order is an integer with no intermediate values the transition
+			duration is meaningless; it will always jump from position to position
+			when in a flex box. The only way around is to calculate and absolutely
+			position each toast element.
+
+			transition: order 500ms ease-out;
+		*/
+	}
+</style>

--- a/packages/ui/src/lib/toaster/Toast.svelte
+++ b/packages/ui/src/lib/toaster/Toast.svelte
@@ -4,7 +4,7 @@
 	}
 
 	const typeClasses: TypeClasses = {
-		Notice: 'bg-core-blue-100 text-core-blue-700 border-blue-700',
+		Notice: 'bg-core-blue-100 text-core-blue-800 border-blue-800',
 		Success: 'bg-core-green-100 text-core-green-800 border-green-800',
 		Warning: 'bg-core-orange-100 text-core-orange-800 border-orange-800',
 		Error: 'bg-core-red-50 text-core-red-800 border-red-800'
@@ -26,26 +26,24 @@
 	}
 </script>
 
-<div
-	role="dialog"
-	id={message.id}
-	class="border p-2 pl-4 pr-4 max-h-24 {classes}"
-	out:fade={{ duration: 100 }}
->
-	<div class="text-lg font-bold flex justify-between items-center">
-		{message.type}
-		{#if message.closeButton}
-			<Button
-				emphasis="secondary"
-				variant="square"
-				class="cursor-pointer w-6 h-6"
-				on:click={message.remove}
-			>
-				<Icon src={XMark} class="stroke-2 w-4 h-4" />
-			</Button>
-		{/if}
+<div role="dialog" id={message.id} class="p-0.5 bg-core-grey-800/50" out:fade={{ duration: 100 }}>
+	<div class="border p-2 pl-4 pr-4 {classes}">
+		<div class="text-lg font-bold flex justify-between items-center">
+			{message.type}
+			{#if message.closeButton}
+				<Button
+					title="Close"
+					emphasis="secondary"
+					variant="square"
+					class="w-6 h-6 !bg-core-grey-700 hover:!bg-core-grey-500"
+					on:click={message.remove}
+				>
+					<Icon src={XMark} class="stroke-2 stroke-white w-4 h-4" />
+				</Button>
+			{/if}
+		</div>
+		<div class="text-sm">{message.text}</div>
 	</div>
-	<div class="text-sm">{message.text}</div>
 </div>
 
 <style>

--- a/packages/ui/src/lib/toaster/Toaster.stories.svelte
+++ b/packages/ui/src/lib/toaster/Toaster.stories.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+	import { Meta, Story } from '@storybook/addon-svelte-csf';
+	import Button from '../button/Button.svelte';
+
+	import Toaster from './Toaster.svelte';
+	import { newToastMessage } from './toaster';
+	import { ToastType } from './types';
+
+	const toastNotice = () => {
+		newToastMessage('A notice!').post();
+	};
+
+	const toastSuccess = () => {
+		newToastMessage('A success!', { type: ToastType.Success }).post();
+	};
+
+	const toastWarning = () => {
+		newToastMessage('A warning!', { type: ToastType.Warning }).post();
+	};
+
+	const toastError = () => {
+		newToastMessage('An error!', { type: ToastType.Error }).post();
+	};
+
+	const longLivedMessage = newToastMessage(
+		'These messages decay and disappear after five seconds. You can set a' +
+			' longer timeToLive and enable closeButton if you need a message to' +
+			' stick around. In the presence of a close button users will think they' +
+			' have to manually dismiss the popup so short lived toasts should not' +
+			' have a close button.',
+		{
+			id: 'a-long-lived-message',
+			timeToLive: 30000,
+			closeButton: true
+		}
+	);
+
+	const toastClosable = () => {
+		longLivedMessage.post();
+	};
+
+	let position = 'TopLeft';
+	const setToaster = (event: MouseEvent) => {
+		const target = event.target as HTMLButtonElement;
+		if (target && target.textContent) {
+			position = target.textContent;
+		}
+	};
+</script>
+
+<Meta
+	title="Ui/Toaster"
+	component={Toaster}
+	parameters={{
+		layout: 'full'
+	}}
+/>
+
+<Story name="Default">
+	<Toaster />
+</Story>
+
+<Story name="Types Dark">
+	<div class="p-6 w-[100vw] h-[100vh]">
+		<Toaster position="Center" />
+		<div class="flex gap-6">
+			<Button on:click={toastNotice}>Notice</Button>
+			<Button condition="success" on:click={toastSuccess}>Success</Button>
+			<Button condition="warning" on:click={toastWarning}>Warning</Button>
+			<Button condition="error" on:click={toastError}>Error</Button>
+		</div>
+	</div>
+</Story>
+
+<Story name="Types Light">
+	<div class="bg-white p-6 w-[100vw] h-[100vh]">
+		<Toaster position="Center" />
+		<div class="flex gap-6">
+			<Button on:click={toastNotice}>Notice</Button>
+			<Button condition="success" on:click={toastSuccess}>Success</Button>
+			<Button condition="warning" on:click={toastWarning}>Warning</Button>
+			<Button condition="error" on:click={toastError}>Error</Button>
+		</div>
+	</div>
+</Story>
+
+<Story name="Position Dark">
+	<div class="relative p-6 w-[100vw] h-[100vh]">
+		<Toaster {position} />
+		<div
+			class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transform flex flex-wrap justify-center gap-6 [&>*]:basis-3/12"
+		>
+			<Button on:click={setToaster}>TopLeft</Button>
+			<Button on:click={setToaster}>TopCenter</Button>
+			<Button on:click={setToaster}>TopRight</Button>
+			<Button on:click={setToaster}>CenterLeft</Button>
+			<Button condition="warning" on:click={toastNotice}>Toast!</Button>
+			<Button on:click={setToaster}>CenterRight</Button>
+			<Button on:click={setToaster}>BottomLeft</Button>
+			<Button on:click={setToaster}>BottomCenter</Button>
+			<Button on:click={setToaster}>BottomRight</Button>
+		</div>
+	</div>
+</Story>
+
+<Story name="Position Light">
+	<div class="bg-white relative p-6 w-[100vw] h-[100vh]">
+		<Toaster {position} />
+		<div
+			class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transform flex flex-wrap justify-center gap-6 [&>*]:basis-3/12"
+		>
+			<Button on:click={setToaster}>TopLeft</Button>
+			<Button on:click={setToaster}>TopCenter</Button>
+			<Button on:click={setToaster}>TopRight</Button>
+			<Button on:click={setToaster}>CenterLeft</Button>
+			<Button condition="warning" on:click={toastNotice}>Toast!</Button>
+			<Button on:click={setToaster}>CenterRight</Button>
+			<Button on:click={setToaster}>BottomLeft</Button>
+			<Button on:click={setToaster}>BottomCenter</Button>
+			<Button on:click={setToaster}>BottomRight</Button>
+		</div>
+	</div>
+</Story>
+
+<Story name="Close Button">
+	<div class="p-6 w-[100vw] h-[100vh]">
+		<Toaster position="Center" />
+		<div class="flex gap-6">
+			<Button on:click={toastClosable}>Toast!</Button>
+		</div>
+	</div>
+</Story>

--- a/packages/ui/src/lib/toaster/Toaster.stories.svelte
+++ b/packages/ui/src/lib/toaster/Toaster.stories.svelte
@@ -25,7 +25,7 @@
 	};
 
 	const longLivedMessage = newToastMessage(
-		'These messages decay and disappear after five seconds. You can set a' +
+		'By default, messages disappear after five seconds. You can set a' +
 			' longer timeToLive and enable closeButton if you need a message to' +
 			' stick around. In the presence of a close button users will think they' +
 			' have to manually dismiss the popup so short lived toasts should not' +

--- a/packages/ui/src/lib/toaster/Toaster.stories.svelte
+++ b/packages/ui/src/lib/toaster/Toaster.stories.svelte
@@ -98,15 +98,31 @@
 		<div
 			class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transform flex flex-wrap justify-center gap-6 [&>*]:basis-3/12"
 		>
-			<Button on:click={setToaster}>TopLeft</Button>
-			<Button on:click={setToaster}>TopCenter</Button>
-			<Button on:click={setToaster}>TopRight</Button>
-			<Button on:click={setToaster}>CenterLeft</Button>
-			<Button condition="warning" on:click={toastNotice}>Toast!</Button>
-			<Button on:click={setToaster}>CenterRight</Button>
-			<Button on:click={setToaster}>BottomLeft</Button>
-			<Button on:click={setToaster}>BottomCenter</Button>
-			<Button on:click={setToaster}>BottomRight</Button>
+			<Button on:click={setToaster} variant={position === 'TopLeft' ? 'solid' : 'outline'}>
+				TopLeft
+			</Button>
+			<Button on:click={setToaster} variant={position === 'TopCenter' ? 'solid' : 'outline'}>
+				TopCenter
+			</Button>
+			<Button on:click={setToaster} variant={position === 'TopRight' ? 'solid' : 'outline'}>
+				TopRight
+			</Button>
+			<Button on:click={setToaster} variant={position === 'CenterLeft' ? 'solid' : 'outline'}>
+				CenterLeft
+			</Button>
+			<Button condition="warning" on:click={toastNotice}>Add Toast!</Button>
+			<Button on:click={setToaster} variant={position === 'CenterRight' ? 'solid' : 'outline'}>
+				CenterRight
+			</Button>
+			<Button on:click={setToaster} variant={position === 'BottomLeft' ? 'solid' : 'outline'}>
+				BottomLeft
+			</Button>
+			<Button on:click={setToaster} variant={position === 'BottomCenter' ? 'solid' : 'outline'}>
+				BottomCenter
+			</Button>
+			<Button on:click={setToaster} variant={position === 'BottomRight' ? 'solid' : 'outline'}>
+				BottomRight
+			</Button>
 		</div>
 	</div>
 </Story>

--- a/packages/ui/src/lib/toaster/Toaster.stories.svelte
+++ b/packages/ui/src/lib/toaster/Toaster.stories.svelte
@@ -6,6 +6,8 @@
 	import { newToastMessage } from './toaster';
 	import { ToastType } from './types';
 
+	import typeDocs from './types?raw';
+
 	const toastNotice = () => {
 		newToastMessage('A notice!').post();
 	};
@@ -81,6 +83,12 @@
 			<Button condition="warning" on:click={toastWarning}>Warning</Button>
 			<Button condition="error" on:click={toastError}>Error</Button>
 		</div>
+	</div>
+</Story>
+
+<Story name="TypeScript">
+	<div class="text-white p-6 w-[100vw]">
+		<pre><code>{typeDocs}</code></pre>
 	</div>
 </Story>
 

--- a/packages/ui/src/lib/toaster/Toaster.stories.svelte
+++ b/packages/ui/src/lib/toaster/Toaster.stories.svelte
@@ -117,15 +117,31 @@
 		<div
 			class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transform flex flex-wrap justify-center gap-6 [&>*]:basis-3/12"
 		>
-			<Button on:click={setToaster}>TopLeft</Button>
-			<Button on:click={setToaster}>TopCenter</Button>
-			<Button on:click={setToaster}>TopRight</Button>
-			<Button on:click={setToaster}>CenterLeft</Button>
-			<Button condition="warning" on:click={toastNotice}>Toast!</Button>
-			<Button on:click={setToaster}>CenterRight</Button>
-			<Button on:click={setToaster}>BottomLeft</Button>
-			<Button on:click={setToaster}>BottomCenter</Button>
-			<Button on:click={setToaster}>BottomRight</Button>
+			<Button on:click={setToaster} variant={position === 'TopLeft' ? 'solid' : 'outline'}>
+				TopLeft
+			</Button>
+			<Button on:click={setToaster} variant={position === 'TopCenter' ? 'solid' : 'outline'}>
+				TopCenter
+			</Button>
+			<Button on:click={setToaster} variant={position === 'TopRight' ? 'solid' : 'outline'}>
+				TopRight
+			</Button>
+			<Button on:click={setToaster} variant={position === 'CenterLeft' ? 'solid' : 'outline'}>
+				CenterLeft
+			</Button>
+			<Button condition="warning" on:click={toastNotice}>Add Toast!</Button>
+			<Button on:click={setToaster} variant={position === 'CenterRight' ? 'solid' : 'outline'}>
+				CenterRight
+			</Button>
+			<Button on:click={setToaster} variant={position === 'BottomLeft' ? 'solid' : 'outline'}>
+				BottomLeft
+			</Button>
+			<Button on:click={setToaster} variant={position === 'BottomCenter' ? 'solid' : 'outline'}>
+				BottomCenter
+			</Button>
+			<Button on:click={setToaster} variant={position === 'BottomRight' ? 'solid' : 'outline'}>
+				BottomRight
+			</Button>
 		</div>
 	</div>
 </Story>

--- a/packages/ui/src/lib/toaster/Toaster.svelte
+++ b/packages/ui/src/lib/toaster/Toaster.svelte
@@ -1,0 +1,49 @@
+<script lang="ts" context="module">
+	export enum ToasterPosition {
+		TopLeft = 'TopLeft',
+		TopCenter = 'TopCenter',
+		TopRight = 'TopRight',
+		TopRightOffset = 'TopRightOffset',
+		CenterRight = 'CenterRight',
+		BottomRight = 'BottomRight',
+		BottomCenter = 'BottomCenter',
+		BottomLeft = 'BottomLeft',
+		CenterLeft = 'CenterLeft'
+	}
+
+	type ToasterPositionClass = {
+		[key: string]: string;
+	};
+
+	const positionClasses: ToasterPositionClass = {
+		TopLeft: 'top-6 left-6',
+		TopCenter: 'top-6 left-1/2 -translate-x-1/2 transform',
+		TopRight: 'top-6 right-6',
+		TopRightOffset: 'top-16 right-6',
+		CenterRight: 'top-1/2 -translate-y-1/2 right-6 transform',
+		BottomRight: 'bottom-6 right-6',
+		BottomCenter: 'bottom-6 left-1/2 -translate-x-1/2 transform',
+		BottomLeft: 'bottom-6 left-6',
+		CenterLeft: 'top-1/2 -translate-y-1/2 left-6 transform'
+	};
+</script>
+
+<script lang="ts">
+	import Toast from './Toast.svelte';
+	import { messages } from './toaster';
+
+	export let position = 'TopCenter';
+	export let classes = '';
+
+	const posClasses = positionClasses[position] || '';
+</script>
+
+<div
+	style:display={$messages.length === 0 ? 'none' : 'block'}
+	class="fixed flex flex-col gap-4 z-[50] w-fit p-1 bg-core-grey-800/50 {posClasses} {classes}"
+	{...$$restProps}
+>
+	{#each $messages as message (message.id)}
+		<Toast {message} />
+	{/each}
+</div>

--- a/packages/ui/src/lib/toaster/Toaster.svelte
+++ b/packages/ui/src/lib/toaster/Toaster.svelte
@@ -3,12 +3,12 @@
 		TopLeft = 'TopLeft',
 		TopCenter = 'TopCenter',
 		TopRight = 'TopRight',
-		TopRightOffset = 'TopRightOffset',
 		CenterRight = 'CenterRight',
 		BottomRight = 'BottomRight',
 		BottomCenter = 'BottomCenter',
 		BottomLeft = 'BottomLeft',
-		CenterLeft = 'CenterLeft'
+		CenterLeft = 'CenterLeft',
+		Center = 'Center'
 	}
 
 	type ToasterPositionClass = {
@@ -19,12 +19,12 @@
 		TopLeft: 'top-6 left-6',
 		TopCenter: 'top-6 left-1/2 -translate-x-1/2 transform',
 		TopRight: 'top-6 right-6',
-		TopRightOffset: 'top-16 right-6',
 		CenterRight: 'top-1/2 -translate-y-1/2 right-6 transform',
 		BottomRight: 'bottom-6 right-6',
 		BottomCenter: 'bottom-6 left-1/2 -translate-x-1/2 transform',
 		BottomLeft: 'bottom-6 left-6',
-		CenterLeft: 'top-1/2 -translate-y-1/2 left-6 transform'
+		CenterLeft: 'top-1/2 -translate-y-1/2 left-6 transform',
+		Center: 'top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2 transform'
 	};
 </script>
 
@@ -35,12 +35,12 @@
 	export let position = 'TopCenter';
 	export let classes = '';
 
-	const posClasses = positionClasses[position] || '';
+	$: posClasses = positionClasses[position] || '';
 </script>
 
 <div
 	style:display={$messages.length === 0 ? 'none' : 'block'}
-	class="fixed flex flex-col gap-4 z-[50] w-fit p-1 bg-core-grey-800/50 {posClasses} {classes}"
+	class="fixed flex flex-col space-y-1 z-[50] w-fit {posClasses} {classes}"
 	{...$$restProps}
 >
 	{#each $messages as message (message.id)}

--- a/packages/ui/src/lib/toaster/Toaster.svelte
+++ b/packages/ui/src/lib/toaster/Toaster.svelte
@@ -19,10 +19,11 @@
 <script lang="ts">
 	import Toast from './Toast.svelte';
 	import { messages } from './toaster';
+	import type { ToasterPosition } from './types';
 
 	// position is used to layout the Toaster. You can specify your own classes
 	// for positioning via the classes property if you want something bespoke.
-	export let position = 'TopCenter';
+	export let position: keyof typeof ToasterPosition = 'TopCenter';
 
 	// classes for applying additional classes. These are appended to the class
 	// string so they have implicit but weak priority over other styles.

--- a/packages/ui/src/lib/toaster/Toaster.svelte
+++ b/packages/ui/src/lib/toaster/Toaster.svelte
@@ -1,16 +1,4 @@
 <script lang="ts" context="module">
-	export enum ToasterPosition {
-		TopLeft = 'TopLeft',
-		TopCenter = 'TopCenter',
-		TopRight = 'TopRight',
-		CenterRight = 'CenterRight',
-		BottomRight = 'BottomRight',
-		BottomCenter = 'BottomCenter',
-		BottomLeft = 'BottomLeft',
-		CenterLeft = 'CenterLeft',
-		Center = 'Center'
-	}
-
 	type ToasterPositionClass = {
 		[key: string]: string;
 	};
@@ -32,8 +20,15 @@
 	import Toast from './Toast.svelte';
 	import { messages } from './toaster';
 
+	// position is used to layout the Toaster. You can specify your own classes
+	// for positioning via the classes property if you want something bespoke.
 	export let position = 'TopCenter';
+
+	// classes for applying additional classes. These are appended to the class
+	// string so they have implicit but weak priority over other styles.
 	export let classes = '';
+
+	// ...$$restProps applied to the top level element.
 
 	$: posClasses = positionClasses[position] || '';
 </script>

--- a/packages/ui/src/lib/toaster/toaster.ts
+++ b/packages/ui/src/lib/toaster/toaster.ts
@@ -1,0 +1,72 @@
+import { writable, type Writable } from 'svelte/store';
+import type { ToastMessage, ToastMessageOptions } from './types';
+import { ToastType } from './types';
+
+const DEFAULT_TIME_TO_LIVE = 4000;
+const MAX_MESSAGES = 3;
+
+export const messages: Writable<ToastMessage[]> = writable([]);
+
+// newToastMessage creates a storable message that can be posted or refreshed
+// by the user dev using the ToastMessage.post function.
+//
+// E.g. when a user tries to advance to the next form page but the current
+// form page contains errors, spamming the next button should only refresh the
+// existing error message and not create a long list of duplicate messages.
+export const newToastMessage = (text: string, options: ToastMessageOptions = {}) => {
+	const id = options.id ? options.id : crypto.randomUUID();
+	const type = options.type ? options.type : ToastType.Notice;
+
+	const msg: ToastMessage = {
+		text: text,
+		id: id,
+		type: type,
+		closeButton: !!options.closeButton,
+		post: () => {},
+		remove: () => {}
+	};
+
+	msg.post = () => {
+		removeMessage(msg);
+		postMessage(msg, 'timeToLive' in options ? options.timeToLive : DEFAULT_TIME_TO_LIVE);
+	};
+
+	msg.remove = () => {
+		removeMessage(msg);
+	};
+
+	return msg;
+};
+
+// postToastMessage creates and posts a new message.
+//
+// It is intended for situations where you just need to tell the end user
+// something and there is little or no chance of the message being repeated
+// before timeout or where the precise text content changes from message to
+// message.
+export const postToastMessage = (text: string, options: ToastMessageOptions = {}) => {
+	const msg = newToastMessage(text, options);
+	msg.post();
+	return msg;
+};
+
+const postMessage = (msg: ToastMessage, timeToLive = 0) => {
+	clearTimeout(msg.postId);
+	showMessage(msg);
+
+	if (timeToLive > 0) {
+		msg.postId = setTimeout(msg.remove, timeToLive);
+	}
+};
+
+const showMessage = (msg: ToastMessage) => {
+	messages.update((msgList) => {
+		return [msg, ...msgList].slice(0, MAX_MESSAGES);
+	});
+};
+
+const removeMessage = (msg: ToastMessage) => {
+	messages.update((msgList) => {
+		return msgList.filter((m) => m.id !== msg.id);
+	});
+};

--- a/packages/ui/src/lib/toaster/toaster.ts
+++ b/packages/ui/src/lib/toaster/toaster.ts
@@ -2,7 +2,7 @@ import { writable, type Writable } from 'svelte/store';
 import type { ToastMessage, ToastMessageOptions } from './types';
 import { ToastType } from './types';
 
-const DEFAULT_TIME_TO_LIVE = 4000;
+const DEFAULT_TIME_TO_LIVE = 5000;
 const MAX_MESSAGES = 3;
 
 export const messages: Writable<ToastMessage[]> = writable([]);
@@ -10,12 +10,12 @@ export const messages: Writable<ToastMessage[]> = writable([]);
 // newToastMessage creates a storable message that can be posted or refreshed
 // by the user dev using the ToastMessage.post function.
 //
-// E.g. when a user tries to advance to the next form page but the current
-// form page contains errors, spamming the next button should only refresh the
-// existing error message and not create a long list of duplicate messages.
+// Often there is no need to store and reuse a toast. You can simple fire and
+// forget: newTostMessage("This is a notice!").post().
 export const newToastMessage = (text: string, options: ToastMessageOptions = {}) => {
 	const id = options.id ? options.id : crypto.randomUUID();
 	const type = options.type ? options.type : ToastType.Notice;
+	const timeToLive = options.timeToLive ? options.timeToLive : DEFAULT_TIME_TO_LIVE;
 
 	const msg: ToastMessage = {
 		text: text,
@@ -28,25 +28,13 @@ export const newToastMessage = (text: string, options: ToastMessageOptions = {})
 
 	msg.post = () => {
 		removeMessage(msg);
-		postMessage(msg, 'timeToLive' in options ? options.timeToLive : DEFAULT_TIME_TO_LIVE);
+		postMessage(msg, timeToLive);
 	};
 
 	msg.remove = () => {
 		removeMessage(msg);
 	};
 
-	return msg;
-};
-
-// postToastMessage creates and posts a new message.
-//
-// It is intended for situations where you just need to tell the end user
-// something and there is little or no chance of the message being repeated
-// before timeout or where the precise text content changes from message to
-// message.
-export const postToastMessage = (text: string, options: ToastMessageOptions = {}) => {
-	const msg = newToastMessage(text, options);
-	msg.post();
 	return msg;
 };
 

--- a/packages/ui/src/lib/toaster/types.ts
+++ b/packages/ui/src/lib/toaster/types.ts
@@ -1,0 +1,47 @@
+// ToastType is a collection of valid toast message types.
+export enum ToastType {
+	Notice = 'Notice',
+	Success = 'Success',
+	Warning = 'Warning',
+	Error = 'Error'
+}
+
+// ToastMessage represents a message with functionality for posting, removing
+// and refreshing itself.
+export interface ToastMessage {
+	// text is just the message text to be displayed to the end user.
+	text: string;
+
+	// id is used as the ToastMessage id. It is auto-generated if falsey after
+	// string trimming.
+	id: string;
+
+	// postId is always auto-generated and uniquely identifies the display
+	// instance of the ToastMessage, i.e. calling ToastMessage.post twice will
+	// result in new postId being generated (if timeToLive is greater than zero)
+	// while id always remains the same.
+	postId?: any;
+
+	// type is the ToastType that controls styling and indicates urgency of the
+	// message to the end user. By default this will be ToastType.Notice.
+	type: ToastType;
+
+	// closeButton is true if a close button should be displayed.
+	closeButton: boolean;
+
+	// post is used to post or refresh the message within its Toaster.
+	post: () => void;
+
+	// remove is used to remove the message from the Toaster. This is called when
+	// timeout is hit but may also be called by the user dev to cancel early.
+	remove: () => void;
+}
+
+// ToastMessageOptions are optional parameters to newToastMessage and
+// postToastMessage.
+export interface ToastMessageOptions {
+	id?: string;
+	type?: ToastType;
+	timeToLive?: number;
+	closeButton?: boolean;
+}

--- a/packages/ui/src/lib/toaster/types.ts
+++ b/packages/ui/src/lib/toaster/types.ts
@@ -6,6 +6,20 @@ export enum ToastType {
 	Error = 'Error'
 }
 
+// ToasterPosition is an enumeration of valid positions that can be passed to
+// the Toaster component via the 'position' property.
+export enum ToasterPosition {
+	TopLeft = 'TopLeft',
+	TopCenter = 'TopCenter',
+	TopRight = 'TopRight',
+	CenterRight = 'CenterRight',
+	BottomRight = 'BottomRight',
+	BottomCenter = 'BottomCenter',
+	BottomLeft = 'BottomLeft',
+	CenterLeft = 'CenterLeft',
+	Center = 'Center'
+}
+
 // ToastMessage represents a message with functionality for posting, removing
 // and refreshing itself.
 export interface ToastMessage {


### PR DESCRIPTION
**What does this change?**

1. Adds a `Toaster` component for rendering short lived toast messages.
2. Adds a `newToastMessage` function for posting new toasts from anywhere in the app.

**Why?**

Needed toasts for error messaging in call for sites.

**How is it tested?**

1. Within Call for Sites app.
2. Storybook

**How is it documented?**

1. Storybook
2. Experimental story presenting the TypeScript types as defined in code
3. Experimental README for reference when we figure out how we want to do API docs

**Are light and dark themes considered?**

Yes.

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
