### PR TITLE
Add justValue prop to Select component

### DIFF
--- a/.changeset/hfuufh-ifie-eifie.md
+++ b/.changeset/hfuufh-ifie-eifie.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: `Select` component now exposes a `justValue` prop that can be bound to

--- a/packages/ui/src/lib/select/Select.stories.svelte
+++ b/packages/ui/src/lib/select/Select.stories.svelte
@@ -2,6 +2,7 @@
 	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 
 	import Select from './Select.svelte';
+	import Button from '../button/Button.svelte';
 
 	type Item = { label: string; value: number };
 	let value: Item;
@@ -11,6 +12,8 @@
 		{ label: 'Two', value: 2 },
 		{ label: 'Three', value: 3 }
 	];
+
+	let justValue: number;
 </script>
 
 <Meta title="Ui/Select" component={Select} />
@@ -136,5 +139,21 @@
 			disabled
 			optional
 		/>
+	</div>
+</Story>
+
+<Story name="Binidng to justValue">
+	<div class="w-[500px] flex flex-col gap-2">
+		<p>
+			You can bind directly to <code>justValue</code>, rather than <code>value</code> (which is an
+			object including the <code>label</code> as well as <code>vlaue</code>)
+		</p>
+
+		<div>Current value: <span class="font-bold">{justValue}</span></div>
+
+		<Button on:click={() => (justValue = 2)}>Reset to 2</Button>
+		<Button on:click={() => (justValue = null)}>Clear</Button>
+
+		<Select {items} bind:justValue id="labelled-input" />
 	</div>
 </Story>

--- a/packages/ui/src/lib/select/Select.svelte
+++ b/packages/ui/src/lib/select/Select.svelte
@@ -53,6 +53,26 @@
 	export let listOffset = 5;
 	export let hoverItemIndex = 0;
 	export let floatingConfig = {};
+
+	// We expose a justValue prop that is writable: the main svelte-select component has one that is read-only
+	export let justValue: any;
+
+	// respond to external change in justValue
+	const applyChangeFromjustValue = (newjustValue: any) => {
+		if (!value || newjustValue != value[itemId]) {
+			value = items.find((f) => f[itemId] === newjustValue);
+		}
+	};
+	$: applyChangeFromjustValue(justValue);
+
+	// respond to changes in selection
+	const updatejustValueFromSelection = (newValue: { [key: string]: any }) => {
+		const newjustValue = newValue && newValue[itemId];
+		if (justValue !== newjustValue) {
+			justValue = newjustValue;
+		}
+	};
+	$: updatejustValueFromSelection(value);
 </script>
 
 <InputWrapper {...$$restProps} {id} {disabled} {error}>

--- a/packages/ui/src/lib/select/Select.svelte
+++ b/packages/ui/src/lib/select/Select.svelte
@@ -35,7 +35,6 @@
 	export let closeListOnChange = true;
 
 	export let createGroupHeaderItem: any = undefined; // ?
-	export const getFilteredItems: any = undefined; // ?
 
 	export let searchable = true;
 	export let inputStyles = '';
@@ -102,7 +101,6 @@
 			{required}
 			{closeListOnChange}
 			{createGroupHeaderItem}
-			{getFilteredItems}
 			{searchable}
 			{inputStyles}
 			{clearable}


### PR DESCRIPTION
**What does this change?**

Add a `justValue` prop to the `Select` component that can be bound to.

The `value` prop is an object containing both the label and value of the selected item. This is inconvenient: 


Often the select sets a value that can also be updated by other interactions (for example, users might be able to select a borough by either using the select control or by clicking on a map). This is currently inconvenient to handle: we can't just bind a store to the `value` prop, since this is is an object containing both the label and value of the selected item, not just the value.

`svelte-select` provides a `justValue` prop, but it is read-only. This PR updates our wrapper around it (the `Select` component) to add a prop with the saem name that is writable.

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
