### PR TITLE
Maps exports

### DIFF
--- a/.changeset/kgierif-dmiqwd-keiwie.md
+++ b/.changeset/kgierif-dmiqwd-keiwie.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': major
+---
+
+CHANGED - map themes are now imported as objects directly from `@ldn-viz/maps`, rather than being imported as JSON files from  `@ldn-viz/maps/themes`

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -14,6 +14,12 @@
 		"lint": "prettier --check . && eslint src",
 		"format": "prettier --write ."
 	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"svelte": "./dist/index.js"
+		}
+	},
 	"files": [
 		"themes",
 		"dist",

--- a/packages/maps/src/lib/index.js
+++ b/packages/maps/src/lib/index.js
@@ -13,3 +13,8 @@ export { default as MapControlZoom } from './mapControlZoom/MapControlZoom.svelt
 // themes
 export * from './themes/animations';
 export * from './themes/bounds';
+
+export * as theme_os_dark_grey_muted_buildings from './themes/os_dark_grey_muted_buildings.json';
+export * as theme_os_dark from './themes/os_dark.json';
+export * as theme_os_greyscale from './themes/os_greyscale.json';
+export * as theme_os_light_vts from './themes/os_light_vts.json';


### PR DESCRIPTION
This fixes a warning from `vite-plugin-svelte`:
> The following packages have a svelte field in their package.json
> but no exports condition for svelte

See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition

It does this by adding an exports condition (as for the other packages in the monorepo); MapLibre themes are now exported via index.js.

(see also https://github.com/Greater-London-Authority/ldn-viz-tools/commit/ae498d91358af59dd9faafcbe301a577e905ccb9)
