### PR TITLE
Fix/sidebar modal width

### DIFF
--- a/.changeset/good-shrimps-change.md
+++ b/.changeset/good-shrimps-change.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/ui": minor
+---
+
+Updates sidebar elements to accept hint component as a slot

--- a/.changeset/good-shrimps-change.md
+++ b/.changeset/good-shrimps-change.md
@@ -1,5 +1,5 @@
 ---
-"@ldn-viz/ui": minor
+"@ldn-viz/ui": major
 ---
 
-Updates sidebar elements to accept hint component as a slot
+CHANGED - sidebar elements now accept `SidebarHint` component as a slot

--- a/package-lock.json
+++ b/package-lock.json
@@ -18754,7 +18754,7 @@
     },
     "packages/ui": {
       "name": "@ldn-viz/ui",
-      "version": "4.1.0",
+      "version": "5.0.0",
       "dependencies": {
         "@melt-ui/svelte": "^0.76.0",
         "@steeze-ui/heroicons": "^2.3.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -56,7 +56,7 @@
 		"typescript": "^5.4.2",
 		"vite": "^5.1.6",
 		"vitest": "^1.3.1",
-		"@ldn-viz/docs": "^0.0.1"
+		"@ldn-viz/docs": "*"
 	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/packages/ui/src/lib/appShell/AppShell.stories.svelte
+++ b/packages/ui/src/lib/appShell/AppShell.stories.svelte
@@ -16,6 +16,7 @@
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 	import Sidebar from '../sidebar/Sidebar.svelte';
 	import SidebarHeader from '../sidebar/elements/sidebarHeader/SidebarHeader.svelte';
+	import SidebarHint from '../sidebar/elements/sidebarHint/SidebarHint.svelte';
 	import SidebarSection from '../sidebar/elements/sidebarSection/SidebarSection.svelte';
 	import SidebarGroupTitle from '../sidebar/elements/sidebarSection/sidebarGroupTitle/SidebarGroupTitle.svelte';
 	import SidebarTabLabel from '../sidebar/elements/sidebarTabs/SidebarTabLabel.svelte';
@@ -46,9 +47,15 @@
 					<SidebarSection title="Section Title">
 						Section Content
 						<div>
-							<SidebarGroupTitle hintType="modal" hintLabel="why">
-								Pay Attention to this group
-								<svelte:fragment slot="hint">Because it's Awesome!</svelte:fragment>
+							<SidebarGroupTitle>
+								Group Title
+								<SidebarHint slot="hint" hintType="tooltip">
+									<p class="mb-4">Any content you want can go here</p>
+									<p>
+										Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+										nec venenatis sapien. Etiam venenatis felis.
+									</p>
+								</SidebarHint>
 							</SidebarGroupTitle>
 							Grouped content
 						</div>
@@ -76,9 +83,15 @@
 					<SidebarSection title="Section Title">
 						Section Content
 						<div>
-							<SidebarGroupTitle hintType="modal" hintLabel="why">
-								Pay Attention to this group
-								<svelte:fragment slot="hint">Because it's Awesome!</svelte:fragment>
+							<SidebarGroupTitle>
+								Group Title
+								<SidebarHint slot="hint" hintType="tooltip">
+									<p class="mb-4">Any content you want can go here</p>
+									<p>
+										Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+										nec venenatis sapien. Etiam venenatis felis.
+									</p>
+								</SidebarHint>
 							</SidebarGroupTitle>
 							Grouped content
 						</div>
@@ -106,9 +119,15 @@
 					<SidebarSection title="Section Title">
 						Section Content
 						<div>
-							<SidebarGroupTitle hintType="modal" hintLabel="why">
-								Pay Attention to this group
-								<svelte:fragment slot="hint">Because it's Awesome!</svelte:fragment>
+							<SidebarGroupTitle>
+								Group Title
+								<SidebarHint slot="hint" hintType="tooltip">
+									<p class="mb-4">Any content you want can go here</p>
+									<p>
+										Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+										nec venenatis sapien. Etiam venenatis felis.
+									</p>
+								</SidebarHint>
 							</SidebarGroupTitle>
 							Grouped content
 						</div>
@@ -136,9 +155,15 @@
 					<SidebarSection title="Section Title">
 						Section Content
 						<div>
-							<SidebarGroupTitle hintType="modal" hintLabel="why">
-								Pay Attention to this group
-								<svelte:fragment slot="hint">Because it's Awesome!</svelte:fragment>
+							<SidebarGroupTitle>
+								Group Title
+								<SidebarHint slot="hint" hintType="tooltip">
+									<p class="mb-4">Any content you want can go here</p>
+									<p>
+										Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+										nec venenatis sapien. Etiam venenatis felis.
+									</p>
+								</SidebarHint>
 							</SidebarGroupTitle>
 							Grouped content
 						</div>
@@ -166,9 +191,15 @@
 					<SidebarSection title="Section Title">
 						Section Content
 						<div>
-							<SidebarGroupTitle hintType="modal" hintLabel="why">
-								Pay Attention to this group
-								<svelte:fragment slot="hint">Because it's Awesome!</svelte:fragment>
+							<SidebarGroupTitle>
+								Group Title
+								<SidebarHint slot="hint" hintType="tooltip">
+									<p class="mb-4">Any content you want can go here</p>
+									<p>
+										Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+										nec venenatis sapien. Etiam venenatis felis.
+									</p>
+								</SidebarHint>
 							</SidebarGroupTitle>
 							Grouped content
 						</div>
@@ -196,9 +227,15 @@
 					<SidebarSection title="Section Title">
 						Section Content
 						<div>
-							<SidebarGroupTitle hintType="modal" hintLabel="why">
-								Pay Attention to this group
-								<svelte:fragment slot="hint">Because it's Awesome!</svelte:fragment>
+							<SidebarGroupTitle>
+								Group Title
+								<SidebarHint slot="hint" hintType="tooltip">
+									<p class="mb-4">Any content you want can go here</p>
+									<p>
+										Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+										nec venenatis sapien. Etiam venenatis felis.
+									</p>
+								</SidebarHint>
 							</SidebarGroupTitle>
 							Grouped content
 						</div>
@@ -246,9 +283,15 @@
 					<SidebarSection title="Section Title">
 						Section Content
 						<div>
-							<SidebarGroupTitle hintType="modal" hintLabel="why">
-								Pay Attention to this group
-								<svelte:fragment slot="hint">Because it's Awesome!</svelte:fragment>
+							<SidebarGroupTitle>
+								Group Title
+								<SidebarHint slot="hint" hintType="tooltip">
+									<p class="mb-4">Any content you want can go here</p>
+									<p>
+										Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+										nec venenatis sapien. Etiam venenatis felis.
+									</p>
+								</SidebarHint>
 							</SidebarGroupTitle>
 							Grouped content
 						</div>
@@ -276,9 +319,15 @@
 					<SidebarSection title="Section Title">
 						Section Content
 						<div>
-							<SidebarGroupTitle hintType="modal" hintLabel="why">
-								Pay Attention to this group
-								<svelte:fragment slot="hint">Because it's Awesome!</svelte:fragment>
+							<SidebarGroupTitle>
+								Group Title
+								<SidebarHint slot="hint" hintType="tooltip">
+									<p class="mb-4">Any content you want can go here</p>
+									<p>
+										Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+										nec venenatis sapien. Etiam venenatis felis.
+									</p>
+								</SidebarHint>
 							</SidebarGroupTitle>
 							Grouped content
 						</div>
@@ -342,9 +391,15 @@
 					<SidebarSection title="Section Title">
 						Section Content
 						<div>
-							<SidebarGroupTitle hintType="modal" hintLabel="why">
-								Pay Attention to this group
-								<svelte:fragment slot="hint">Because it's Awesome!</svelte:fragment>
+							<SidebarGroupTitle>
+								Group Title
+								<SidebarHint slot="hint" hintType="tooltip">
+									<p class="mb-4">Any content you want can go here</p>
+									<p>
+										Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+										nec venenatis sapien. Etiam venenatis felis.
+									</p>
+								</SidebarHint>
 							</SidebarGroupTitle>
 							Grouped content
 						</div>

--- a/packages/ui/src/lib/sidebar/Sidebar.stories.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.stories.svelte
@@ -1,5 +1,5 @@
 <script context="module">
-	import { RelativeWrapper } from '@ldn-viz/docs';
+	import { RelativeWrapper } from '../../../../../apps/docs';
 	import Sidebar from './Sidebar.svelte';
 
 	export const meta = {
@@ -42,6 +42,7 @@
 
 	import { ChartBar, Funnel, Map, MapPin } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
+	import SidebarHint from './elements/sidebarHint/SidebarHint.svelte';
 
 	let selectedValue = 'markers';
 
@@ -79,9 +80,15 @@
 				<SidebarSection title="Section Title">
 					Section Content
 					<div>
-						<SidebarGroupTitle hintType="modal" hintLabel="why">
-							Pay Attention to this group
-							<svelte:fragment slot="hint">Beacuse it's Awesome!</svelte:fragment>
+						<SidebarGroupTitle>
+							Group Title
+							<SidebarHint slot="hint" hintType="tooltip">
+								<p class="mb-4">Any content you want can go here</p>
+								<p>
+									Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+									nec venenatis sapien. Etiam venenatis felis.
+								</p>
+							</SidebarHint>
 						</SidebarGroupTitle>
 						Grouped content
 					</div>
@@ -119,9 +126,15 @@
 				<SidebarSection title="Section Title">
 					Section Content
 					<div>
-						<SidebarGroupTitle hintType="modal" hintLabel="why">
-							Pay Attention to this group
-							<svelte:fragment slot="hint">Beacuse it's Awesome!</svelte:fragment>
+						<SidebarGroupTitle>
+							Group Title
+							<SidebarHint slot="hint" hintType="tooltip">
+								<p class="mb-4">Any content you want can go here</p>
+								<p>
+									Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+									nec venenatis sapien. Etiam venenatis felis.
+								</p>
+							</SidebarHint>
 						</SidebarGroupTitle>
 						Grouped content
 					</div>
@@ -159,9 +172,15 @@
 				<SidebarSection title="Section Title">
 					Section Content
 					<div>
-						<SidebarGroupTitle hintType="modal" hintLabel="why">
-							Pay Attention to this group
-							<svelte:fragment slot="hint">Beacuse it's Awesome!</svelte:fragment>
+						<SidebarGroupTitle>
+							Group Title
+							<SidebarHint slot="hint" hintType="tooltip">
+								<p class="mb-4">Any content you want can go here</p>
+								<p>
+									Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+									nec venenatis sapien. Etiam venenatis felis.
+								</p>
+							</SidebarHint>
 						</SidebarGroupTitle>
 						Grouped content
 					</div>
@@ -271,9 +290,15 @@
 				<SidebarSection title="Section Title">
 					Section Content
 					<div>
-						<SidebarGroupTitle hintType="modal" hintLabel="why">
-							Pay Attention to this group
-							<svelte:fragment slot="hint">Beacuse it's Awesome!</svelte:fragment>
+						<SidebarGroupTitle>
+							Group Title
+							<SidebarHint slot="hint" hintType="tooltip">
+								<p class="mb-4">Any content you want can go here</p>
+								<p>
+									Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+									nec venenatis sapien. Etiam venenatis felis.
+								</p>
+							</SidebarHint>
 						</SidebarGroupTitle>
 						Grouped content
 					</div>
@@ -311,9 +336,15 @@
 				<SidebarSection title="Section Title">
 					Section Content
 					<div>
-						<SidebarGroupTitle hintType="modal" hintLabel="why">
-							Pay Attention to this group
-							<svelte:fragment slot="hint">Beacuse it's Awesome!</svelte:fragment>
+						<SidebarGroupTitle>
+							Group Title
+							<SidebarHint slot="hint" hintType="tooltip">
+								<p class="mb-4">Any content you want can go here</p>
+								<p>
+									Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+									nec venenatis sapien. Etiam venenatis felis.
+								</p>
+							</SidebarHint>
 						</SidebarGroupTitle>
 						Grouped content
 					</div>
@@ -351,9 +382,15 @@
 				<SidebarSection title="Section Title">
 					Section Content
 					<div>
-						<SidebarGroupTitle hintType="modal" hintLabel="why">
-							Pay Attention to this group
-							<svelte:fragment slot="hint">Beacuse it's Awesome!</svelte:fragment>
+						<SidebarGroupTitle>
+							Group Title
+							<SidebarHint slot="hint" hintType="tooltip">
+								<p class="mb-4">Any content you want can go here</p>
+								<p>
+									Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+									nec venenatis sapien. Etiam venenatis felis.
+								</p>
+							</SidebarHint>
 						</SidebarGroupTitle>
 						Grouped content
 					</div>
@@ -391,9 +428,15 @@
 				<SidebarSection title="Section Title">
 					Section Content
 					<div>
-						<SidebarGroupTitle hintType="modal" hintLabel="why">
-							Pay Attention to this group
-							<svelte:fragment slot="hint">Beacuse it's Awesome!</svelte:fragment>
+						<SidebarGroupTitle>
+							Group Title
+							<SidebarHint slot="hint" hintType="tooltip">
+								<p class="mb-4">Any content you want can go here</p>
+								<p>
+									Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+									nec venenatis sapien. Etiam venenatis felis.
+								</p>
+							</SidebarHint>
 						</SidebarGroupTitle>
 						Grouped content
 					</div>
@@ -431,9 +474,15 @@
 				<SidebarSection title="Section Title">
 					Section Content
 					<div>
-						<SidebarGroupTitle hintType="modal" hintLabel="why">
-							Pay Attention to this group
-							<svelte:fragment slot="hint">Beacuse it's Awesome!</svelte:fragment>
+						<SidebarGroupTitle>
+							Group Title
+							<SidebarHint slot="hint" hintType="tooltip">
+								<p class="mb-4">Any content you want can go here</p>
+								<p>
+									Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+									nec venenatis sapien. Etiam venenatis felis.
+								</p>
+							</SidebarHint>
 						</SidebarGroupTitle>
 						Grouped content
 					</div>
@@ -471,9 +520,15 @@
 				<SidebarSection title="Section Title">
 					Section Content
 					<div>
-						<SidebarGroupTitle hintType="modal" hintLabel="why">
-							Pay Attention to this group
-							<svelte:fragment slot="hint">Beacuse it's Awesome!</svelte:fragment>
+						<SidebarGroupTitle>
+							Group Title
+							<SidebarHint slot="hint" hintType="tooltip">
+								<p class="mb-4">Any content you want can go here</p>
+								<p>
+									Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+									nec venenatis sapien. Etiam venenatis felis.
+								</p>
+							</SidebarHint>
 						</SidebarGroupTitle>
 						Grouped content
 					</div>
@@ -543,9 +598,15 @@
 				<SidebarSection title="Section Title">
 					Section Content
 					<div>
-						<SidebarGroupTitle hintType="modal" hintLabel="why">
-							Pay Attention to this group
-							<svelte:fragment slot="hint">Beacuse it's Awesome!</svelte:fragment>
+						<SidebarGroupTitle>
+							Group Title
+							<SidebarHint slot="hint" hintType="tooltip">
+								<p class="mb-4">Any content you want can go here</p>
+								<p>
+									Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui,
+									nec venenatis sapien. Etiam venenatis felis.
+								</p>
+							</SidebarHint>
 						</SidebarGroupTitle>
 						Grouped content
 					</div>

--- a/packages/ui/src/lib/sidebar/elements/sidebarHeader/SidebarHeader.stories.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarHeader/SidebarHeader.stories.svelte
@@ -37,16 +37,19 @@
 </Story>
 
 <Story name="With Hint" source>
-	<SidebarHeader title="Main sidebar title" hintType="modal">
-		<svelte:fragment slot="hint">Content hint here</svelte:fragment>
+	<SidebarHeader title="Main sidebar title">
+		<SidebarHint slot="hint" hintType="modal" modalTitle="About" modalWidth="5xl">
+			<p class="mb-4">Any content you want can go here</p>
+			<p>
+				Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui, nec
+				venenatis sapien. Etiam venenatis felis.
+			</p>
+		</SidebarHint>
 	</SidebarHeader>
 </Story>
 
 <Story name="With Long Title" source>
 	<SidebarHeader
 		title={`Main sidebar title which is<br /> unfortunately very long and so<br /> needs some breaks inserting`}
-		hintType="modal"
-	>
-		<svelte:fragment slot="hint">Content hint here</svelte:fragment>
-	</SidebarHeader>
+	></SidebarHeader>
 </Story>

--- a/packages/ui/src/lib/sidebar/elements/sidebarHeader/SidebarHeader.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarHeader/SidebarHeader.svelte
@@ -17,12 +17,9 @@
 
 <script lang="ts">
 	import { classNames } from '../../../utils/classNames';
-	import SidebarHint from '../sidebarHint/SidebarHint.svelte';
 
 	export let title: string;
 	export let branded: 'true' | 'false' = 'true';
-	export let hintType: 'popover' | 'modal' | 'tooltip' | undefined = undefined;
-	export let hintLabel: string | undefined = undefined;
 
 	$: headerClasses = classNames('py-1', ...themeClasses, brandClasses[branded]);
 </script>
@@ -31,10 +28,8 @@
 	<div class="flex justify-between items-end">
 		<h1 class="text-xl font-bold">{@html title}</h1>
 
-		{#if hintType}
-			<SidebarHint {hintType} {hintLabel}>
-				<slot name="hint" />
-			</SidebarHint>
+		{#if $$slots.hint}
+			<slot name="hint" />
 		{/if}
 	</div>
 

--- a/packages/ui/src/lib/sidebar/elements/sidebarHint/SidebarHint.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarHint/SidebarHint.svelte
@@ -24,11 +24,11 @@
 </script>
 
 {#if hintType === 'tooltip'}
-	<Tooltip {hintLabel}>
+	<Tooltip {hintLabel} hintSize="sm">
 		<slot />
 	</Tooltip>
 {:else if hintType === 'popover'}
-	<Tooltip {hintLabel}>
+	<Tooltip {hintLabel} hintSize="sm">
 		<slot />
 	</Tooltip>
 {:else if hintType === 'modal'}

--- a/packages/ui/src/lib/sidebar/elements/sidebarSection/SidebarSection.stories.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarSection/SidebarSection.stories.svelte
@@ -9,6 +9,7 @@
 
 <script>
 	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import SidebarHint from '../sidebarHint/SidebarHint.svelte';
 	import SidebarGroupTitle from './sidebarGroupTitle/SidebarGroupTitle.svelte';
 </script>
 
@@ -24,9 +25,11 @@
 	<SidebarSection title="Section Title">
 		Section Content
 		<div>
-			<SidebarGroupTitle hintType="modal" hintLabel="why">
+			<SidebarGroupTitle>
 				Pay Attention to this group
-				<svelte:fragment slot="hint">Beacuse it's Awesome!</svelte:fragment>
+				<SidebarHint slot="hint" hintType="modal" hintLabel="why">
+					Beacuse it's Awesome!
+				</SidebarHint>
 			</SidebarGroupTitle>
 			Grouped content
 		</div>

--- a/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarGroupTitle/SidebarGroupTitle.stories.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarGroupTitle/SidebarGroupTitle.stories.svelte
@@ -1,4 +1,5 @@
 <script context="module">
+	import SidebarHint from '../../sidebarHint/SidebarHint.svelte';
 	import SidebarGroupTitle from './SidebarGroupTitle.svelte';
 
 	export const meta = {
@@ -20,5 +21,14 @@
 </Story>
 
 <Story name="With Hint" source>
-	<SidebarGroupTitle hintType="modal">Group Title</SidebarGroupTitle>
+	<SidebarGroupTitle>
+		Group Title
+		<SidebarHint slot="hint" hintType="tooltip">
+			<p class="mb-4">Any content you want can go here</p>
+			<p>
+				Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui, nec
+				venenatis sapien. Etiam venenatis felis.
+			</p>
+		</SidebarHint>
+	</SidebarGroupTitle>
 </Story>

--- a/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarGroupTitle/SidebarGroupTitle.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarGroupTitle/SidebarGroupTitle.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
 	import { classNames } from '../../../../utils/classNames';
-	import SidebarHint from '../../sidebarHint/SidebarHint.svelte';
-
-	export let hintType: 'popover' | 'modal' | 'tooltip' | undefined = undefined;
-	export let hintLabel: string | undefined = undefined;
 
 	const darkThemeClasses = 'dark:text-white';
 	const lightThemeClasses = 'text-core-grey-700';
@@ -16,9 +12,7 @@
 <div class={groupTitleClasses}>
 	<h3 class="font-bold text-sm"><slot /></h3>
 
-	{#if hintType}
-		<SidebarHint {hintType} {hintLabel}>
-			<slot name="hint" />
-		</SidebarHint>
+	{#if $$slots.hint}
+		<slot name="hint" />
 	{/if}
 </div>

--- a/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarSectionTitle/SidebarSectionTitle.stories.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarSectionTitle/SidebarSectionTitle.stories.svelte
@@ -1,4 +1,5 @@
 <script context="module">
+	import SidebarHint from '../../sidebarHint/SidebarHint.svelte';
 	import SidebarSectionTitle from './SidebarSectionTitle.svelte';
 
 	export const meta = {
@@ -29,8 +30,14 @@
 </Story>
 
 <Story name="With Hint" source>
-	<SidebarSectionTitle hintType="modal">
+	<SidebarSectionTitle>
 		Section Title
-		<svelte:fragment slot="hint">Content hint here</svelte:fragment>
+		<SidebarHint slot="hint" hintType="tooltip">
+			<p class="mb-4">Any content you want can go here</p>
+			<p>
+				Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui, nec
+				venenatis sapien. Etiam venenatis felis.
+			</p>
+		</SidebarHint>
 	</SidebarSectionTitle>
 </Story>

--- a/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarSectionTitle/SidebarSectionTitle.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarSectionTitle/SidebarSectionTitle.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
 	import { classNames } from '../../../../utils/classNames';
-	import SidebarHint from '../../sidebarHint/SidebarHint.svelte';
-
-	export let hintType: 'popover' | 'modal' | 'tooltip' | undefined = undefined;
-	export let hintLabel: string | undefined = undefined;
 
 	const darkThemeClasses = 'dark:text-white';
 	const lightThemeClasses = 'text-core-grey-700';
@@ -17,10 +13,8 @@
 	<div class="flex justify-between items-end">
 		<h1 class="font-bold text-base"><slot /></h1>
 
-		{#if hintType}
-			<SidebarHint {hintType} {hintLabel}>
-				<slot name="hint" />
-			</SidebarHint>
+		{#if $$slots.hint}
+			<slot name="hint" />
 		{/if}
 	</div>
 

--- a/packages/ui/src/lib/tooltip/tooltip.ts
+++ b/packages/ui/src/lib/tooltip/tooltip.ts
@@ -1,6 +1,6 @@
 import { createFloatingActions } from 'svelte-floating-ui';
 
 export const [floatingRef, floatingContent] = createFloatingActions({
-	strategy: 'absolute',
+	strategy: 'fixed',
 	placement: 'top'
 });


### PR DESCRIPTION
**What does this change?**
Sidebar elements that can display a hint now accept the sidebarHint component into a hint slot

**Why?**
Allows greater flexibility and reduces the responsibility surface of the parent component

**How?**
Slots over props

**Related issues**:
#282 

**Does this introduce new dependencies?**
no

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
na

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
