### PR TITLE
Fix map controls divs interferring with map interactions

### DIFF
--- a/.changeset/mon-tue-wed.md
+++ b/.changeset/mon-tue-wed.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+FIXED - Unused space within map controls interfering with map interactions.

--- a/packages/maps/src/lib/mapControlFullscreen/MapControlFullscreen.svelte
+++ b/packages/maps/src/lib/mapControlFullscreen/MapControlFullscreen.svelte
@@ -82,7 +82,7 @@
 			variant="square"
 			emphasis="secondary"
 			title={$isFullscreen ? mode.titleIn : mode.titleOut}
-			class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500"
+			class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500 pointer-events-auto"
 			on:click={handle}
 		>
 			<Icon src={$isFullscreen ? mode.iconIn : mode.iconOut} class="w-8 h-8 p-1" />

--- a/packages/maps/src/lib/mapControlGroup/MapControlGroup.stories.svelte
+++ b/packages/maps/src/lib/mapControlGroup/MapControlGroup.stories.svelte
@@ -74,7 +74,7 @@
 			</div>
 
 			<MapControlGroup position="TopLeft">
-				<div class="text-white w-80 flex">
+				<div class="text-white w-80 flex pointer-events-auto">
 					<input
 						type="text"
 						class="grow bg-core-grey-500 placeholder-core-grey-200 p-2"
@@ -91,7 +91,7 @@
 			</MapControlGroup>
 
 			<MapControlGroup position="TopRight">
-				<p class="bg-core-grey-800 p-2 text-white text-center">
+				<p class="bg-core-grey-800 p-2 text-white text-center pointer-events-auto">
 					Bespoke controls<br />E.g. Drawing
 				</p>
 			</MapControlGroup>

--- a/packages/maps/src/lib/mapControlGroup/MapControlGroup.svelte
+++ b/packages/maps/src/lib/mapControlGroup/MapControlGroup.svelte
@@ -29,7 +29,7 @@
 </script>
 
 <script lang="ts">
-	export let position: string | MapControlGroupPositions = MapControlGroupPositions.TopLeft;
+	export let position: keyof typeof MapControlGroupPositions = MapControlGroupPositions.TopLeft;
 	export let classes = '';
 
 	const positionClass = positionClasses[position];

--- a/packages/maps/src/lib/mapControlGroup/MapControlGroup.svelte
+++ b/packages/maps/src/lib/mapControlGroup/MapControlGroup.svelte
@@ -12,7 +12,7 @@
 	}
 
 	type PositionClass = {
-		[key: string]: string;
+		[key in keyof typeof MapControlGroupPositions]: string;
 	};
 
 	const positionClasses: PositionClass = {

--- a/packages/maps/src/lib/mapControlGroup/MapControlGroup.svelte
+++ b/packages/maps/src/lib/mapControlGroup/MapControlGroup.svelte
@@ -12,7 +12,7 @@
 	}
 
 	type PositionClass = {
-		[key: MapControlGroupPositions]: string;
+		[key: string]: string;
 	};
 
 	const positionClasses: PositionClass = {
@@ -29,12 +29,12 @@
 </script>
 
 <script lang="ts">
-	export let position = MapControlGroupPositions.TopLeft;
+	export let position: string | MapControlGroupPositions = MapControlGroupPositions.TopLeft;
 	export let classes = '';
 
 	const positionClass = positionClasses[position];
 </script>
 
-<div class="absolute {positionClass} z-10 flex flex-col space-y-2 {classes}">
+<div class="absolute {positionClass} z-10 flex flex-col space-y-2 pointer-events-none {classes}">
 	<slot />
 </div>

--- a/packages/maps/src/lib/mapControlPan/MapControlPan.svelte
+++ b/packages/maps/src/lib/mapControlPan/MapControlPan.svelte
@@ -54,7 +54,7 @@
 			variant="square"
 			emphasis="secondary"
 			title="Pan up"
-			class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500"
+			class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500 pointer-events-auto"
 			on:click={newHandler(panUp)}
 		>
 			<Icon src={ChevronUp} class="w-8 h-8 pb-1 pt-0.5" />
@@ -66,7 +66,7 @@
 			variant="square"
 			emphasis="secondary"
 			title="Pan left"
-			class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500"
+			class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500pointer-events-auto"
 			on:click={newHandler(panLeft)}
 		>
 			<Icon src={ChevronLeft} class="w-8 h-8 pr-1 pl-0.5" />
@@ -78,7 +78,7 @@
 			variant="square"
 			emphasis="secondary"
 			title="Pan right"
-			class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500"
+			class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500 pointer-events-auto"
 			on:click={newHandler(panRight)}
 		>
 			<Icon src={ChevronRight} class="w-8 h-8 pl-1 pr-0.5" />
@@ -90,7 +90,7 @@
 			variant="square"
 			emphasis="secondary"
 			title="Pan down"
-			class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500"
+			class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500 pointer-events-auto"
 			on:click={newHandler(panDown)}
 		>
 			<Icon src={ChevronDown} class="w-8 h-8 pt-1 pb-0.5" />

--- a/packages/maps/src/lib/mapControlRefresh/MapControlRefresh.svelte
+++ b/packages/maps/src/lib/mapControlRefresh/MapControlRefresh.svelte
@@ -11,7 +11,7 @@
 		variant="square"
 		emphasis="secondary"
 		title="Refresh page"
-		class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500"
+		class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500 pointer-events-auto"
 		on:click={handle}
 	>
 		<Icon src={ArrowPath} class="w-8 h-8 p-1" />

--- a/packages/maps/src/lib/mapControlZoom/MapControlZoom.svelte
+++ b/packages/maps/src/lib/mapControlZoom/MapControlZoom.svelte
@@ -30,7 +30,7 @@
 		variant="square"
 		emphasis="secondary"
 		title="Zoom in"
-		class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500"
+		class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500 pointer-events-auto"
 		on:click={newHandler(zoomIn)}
 	>
 		<Icon src={PlusSmall} class="w-8 h-8 p-0.5" />
@@ -39,7 +39,7 @@
 		variant="square"
 		emphasis="secondary"
 		title="Zoom out"
-		class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500"
+		class="dark:bg-core-grey-800 dark:text-white hover:dark:bg-core-grey-500 pointer-events-auto"
 		on:click={newHandler(zoomOut)}
 	>
 		<Icon src={MinusSmall} class="w-8 h-8 p-0.5" />


### PR DESCRIPTION
**What does this change?**

Fixes map controls interfering with map interactions.

**Why?**

Map control areas preventing panning and drawing on the map. Mostly only noticable on smaller laptops, e.g. surface pro etc.

**How?**

Disabled all pointer events in map controls and enable only at a fine grained level, i.e. applied pointer events to buttons directly rather than their containing elements to avoid padded and margin space from causing problems too.

- [x] Have you included changeset file?
