### PR TITLE
Fix/sidebar jank

### DIFF
--- a/.changeset/aaa_bbb_ccc_ddd.md
+++ b/.changeset/aaa_bbb_ccc_ddd.md
@@ -1,0 +1,8 @@
+---
+'@ldn-viz/maps': minor
+'@ldn-viz/ui': minor
+---
+
+ADDED `MapControlGeocoder`, `MapControlGeolocator`, and `MapControlLocationSearch` components to `@ldn-viz/maps`
+
+ADDED `Geocoder`, `Geolocator`, and `GeocoderSuggestionList` components to `@ldn-viz/ui`

--- a/.changeset/big-years-beg.md
+++ b/.changeset/big-years-beg.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/ui": minor
+---
+
+AppShell awaits innerwidth calc before showing sidebar

--- a/.changeset/kgierif-dmiqwd-keiwie.md
+++ b/.changeset/kgierif-dmiqwd-keiwie.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': major
+---
+
+CHANGED - map themes are now imported as objects directly from `@ldn-viz/maps`, rather than being imported as JSON files from  `@ldn-viz/maps/themes`

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -14,6 +14,12 @@
 		"lint": "prettier --check . && eslint src",
 		"format": "prettier --write ."
 	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"svelte": "./dist/index.js"
+		}
+	},
 	"files": [
 		"themes",
 		"dist",

--- a/packages/maps/src/lib/index.js
+++ b/packages/maps/src/lib/index.js
@@ -10,6 +10,12 @@ export { default as MapControlPan } from './mapControlPan/MapControlPan.svelte';
 export { default as MapControlRefresh } from './mapControlRefresh/MapControlRefresh.svelte';
 export { default as MapControlZoom } from './mapControlZoom/MapControlZoom.svelte';
 
+// Location Search
+export * from './mapControlLocationSearch/MapGeocoderAdapterMapBox';
+export { default as MapControlGeocoder } from './mapControlLocationSearch/MapControlGeocoder.svelte';
+export { default as MapControlGeolocator } from './mapControlLocationSearch/MapControlGeolocator.svelte';
+export { default as MapControlLocationSearch } from './mapControlLocationSearch/MapControlLocationSearch.svelte';
+
 // themes
 export * from './themes/animations';
 export * from './themes/bounds';

--- a/packages/maps/src/lib/index.js
+++ b/packages/maps/src/lib/index.js
@@ -13,3 +13,8 @@ export { default as MapControlZoom } from './mapControlZoom/MapControlZoom.svelt
 // themes
 export * from './themes/animations';
 export * from './themes/bounds';
+
+export * as theme_os_dark_grey_muted_buildings from './themes/os_dark_grey_muted_buildings.json';
+export * as theme_os_dark from './themes/os_dark.json';
+export * as theme_os_greyscale from './themes/os_greyscale.json';
+export * as theme_os_light_vts from './themes/os_light_vts.json';

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlGeocoder.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlGeocoder.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { Geocoder, GeocoderSuggestionList } from '@ldn-viz/ui';
+	import { setFeature, clearFeature } from './map-layer';
+	import type { MapStore, MapGLStore } from './map-types';
+
+	import type {
+		Geolocation,
+		OnGeolocationSearchResult,
+		OnGeolocationSearchError,
+		GeocoderAdapter
+	} from '@ldn-viz/ui';
+
+	// adapter to source location suggestions from.
+	export let adapter: GeocoderAdapter;
+
+	// onLocationSelected is invoked when a user clicks a suggestion.
+	export let onLocationSelected: undefined | OnGeolocationSearchResult = undefined;
+
+	// onSearchError is invoked when the adapter rejects a promise for a search.
+	export let onSearchError: undefined | OnGeolocationSearchError;
+
+	// maxSuggestions is the maximum number of suggestion to show. This does
+	// not limit the results array.
+	export let maxSuggestions: number = 5;
+
+	// classes is a string of additional CSS classes that are passed to the
+	// geocoder and applied to its root element.
+	export let classes = '';
+
+	// inputClasses is a string of additional CSS classes that are passed to the
+	// geocoder and applied specifically to the text input field.
+	export let inputClasses = '';
+
+	const map: MapStore = getContext('map');
+	const mapgl: MapGLStore = getContext('map_gl');
+
+	const zoomLevel = 16;
+	const delay = 500;
+
+	const onLocationSelectedGeocoder = (location: Geolocation) => {
+		if (!$map) {
+			return;
+		}
+
+		showClearButton = true;
+		setFeature('geocoder', $map, $mapgl, location, { zoom: zoomLevel });
+
+		if (onLocationSelected) {
+			onLocationSelected(location);
+		}
+	};
+
+	let showClearButton = false;
+	$: !showClearButton && clearFeature('geocoder', $map);
+</script>
+
+<Geocoder
+	{adapter}
+	{delay}
+	{onSearchError}
+	onLocationSelected={onLocationSelectedGeocoder}
+	{classes}
+	{inputClasses}
+	bind:showClearButton
+	let:onSuggestionEvent
+	let:attribution
+	let:suggestions
+	{...$$restProps}
+>
+	{#if suggestions.length > 0}
+		<GeocoderSuggestionList {onSuggestionEvent} {attribution} {suggestions} {maxSuggestions} />
+	{/if}
+</Geocoder>

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlGeolocator.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlGeolocator.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { setFeature, clearFeature } from './map-layer';
+	import { Geolocator } from '@ldn-viz/ui';
+	import type { MapStore, MapGLStore } from './map-types';
+
+	import type {
+		GeolocationUnamed,
+		OnGeolocationSearchResult,
+		OnGeolocationSearchError
+	} from '@ldn-viz/ui';
+
+	// onLocationFound is invoked when the browser finds a location.
+	export let onLocationFound: undefined | OnGeolocationSearchResult = undefined;
+
+	// onSearchError is invoked when a search error occurs.
+	export let onSearchError: undefined | OnGeolocationSearchError = undefined;
+
+	const map: MapStore = getContext('map');
+	const mapgl: MapGLStore = getContext('map_gl');
+	const zoomLevel = 16;
+
+	const flyToLocation = (location: GeolocationUnamed) => {
+		if (!$map) {
+			return;
+		}
+
+		setFeature('geolocator', $map, $mapgl, location, { zoom: zoomLevel });
+
+		if (onLocationFound) {
+			onLocationFound(location);
+		}
+	};
+
+	let showClearButton = false;
+	$: !showClearButton && clearFeature('geolocator', $map);
+</script>
+
+<Geolocator onLocationFound={flyToLocation} {onSearchError} bind:showClearButton />

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
@@ -1,0 +1,67 @@
+<script context="module">
+	import MapControlLocationSearch from './MapControlLocationSearch.svelte';
+
+	export const meta = {
+		title: 'Maps/MapControlLocationSearch',
+		component: MapControlLocationSearch,
+		parameters: {
+			layout: 'fullscreen'
+		}
+	};
+</script>
+
+<script lang="ts">
+	import { Template, Story } from '@storybook/addon-svelte-csf';
+
+	import * as os_light_vts from '../themes/os_light_vts.json';
+	import MapApp from '../map/MapApp.svelte';
+	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+
+	import MapControlGroup from '../mapControlGroup/MapControlGroup.svelte';
+
+	import { MapGeocoderAdapterMapBox } from './MapGeocoderAdapterMapBox';
+	import type { OnGeolocationSearchError, GeolocationSearchError } from '@ldn-viz/ui';
+
+	const transformRequest = appendOSKeyToUrl('vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP');
+	const adapter = new MapGeocoderAdapterMapBox(
+		'pk.eyJ1IjoiZ2xhLWdpcyIsImEiOiJjanBvNGh1bncwOTkzNDNueWt5MGU1ZGtiIn0.XFxLdq2dXttcXSXTiREPTA'
+	);
+
+	const onSearchError: OnGeolocationSearchError = (err: GeolocationSearchError) => {
+		console.error(err);
+	};
+</script>
+
+<Template let:args>
+	<MapControlLocationSearch {...args} />
+</Template>
+
+<Story name="Location Search">
+	<MapApp>
+		<Map
+			options={{
+				style: os_light_vts,
+				transformRequest
+			}}
+		>
+			<MapControlGroup position="TopLeft">
+				<MapControlLocationSearch {adapter} {onSearchError} />
+			</MapControlGroup>
+		</Map>
+	</MapApp>
+</Story>
+
+<Story name="Hidden Geolocator">
+	<MapApp>
+		<Map
+			options={{
+				style: os_light_vts,
+				transformRequest
+			}}
+		>
+			<MapControlGroup position="TopLeft">
+				<MapControlLocationSearch {adapter} {onSearchError} hideGeolocator />
+			</MapControlGroup>
+		</Map>
+	</MapApp>
+</Story>

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import MapControlGeocoder from './MapControlGeocoder.svelte';
+	import MapControlGeolocator from './MapControlGeolocator.svelte';
+	import { initMapLayer } from './map-layer';
+
+	import type { MapStore } from './map-types';
+	import type {
+		GeocoderAdapter,
+		OnGeolocationSearchResult,
+		OnGeolocationSearchError
+	} from '@ldn-viz/ui';
+
+	const map: MapStore = getContext('map');
+
+	// adapter to source location suggestions from.
+	export let adapter: GeocoderAdapter;
+
+	// onLocationFound is invoked when a user clicks a suggestion.
+	export let onLocationFound: undefined | OnGeolocationSearchResult = undefined;
+
+	// onSearchError is invoked when the adapter rejects a promise for a search.
+	export let onSearchError: undefined | OnGeolocationSearchError = undefined;
+
+	// maxSuggestions is the maximum number of suggestion to show. This does
+	// not limit the results array.
+	export let maxSuggestions: number = 5;
+
+	// hideGeolocator hides the geolocator.
+	export let hideGeolocator = false;
+
+	let limitWidthClass = '';
+	if (hideGeolocator) {
+		// 100% - left margin - right margin
+		limitWidthClass = 'max-w-[calc(100dvw-1.5rem-1.5rem)]';
+	} else {
+		// 100% - geolocator button width - left margin - right margin
+		limitWidthClass = 'max-w-[calc(100dvw-2.5rem-1.5rem-1.5rem)]';
+	}
+
+	$: initMapLayer($map);
+</script>
+
+<div class="flex" {...$$restProps}>
+	<MapControlGeocoder
+		{adapter}
+		onLocationSelected={onLocationFound}
+		{onSearchError}
+		{maxSuggestions}
+		inputClasses="w-72 {limitWidthClass}"
+	/>
+	{#if !hideGeolocator}
+		<MapControlGeolocator {onLocationFound} {onSearchError} />
+	{/if}
+</div>

--- a/packages/maps/src/lib/mapControlLocationSearch/MapGeocoderAdapterMapBox.ts
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapGeocoderAdapterMapBox.ts
@@ -1,0 +1,123 @@
+import { GREATER_LONDON_BOUNDS_PADDED } from '@ldn-viz/maps';
+import type {
+	GeolocationCoords,
+	GeolocationBounds,
+	GeolocationNamed,
+	GeocoderAdapter
+} from '@ldn-viz/ui';
+
+type MapBoxFeature = {
+	id: string;
+	text: string; // name
+	place_name: string; // address
+	center: [number, number];
+	bbox?: [number, number, number, number]; // bounds
+	[otherOptions: string]: unknown;
+};
+
+type MapBoxFeatureCollection = {
+	features: MapBoxFeature[];
+	[otherOptions: string]: unknown;
+};
+
+// MapGeocoderAdapterMapBox adapter uses the MapBox API to source locations.
+//
+// Due to licensing this adapter can only be used within @ldn-viz maps and
+// result locations must be shown on the map.
+export class MapGeocoderAdapterMapBox implements GeocoderAdapter {
+	private _token: string = '';
+	private _resultCount: number = 5;
+
+	constructor(token: string, resultCount = 5) {
+		this._token = token;
+		this.setResultCount(resultCount);
+	}
+
+	// GeocoderAdapter functions.
+
+	search(text: string) {
+		const url = buildUrl(text, this._token, this._resultCount);
+		return fetch(url)
+			.then((res) => res.json())
+			.then(transformGeoJSONToNamedGeolocations);
+	}
+
+	attribution() {
+		return {
+			text: 'Powered by MapBox',
+			link: 'https://docs.mapbox.com/api/search/'
+		};
+	}
+
+	// MapGeocoderAdapterMapBox functions.
+
+	setResultCount(resultCount: number): MapGeocoderAdapterMapBox {
+		if (resultCount > 10) {
+			resultCount = 10;
+			console.warn(
+				`[MapGeocoderAdapterMapBox] maximum MapBox API result count is 10. ${resultCount} is too high so defaulting to 10`
+			);
+		} else if (resultCount < 1) {
+			resultCount = 1;
+			console.warn(
+				`[MapGeocoderAdapterMapBox] minimum MapBox API result count is 1. ${resultCount} is too low so defaulting to 1`
+			);
+		}
+
+		this._resultCount = resultCount;
+		return this;
+	}
+}
+
+const buildUrl = (text: string, token: string, resultCount: number): string => {
+	text = encodeURIComponent(text);
+
+	const queryString = new URLSearchParams({
+		access_token: token,
+		bbox: GREATER_LONDON_BOUNDS_PADDED.flat().toString(),
+		autocomplete: true.toString(),
+		limit: resultCount.toString()
+	});
+
+	return `https://api.mapbox.com/geocoding/v5/mapbox.places/${text}.json?${queryString}`;
+};
+
+const transformGeoJSONToNamedGeolocations = (
+	geojson: MapBoxFeatureCollection
+): GeolocationNamed[] => {
+	return geojson.features.map((loc) => {
+		return {
+			id: loc.id,
+			name: loc.text,
+			address: removeNameFromAddress(loc.place_name, loc.text),
+			// loc.center isn't always the center of the bbox
+			center: calcBoundingBoxCenter(loc.bbox, loc.center),
+			bounds: loc.bbox
+		};
+	});
+};
+
+const removeNameFromAddress = (address: string, name: string) => {
+	if (!address.startsWith(name)) {
+		return address;
+	}
+
+	address = address.slice(name.length).trim();
+
+	if (address.startsWith(',')) {
+		return address.slice(1).trim();
+	}
+
+	return address;
+};
+
+const calcBoundingBoxCenter = (
+	bbox: undefined | GeolocationBounds,
+	center: GeolocationCoords
+): GeolocationCoords => {
+	if (!bbox) {
+		return center;
+	}
+
+	return [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2];
+};

--- a/packages/maps/src/lib/mapControlLocationSearch/map-layer.ts
+++ b/packages/maps/src/lib/mapControlLocationSearch/map-layer.ts
@@ -1,0 +1,177 @@
+import { GLIDE_ANIMATION_OPTIONS } from '@ldn-viz/maps';
+import type { GeolocationCoords, GeolocationBounds, Geolocation } from '@ldn-viz/ui';
+
+import type {
+	Map,
+	Marker,
+	GeoJSONSource,
+	SourceSpecification,
+	LayerSpecification,
+	FlyToOptions
+} from 'maplibre-gl';
+
+import type { FeatureCollection } from 'geojson';
+import type { MapGL } from './map-types';
+
+const markers: { [keys: string]: Marker } = {};
+const sourceId = 'gla/context/location-search';
+
+const sourceSpec: SourceSpecification = {
+	type: 'geojson',
+	data: {
+		type: 'FeatureCollection',
+		features: []
+	}
+};
+
+const layerSpecs: LayerSpecification[] = [
+	{
+		id: `${sourceId}/map-point-symbol`,
+		source: sourceId,
+		type: 'symbol',
+		layout: {
+			'icon-image': 'map-pin',
+			'icon-size': 0.4
+		}
+	}
+];
+
+export const initMapLayer = (map: Map) => {
+	if (!map) {
+		return;
+	}
+
+	removeLayers(map);
+	addLayers(map);
+};
+
+const removeLayers = (map: Map) => {
+	for (const layer of layerSpecs) {
+		if (map.getLayer(layer.id)) {
+			map.removeLayer(layer.id);
+		}
+	}
+
+	if (map.getSource(sourceId)) {
+		map.removeSource(sourceId);
+	}
+};
+
+const addLayers = (map: Map) => {
+	map.addSource(sourceId, sourceSpec);
+
+	for (const layer of layerSpecs) {
+		map.addLayer(layer);
+	}
+};
+
+export const setFeature = (
+	ref: string,
+	map: Map,
+	mapgl: MapGL,
+	location: Geolocation,
+	flyOptions: FlyToOptions = {}
+) => {
+	if (!map) {
+		return;
+	}
+
+	(map.getSource(sourceId) as GeoJSONSource)?.setData(
+		createFeatureCollection(location) as FeatureCollection
+	);
+
+	addMarkerAndFlyToLocation(ref, map, mapgl, location, flyOptions);
+};
+
+const addMarkerAndFlyToLocation = (
+	ref: string,
+	map: Map,
+	mapgl: MapGL,
+	location: Geolocation,
+	flyOptions: FlyToOptions
+) => {
+	setMarker(ref, map, mapgl, location.center);
+
+	if (location.bounds) {
+		flyToBounds(map, location.bounds);
+	} else {
+		flyToCoords(map, location.center, flyOptions);
+	}
+};
+
+const setMarker = (ref: string, map: Map, mapgl: MapGL, coords: GeolocationCoords) => {
+	clearMarker(ref);
+
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	markers[ref] = new mapgl.Marker().setLngLat(coords).addTo(map);
+};
+
+const clearMarker = (ref: string) => {
+	if (markers[ref]) {
+		markers[ref].remove();
+		delete markers[ref];
+	}
+};
+
+export const clearFeature = (ref: string, map: Map) => {
+	if (!map) {
+		return;
+	}
+
+	clearMarker(ref);
+	(map.getSource(sourceId) as GeoJSONSource)?.setData({
+		type: 'FeatureCollection',
+		features: []
+	});
+};
+
+const createFeatureCollection = (location: Geolocation) => {
+	return {
+		type: 'FeatureCollection',
+		features: [createFeature(location)]
+	};
+};
+
+const createFeature = (location: Geolocation) => {
+	return {
+		type: 'Feature',
+		geometry: createFeatureGeometry(location),
+		properties: {}
+	};
+};
+
+const createFeatureGeometry = (location: Geolocation) => {
+	if (location.bounds) {
+		return createFeatureGeometryBounds(location);
+	}
+	return createFeatureGeometryPoint(location);
+};
+
+const createFeatureGeometryPoint = (location: Geolocation) => {
+	return {
+		type: 'Point',
+		coordinates: location.center as [number, number]
+	};
+};
+
+const createFeatureGeometryBounds = (location: Geolocation) => {
+	return {
+		type: 'Polygon',
+		coordinates: [location.bounds as [number, number, number, number]]
+	};
+};
+
+const flyToBounds = (map: Map, bounds: GeolocationBounds) => {
+	map.fitBounds(bounds, {
+		...GLIDE_ANIMATION_OPTIONS
+	});
+};
+
+const flyToCoords = (map: Map, coords: GeolocationCoords, options: FlyToOptions) => {
+	map.flyTo({
+		...GLIDE_ANIMATION_OPTIONS,
+		center: coords,
+		...options
+	});
+};

--- a/packages/maps/src/lib/mapControlLocationSearch/map-types.ts
+++ b/packages/maps/src/lib/mapControlLocationSearch/map-types.ts
@@ -1,0 +1,11 @@
+import type { Writable } from 'svelte/store';
+
+import type { Map, Marker } from 'maplibre-gl';
+
+export interface MapGL {
+	Marker: Marker;
+	[keys: string]: unknown;
+}
+
+export type MapStore = Writable<Map>;
+export type MapGLStore = Writable<MapGL>;

--- a/packages/maps/src/lib/themes/animations.ts
+++ b/packages/maps/src/lib/themes/animations.ts
@@ -1,8 +1,8 @@
-import { type AnimationOptions, type FlyOptions } from 'maplibre-gl';
+import type { AnimationOptions, FlyToOptions } from 'maplibre-gl';
 
 // https://easings.net/
-export const easeOutQuad = (t) => 1 - (1 - t) * (1 - t);
-export const easeOutQuart = (t) => 1 - Math.pow(1 - t, 4);
+export const easeOutQuad = (t: number) => 1 - (1 - t) * (1 - t);
+export const easeOutQuart = (t: number) => 1 - Math.pow(1 - t, 4);
 
 export const ZOOM_ANIMATION_OPTIONS: AnimationOptions = {
 	animate: true,
@@ -11,7 +11,7 @@ export const ZOOM_ANIMATION_OPTIONS: AnimationOptions = {
 	freezeElevation: true
 };
 
-export const GLIDE_ANIMATION_OPTIONS: FlyOptions = {
+export const GLIDE_ANIMATION_OPTIONS: FlyToOptions = {
 	animate: true,
 	duration: 1000,
 	easing: easeOutQuad
@@ -21,7 +21,7 @@ export const GLIDE_ANIMATION_OPTIONS: FlyOptions = {
 	// - speed (& maxDuration)
 };
 
-export const FLY_ANIMATION_OPTIONS: FlyOptions = {
+export const FLY_ANIMATION_OPTIONS: FlyToOptions = {
 	animate: true,
 	duration: 300,
 	easing: easeOutQuad

--- a/packages/ui/.eslintrc.cjs
+++ b/packages/ui/.eslintrc.cjs
@@ -28,5 +28,9 @@ module.exports = {
 		browser: true,
 		es2017: true,
 		node: true
+	},
+	globals: {
+		GeolocationPosition: 'readonly',
+		GeolocationPositionError: 'readonly'
 	}
 };

--- a/packages/ui/src/lib/appShell/AppShell.svelte
+++ b/packages/ui/src/lib/appShell/AppShell.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { setContext } from 'svelte';
 	import { writable } from 'svelte/store';
-	import { slide } from 'svelte/transition';
+	import { fade, slide } from 'svelte/transition';
 	import {
 		heightLookup,
 		transitionAxis,
@@ -68,7 +68,11 @@
 		</slot>
 	</main>
 
-	<slot name="sidebar">Sidebar</slot>
+	{#if innerWidth !== 0}
+		<div transition:fade={{ duration: 200 }}>
+			<slot name="sidebar">Sidebar</slot>
+		</div>
+	{/if}
 
 	<!-- This div exists to push content to the side of the sidebar	when sidebarPush is set to true-->
 	{#if sidebarPush && $isOpen && $sidebarWidthStore}

--- a/packages/ui/src/lib/geolocation/Geocoder.stories.svelte
+++ b/packages/ui/src/lib/geolocation/Geocoder.stories.svelte
@@ -1,0 +1,173 @@
+<script context="module">
+	import Geocoder from './Geocoder.svelte';
+	import GeocoderSuggestionList from './GeocoderSuggestionList.svelte';
+
+	export const meta = {
+		title: 'Ui/Geocoder',
+		component: Geocoder,
+		parameters: {
+			layout: 'fullscreen'
+		}
+	};
+</script>
+
+<script lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import { GeocoderAdapterList } from './GeocoderAdapterList';
+	import type {
+		GeolocationCoords,
+		GeolocationNamed,
+		OnGeolocationSearchResult,
+		OnGeolocationSearchError,
+		Geolocation
+	} from './types';
+
+	let suggestions: undefined | GeolocationNamed[];
+	let selected = '';
+
+	const formatResult = (location: Geolocation): string => {
+		return '\n' + JSON.stringify(location, null, 2);
+	};
+
+	const onLocationSelected: OnGeolocationSearchResult = (location: Geolocation) => {
+		selected = formatResult(location);
+	};
+
+	const onSearchError: OnGeolocationSearchError = (err) => {
+		console.error(err);
+	};
+
+	const centerOfBounds = (bounds: [number, number, number, number]): GeolocationCoords => {
+		return [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2];
+	};
+
+	const listAdapter = new GeocoderAdapterList([
+		{
+			id: '1',
+			center: [-0.08564082393624517, 51.4944230052667],
+			name: "Bricklayers' Arms",
+			address: 'South of London Bridge somewhere'
+		},
+		{
+			id: '11',
+			center: [-0.08564082393624517, 51.4944230052667],
+			name: 'Bricklayers Arms Flyover',
+			address: "Flys over Bricklayers' Arms"
+		},
+		{
+			id: '12',
+			center: [-0.07272570707647219, 51.520966913867824],
+			name: 'Brick Lane Market',
+			address: 'Brick Lane Market, 91 Brick Ln, London, England E1 6RU, United Kingdom'
+		},
+		{
+			id: '13',
+			center: [-0.0682034415460464, 51.605862586455316],
+			name: 'The Bricklayers Arms',
+			address: 'The Bricklayers Arms, 803-805 High Rd, London, England N17 8ER, United Kingdom'
+		},
+		{
+			id: '14',
+			center: [-0.2167357587457559, 51.466139217180796],
+			name: 'The Bricklayers Arms',
+			address: 'The Bricklayers Arms, 32 Waterman St, London, England SW15 1DD, United Kingdom'
+		},
+		{
+			id: '2',
+			center: [-0.08564082393624517, 51.4944230052667],
+			name: 'Bricklayers Arms Flyover',
+			address: "Flys over Bricklayers' Arms"
+		},
+		{
+			id: '3',
+			center: [-0.10552520175642144, 51.495195323492794],
+			name: 'West Square Gardens',
+			address: 'West Sq, Lambeth, London'
+		},
+		{
+			id: '4',
+			center: centerOfBounds([
+				-0.12463302780648178, 51.520795753244215, -0.12751886736666052, 51.522583023763104
+			]),
+			bounds: [-0.12463302780648178, 51.520795753244215, -0.12751886736666052, 51.522583023763104],
+			name: 'Russell Square',
+			address: 'Next to Russell Square station, Bloomsbury, Camden, London'
+		},
+		{
+			id: '5',
+			center: centerOfBounds([
+				-0.025778325874284747, 51.4962206418233, -0.027878115405741255, 51.49783613304322
+			]),
+			bounds: [-0.025778325874284747, 51.4962206418233, -0.027878115405741255, 51.49783613304322],
+			name: 'Sir John McDougall Gardens',
+			address: 'Westferry Rd, Tower Hamlets, London'
+		}
+	]);
+</script>
+
+<Template let:args>
+	<Geocoder {...args} />
+</Template>
+
+<Story name="Suggestions dropdown">
+	<div class="m-6 space-y-6">
+		<p class="dark:text-white">
+			A simple geocoder with dropdown suggestions. A simple hardcoded list adapter is used here so
+			results are limited.
+		</p>
+		<p class="dark:text-white">
+			At least three characters are required before any suggestions are provided. This avoids
+			spamming the underlying Web APIs with excessively vague requests.
+		</p>
+		<p class="dark:text-white">
+			Try entering 'brick' or 'london' if you're having trouble finding any places.
+		</p>
+		<Geocoder
+			let:onSuggestionEvent
+			let:attribution
+			let:suggestions
+			adapter={listAdapter}
+			{onLocationSelected}
+			{onSearchError}
+			classes="w-72"
+		>
+			{#if suggestions?.length > 0}
+				<GeocoderSuggestionList
+					{onSuggestionEvent}
+					{attribution}
+					{suggestions}
+					maxSuggestions={5}
+				/>
+			{/if}
+		</Geocoder>
+		<pre class="dark:text-white whitespace-pre-wrap">
+			{selected}
+		</pre>
+	</div>
+</Story>
+
+<Story name="Disabled dropdown">
+	<div class="m-6 space-y-6">
+		<p class="dark:text-white">
+			I've disabled the dropdown in this story, intead, I'm accessing the results by binding on the
+			result set. I'm manually displaying them below but you can do whatever you like with them.
+		</p>
+		<p class="dark:text-white">
+			Try entering 'brick' or 'london' if you're having trouble finding any places.
+		</p>
+		<Geocoder
+			adapter={listAdapter}
+			{onLocationSelected}
+			{onSearchError}
+			bind:suggestions
+			classes="w-72"
+		/>
+		<pre class="dark:text-white whitespace-pre-wrap">
+			{#if suggestions}
+				{#each suggestions as location}
+					{formatResult(location)}<br />
+				{/each}
+			{/if}
+		</pre>
+	</div>
+</Story>

--- a/packages/ui/src/lib/geolocation/Geocoder.svelte
+++ b/packages/ui/src/lib/geolocation/Geocoder.svelte
@@ -1,0 +1,287 @@
+<script lang="ts" context="module">
+	type Timeout = ReturnType<typeof setTimeout>;
+
+	const newDebouncer = (func: () => void, delay: number) => {
+		let timerId: undefined | Timeout = undefined;
+
+		const restart = () => {
+			clearTimeout(timerId);
+			timerId = setTimeout(func, delay);
+		};
+
+		const clear = () => {
+			clearTimeout(timerId);
+		};
+
+		return [restart, clear];
+	};
+</script>
+
+<script lang="ts">
+	import { MagnifyingGlass, XMark } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+
+	import type { GeocoderAdapter } from './GeocoderAdapter';
+	import type {
+		GeolocationNamed, //
+		Geolocation,
+		GeolocationSearchError,
+		OnGeolocationSearchResult,
+		OnGeolocationSearchError,
+		OnSuggestionListInteraction
+	} from './types';
+
+	// adapter to source location suggestions from.
+	export let adapter: GeocoderAdapter;
+
+	// delay in ms after a key stroke to minimise redundant API requests.
+	export let delay = 250;
+
+	// onLocationSelected is called when a user clicks a location from the
+	// suggestions list.
+	export let onLocationSelected: undefined | OnGeolocationSearchResult;
+
+	// onSearchError is called when the adapter promise rejects a search request.
+	export let onSearchError: undefined | OnGeolocationSearchError;
+
+	// suggestions can be bound via 'bind:suggestions' to reactively receive
+	// changes to search results.
+	export let suggestions: GeolocationNamed[] = [];
+
+	// classes is a space separated list of additional classes applied to the
+	// root container.
+	export let classes = '';
+
+	// inputClasses is a space separated list of additional classes applied to
+	// the input element because laying input elements can be quite fiddly.
+	export let inputClasses = '';
+
+	// showClearButton forces the showing of the clear button at the end of the
+	// input element.
+	//
+	// It is set to false each time the user clicks the button so binding on this
+	// prop is useful.
+	export let showClearButton = false;
+
+	let container: HTMLElement;
+	let input: HTMLInputElement;
+	let query = '';
+	let showSuggestionList = false;
+
+	const updateSuggestionsNow = async () => {
+		if (!query || query.length < 3) {
+			suggestions = [];
+			showSuggestionList = false;
+			return;
+		}
+
+		try {
+			suggestions = await adapter
+				.search(query)
+				.then((res) => res || [])
+				.catch((err: unknown) => {
+					console.error('[Location Search] Search suggestions could not be retrieved.');
+					onSearchError && onSearchError(err as GeolocationSearchError);
+					return [];
+				});
+
+			showSuggestionList = !!$$slots.default;
+		} catch (e: unknown) {
+			console.error(e);
+			showSuggestionList = false;
+		}
+	};
+
+	const [scheduleUpdate, cancelUpdate] = newDebouncer(updateSuggestionsNow, delay);
+
+	const closeSuggestionsList = () => {
+		cancelUpdate();
+		showSuggestionList = false;
+	};
+
+	const onSelect = (suggestion: Geolocation) => {
+		closeSuggestionsList();
+		onLocationSelected && onLocationSelected(suggestion);
+	};
+
+	const onSuggestionEvent: OnSuggestionListInteraction = (
+		event: Event,
+		suggestion: GeolocationNamed
+	) => {
+		const pressEvent = event as KeyboardEvent;
+		const clickEvent = event as PointerEvent;
+
+		if (pressEvent.key === 'Enter' || clickEvent.type === 'click') {
+			closeSuggestionsList();
+			onLocationSelected && onLocationSelected(suggestion);
+			return;
+		}
+
+		if (pressEvent.key === 'Escape') {
+			closeSuggestionsList();
+			return;
+		}
+
+		if (pressEvent.key === 'ArrowDown') {
+			focusOnNextSuggestion(suggestion);
+			return;
+		}
+
+		if (pressEvent.key === 'ArrowUp') {
+			if (isFirstSuggestion(suggestion)) {
+				focusOnInput();
+				return;
+			}
+
+			focusOnPrevSuggestion(suggestion);
+		}
+	};
+
+	const findSuggestionIndex = (suggestion?: GeolocationNamed) => {
+		if (!suggestion || !suggestions) {
+			return -1;
+		}
+
+		for (let i = 0; i < suggestions.length; i++) {
+			if (suggestions[i].id === suggestion.id) {
+				return i;
+			}
+		}
+
+		return -1;
+	};
+
+	const isFirstSuggestion = (suggestion: GeolocationNamed) => {
+		return findSuggestionIndex(suggestion) === 0;
+	};
+
+	const focusOnPrevSuggestion = (suggestion: GeolocationNamed) => {
+		const i = findSuggestionIndex(suggestion);
+		if (i >= 0) {
+			const prev = i - 1 >= 0 ? suggestions[i - 1] : undefined;
+			focusOnLocation(prev);
+		}
+	};
+
+	const focusOnNextSuggestion = (suggestion: GeolocationNamed) => {
+		const i = findSuggestionIndex(suggestion);
+		if (i >= 0) {
+			const next = i + 1 < suggestions.length ? suggestions[i + 1] : undefined;
+			focusOnLocation(next);
+		}
+	};
+
+	const focusOnLocation = (suggestion?: GeolocationNamed) => {
+		if (!suggestion) {
+			return;
+		}
+
+		const elem = document.querySelector(`[data-geocoder-suggestion-id="${suggestion.id}"]`);
+		if (elem) {
+			(elem as HTMLElement).focus();
+		}
+	};
+
+	const focusOnInput = () => {
+		input.focus();
+		setTimeout(() => {
+			const end = input.value.length;
+			input.setSelectionRange(end, end);
+		}, 0);
+	};
+
+	const hideSuggestionList = (event: Event) => {
+		const target = event.target as HTMLElement;
+		if (!target || !container || !isElementOrChildOf(target, container)) {
+			closeSuggestionsList();
+		}
+	};
+
+	const isElementOrChildOf = (element: HTMLElement, parent: HTMLElement) => {
+		const positionBitmask = element.compareDocumentPosition(parent);
+		return !!(positionBitmask & Node.DOCUMENT_POSITION_CONTAINS);
+	};
+
+	const reshowSuggestionList = (event: Event) => {
+		if (suggestions) {
+			showSuggestionList = !!$$slots.default;
+		}
+
+		navigateSuggestionList(event);
+	};
+
+	const navigateSuggestionList = (event: Event) => {
+		if (!showSuggestionList || !suggestions || suggestions.length === 0) {
+			return;
+		}
+
+		const pressEvent = event as KeyboardEvent;
+
+		if (pressEvent.key === 'Enter') {
+			onSelect(suggestions[0]);
+			return;
+		}
+
+		if (pressEvent.key === 'Escape') {
+			closeSuggestionsList();
+			return;
+		}
+
+		if (pressEvent.key === 'ArrowDown') {
+			focusOnLocation(suggestions[0]);
+		}
+	};
+
+	const clearSearch = () => {
+		showClearButton = false;
+		query = '';
+		suggestions = [];
+		showSuggestionList = false;
+	};
+
+	$: {
+		query;
+		scheduleUpdate();
+	}
+</script>
+
+<svelte:window on:mousedown={hideSuggestionList} on:keyup={hideSuggestionList} />
+
+<search
+	bind:this={container}
+	class="bg-core-grey-600 pointer-events-auto relative w-full h-10 flex {classes}"
+>
+	<div class="absolute top-0 left-0 flex items-center justify-center">
+		<Icon src={MagnifyingGlass} class="w-10 h-10 py-1 p-2 stroke-white" />
+	</div>
+
+	<input
+		bind:this={input}
+		type="search"
+		placeholder="Location search"
+		class="min-w-0 w-64 max-w-[100%] pl-10 grow shrink bg-core-grey-600 border-core-grey-600 placeholder-core-grey-300 h-full text-white {inputClasses}"
+		class:pr-8={showClearButton}
+		bind:value={query}
+		on:focus={reshowSuggestionList}
+		on:click={reshowSuggestionList}
+		on:keyup={reshowSuggestionList}
+	/>
+
+	{#if showClearButton || query?.length > 0}
+		<button
+			on:click={clearSearch}
+			class="absolute top-0 right-0 flex items-center justify-center"
+			title="Clear search and marker"
+		>
+			<Icon src={XMark} class="w-10 h-10 py-1 pl-2 pr-1 stroke-white" />
+		</button>
+	{/if}
+
+	{#if showSuggestionList && suggestions}
+		<slot
+			attribution={adapter?.attribution ? adapter.attribution() : undefined}
+			{suggestions}
+			{onSuggestionEvent}
+		/>
+	{/if}
+</search>

--- a/packages/ui/src/lib/geolocation/GeocoderAdapter.ts
+++ b/packages/ui/src/lib/geolocation/GeocoderAdapter.ts
@@ -1,0 +1,44 @@
+import type { GeolocationNamed } from './types';
+
+// GeocoderAttribution specifies the attribution text and optional link
+// returned by an adapter.
+export interface GeocoderAttribution {
+	// text such as the company or individual name.
+	text: string;
+
+	// link URL to the data source. If this is unknown then link to the company
+	// or individual providing the service.
+	link?: string;
+}
+
+// GeocoderAdapter is used to separate the MapControlGeocoder from the location
+// lookup requests so search methods can easily be swapped out during
+// development or runtime.
+//
+// The simple design allows for bespoke adapters to be developed easily.
+// E.g. an application may require location searching within a non-standard
+// API or where non-standard filtering is needed.
+//
+// If an adapter encounters an error that means it can't return any results it
+// must reject (possible via throw) with a type compatible with
+// OnGeolocationSearchError.
+export interface GeocoderAdapter {
+	// search returns a promise for a list of search results.
+	//
+	// You do not need to implement delay or debounce as the MapControlGeocoder
+	// handles that. Furthermore, search requests are only made if a user's
+	// query contains at least three characters.
+	//
+	// Except for the above constraints, every change to the search input box
+	// will trigger a search request. It is up to individual adapters to apply
+	// any caching or search optimisation.
+	search: (query: string) => Promise<GeolocationNamed[]>;
+
+	// attribution returns an object containing two strings acknowledging the
+	// authors or owners of the location data or hosting service and an optional
+	// link.
+	//
+	// This function is optional and should not be imlemented if attribution is
+	// not needed. Alternatively, returning undefined will also omit attribution.
+	attribution?: () => undefined | GeocoderAttribution;
+}

--- a/packages/ui/src/lib/geolocation/GeocoderAdapterList.ts
+++ b/packages/ui/src/lib/geolocation/GeocoderAdapterList.ts
@@ -1,0 +1,54 @@
+import type { GeolocationNamed } from './types';
+import type { GeocoderAdapter, GeocoderAttribution } from './GeocoderAdapter';
+
+// GeocoderAdapterList is constructed with an array of GeolocationNamed which
+// is searched using name and address.
+//
+// It is very simple being intended for prototyping and demonstration. However,
+// it does make good boilerplate for new adapters.
+export class GeocoderAdapterList implements GeocoderAdapter {
+	private _locations: GeolocationNamed[];
+	private _attribution: undefined | GeocoderAttribution;
+
+	constructor(locations: GeolocationNamed[] = []) {
+		this._locations = locations;
+		this._attribution = undefined;
+	}
+
+	// GeocoderAdapter functions.
+
+	search(searchText: string) {
+		const result = this._locations //
+			.filter((op) => containsQuery(op, searchText));
+		return Promise.resolve(result);
+	}
+
+	attribution() {
+		return this._attribution;
+	}
+
+	// GeocoderAdapterList functions.
+
+	locations(): GeolocationNamed[] {
+		return this._locations;
+	}
+
+	setLocations(locations: GeolocationNamed[]): GeocoderAdapterList {
+		this._locations = locations;
+		return this;
+	}
+
+	setAttribution(attribution: GeocoderAttribution): GeocoderAdapterList {
+		this._attribution = attribution;
+		return this;
+	}
+}
+
+const containsQuery = (location: GeolocationNamed, searchText: string): boolean => {
+	let haystack = location.name ? location.name : '';
+	haystack += ' ';
+	haystack += location.address ? location.address : '';
+	haystack = haystack.trim().toLowerCase();
+
+	return haystack.toLowerCase().includes(searchText.toLowerCase());
+};

--- a/packages/ui/src/lib/geolocation/GeocoderAdapterOSPlaces.ts
+++ b/packages/ui/src/lib/geolocation/GeocoderAdapterOSPlaces.ts
@@ -1,0 +1,240 @@
+import type { GeolocationNamed } from './types';
+import type { GeocoderAdapter } from './GeocoderAdapter';
+
+// LocalCustodianCode represents a mapping between a custodian code and its
+// readable label.
+export interface LocalCustodianCode {
+	label: string;
+	code: number;
+}
+
+// OS_LONDON_LOCAL_CUSTODIAN_CODES is an array of AddressBase custodian codes mapped to
+// their "borough" name (label).
+export const OS_LONDON_LOCAL_CUSTODIAN_CODES: LocalCustodianCode[] = [
+	{
+		label: 'CITY OF LONDON',
+		code: 5030
+	},
+	{
+		label: 'BARKING AND DAGENHAM',
+		code: 5060
+	},
+	{
+		label: 'BARNET',
+		code: 5090
+	},
+	{
+		label: 'BEXLEY',
+		code: 5120
+	},
+	{
+		label: 'BRENT',
+		code: 5150
+	},
+	{
+		label: 'LONDON BOROUGH OF BROMLEY',
+		code: 5180
+	},
+	{
+		label: 'CAMDEN',
+		code: 5210
+	},
+	{
+		label: 'CROYDON',
+		code: 5240
+	},
+	{
+		label: 'EALING',
+		code: 5270
+	},
+	{
+		label: 'ENFIELD',
+		code: 5300
+	},
+	{
+		label: 'GREENWICH',
+		code: 5330
+	},
+	{
+		label: 'HACKNEY',
+		code: 5360
+	},
+	{
+		label: 'HAMMERSMITH AND FULHAM',
+		code: 5390
+	},
+	{
+		label: 'LONDON BOROUGH OF HARINGEY',
+		code: 5420
+	},
+	{
+		label: 'HARROW',
+		code: 5450
+	},
+	{
+		label: 'HAVERING',
+		code: 5480
+	},
+	{
+		label: 'HILLINGDO',
+		code: 5510
+	},
+	{
+		label: 'LONDON BOROUGH OF HOUNSLOW',
+		code: 5540
+	},
+	{
+		label: 'ISLINGTON',
+		code: 5570
+	},
+	{
+		label: 'KENSINGTON AND CHELSEA',
+		code: 5600
+	},
+	{
+		label: 'KINGSTON UPO',
+		code: 5630
+	},
+	{
+		label: 'LAMBETH',
+		code: 5660
+	},
+	{
+		label: 'LEWISHAM',
+		code: 5690
+	},
+	{
+		label: 'MERTON',
+		code: 5720
+	},
+	{
+		label: 'NEWHAM',
+		code: 5750
+	},
+	{
+		label: 'REDBRIDGE',
+		code: 5780
+	},
+	{
+		label: 'RICHMOND UPON THAMES',
+		code: 5810
+	},
+	{
+		label: 'SOUTHWARK',
+		code: 5840
+	},
+	{
+		label: 'SUTTON',
+		code: 5870
+	},
+	{
+		label: 'TOWER HAMLETS',
+		code: 5900
+	},
+	{
+		label: 'WALTHAM FOREST',
+		code: 5930
+	},
+	{
+		label: 'WANDSWORTH',
+		code: 5960
+	},
+	{
+		label: 'CITY OF WESTMINSTER',
+		code: 5990
+	}
+];
+
+interface DPAFeature {
+	UPRN: string;
+	ADDRESS: string;
+	CENTER: [number, number];
+	LNG: number;
+	LAT: number;
+	[otherOptions: string]: unknown;
+}
+
+interface OSPlacesResult {
+	DPA: DPAFeature;
+}
+
+interface OSPlaces {
+	results: OSPlacesResult[];
+	[otherOptions: string]: unknown;
+}
+
+// GeocoderAdapterOSPlaces provides address searching within a specified
+// borough using the OS places API.
+//
+// Usage requires passing an API key and a LOCAL_CUSTODIAN_CODE which
+// represents the borough or borough sized geographical area.
+//
+// Unfortunately, OS Places does not provide a way to query the whole of
+// Greater London. Per request you can query the UK or a borough but not a
+// geographical area in between (AFAIK).
+export class GeocoderAdapterOSPlaces implements GeocoderAdapter {
+	private _key: string = '';
+	private _lcc: number = -1;
+	private _resultCount: number = 5;
+
+	constructor(key: string, localCustodianCode: number, resultCount = 5) {
+		this._key = key;
+		this._lcc = localCustodianCode;
+		this._resultCount = resultCount;
+	}
+
+	// GeocoderAdapter functions.
+
+	search(text: string) {
+		const url = buildUrl(text, this._key, this._lcc, this._resultCount);
+		return fetch(url)
+			.then((res) => res.json())
+			.then(transformResultsToGeolocationNameds);
+	}
+
+	attribution() {
+		return {
+			text: 'OS Places',
+			link: 'https://osdatahub.os.uk/docs/places/overview'
+		};
+	}
+
+	// GeocoderAdapterOSPlaces functions.
+
+	setLocalCustodianCode(_lcc: number): GeocoderAdapterOSPlaces {
+		this._lcc = _lcc;
+		return this;
+	}
+
+	setResultCount(resultCount: number): GeocoderAdapterOSPlaces {
+		this._resultCount = resultCount;
+		return this;
+	}
+}
+
+const buildUrl = (text: string, key: string, lcc: number, resultCount: number): string => {
+	const queryString = new URLSearchParams({
+		query: encodeURIComponent(text),
+		key: key,
+		output_srs: 'WGS84',
+		format: 'JSON',
+		maxresults: resultCount.toString(),
+		fq: `LOCAL_CUSTODIAN_CODE:${lcc}`
+	});
+
+	return `https://api.os.uk/search/places/v1/find?${queryString}`;
+};
+
+const transformResultsToGeolocationNameds = (data: OSPlaces): GeolocationNamed[] => {
+	if (!data.results) {
+		return [];
+	}
+
+	return data.results.map((loc) => ({
+		id: loc.DPA.UPRN,
+		address: loc.DPA.ADDRESS,
+		center: [loc.DPA.LNG, loc.DPA.LAT]
+	}));
+};
+
+export default GeocoderAdapterOSPlaces;

--- a/packages/ui/src/lib/geolocation/GeocoderSuggestion.svelte
+++ b/packages/ui/src/lib/geolocation/GeocoderSuggestion.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import type { GeolocationNamed, OnSuggestionListInteraction } from './types';
+
+	export let suggestion: GeolocationNamed;
+	export let onSuggestionEvent: OnSuggestionListInteraction;
+	export let highlighted: null | GeolocationNamed;
+
+	const navigateList = (event: Event) => {
+		onSuggestionEvent(event, suggestion);
+	};
+
+	const highlight = () => {
+		highlighted = suggestion;
+	};
+</script>
+
+<li>
+	<div
+		role="button"
+		class="w-full px-2.5 py-1.5 cursor-pointer"
+		on:click|self={navigateList}
+		on:keydown={navigateList}
+		on:mouseenter={highlight}
+		on:focus={highlight}
+		class:bg-core-blue-600={highlighted === suggestion}
+		tabindex="0"
+		data-geocoder-suggestion-id={suggestion.id}
+	>
+		{#if suggestion.name}
+			<h1 class="underline pointer-events-none mb-1">{suggestion.name}</h1>
+		{/if}
+		{#if suggestion.address}
+			<p class="pointer-events-none leading-4">{suggestion.address}</p>
+		{/if}
+	</div>
+</li>

--- a/packages/ui/src/lib/geolocation/GeocoderSuggestionList.svelte
+++ b/packages/ui/src/lib/geolocation/GeocoderSuggestionList.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import GeocoderSuggestion from './GeocoderSuggestion.svelte';
+	import type { GeocoderAttribution } from './GeocoderAdapter';
+	import type { GeolocationNamed, OnSuggestionListInteraction } from './types';
+
+	export let attribution: undefined | GeocoderAttribution = undefined;
+
+	// suggestions is an array of named geolocations. The suggestions will be
+	// presented in order and limited by maxSuggestions.
+	export let suggestions: GeolocationNamed[];
+
+	// maxSuggestions is the maximum number of suggestion to show. This does
+	// not limit the results array.
+	export let maxSuggestions: number = 5;
+
+	// onSuggestionEvent is invoked when a keyboard, mouse, or touch
+	// event occurs in the suggestion list, except when a suggestion is selected.
+	export let onSuggestionEvent: OnSuggestionListInteraction;
+
+	// Mouse highlight only
+	let highlighted: null | GeolocationNamed = null;
+
+	const highlightFirstSuggestion = (suggestions: GeolocationNamed[]) => {
+		highlighted = suggestions.length > 0 ? suggestions[0] : null;
+	};
+
+	$: highlightFirstSuggestion(suggestions);
+</script>
+
+<ul class="absolute top-10 left-0 bg-core-grey-600 text-white text-sm w-full">
+	{#if suggestions.length === 0}
+		<li class="w-full px-2.5 py-1.5">
+			<h1 class="pointer-events-none">No locations found</h1>
+		</li>
+	{:else}
+		{#each suggestions as suggestion, i (suggestion.id)}
+			{#if i < maxSuggestions}
+				<GeocoderSuggestion {suggestion} {onSuggestionEvent} bind:highlighted />
+			{/if}
+		{/each}
+	{/if}
+
+	{#if attribution && attribution.text}
+		<li class="w-full px-2.5 py-1.5 text-right text-core-grey-300">
+			{#if attribution.link}
+				<a href={attribution.link} target="_blank" rel="noopener" class="text-core-blue-500">
+					{attribution.text}
+				</a>
+			{:else}
+				{attribution.text}
+			{/if}
+		</li>
+	{/if}
+</ul>

--- a/packages/ui/src/lib/geolocation/Geolocator.svelte
+++ b/packages/ui/src/lib/geolocation/Geolocator.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Button, Spinner } from '@ldn-viz/ui';
+	import { XMark } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import TargetIcon from './TargetIcon.svelte';
+
+	import type {
+		GeolocationCoords,
+		OnGeolocationSearchResult,
+		OnGeolocationSearchError
+	} from './types';
+
+	export let onLocationFound: OnGeolocationSearchResult | undefined;
+	export let onSearchError: OnGeolocationSearchError | undefined;
+	export let showClearButton = false;
+
+	let searchPermitted = false;
+	let allowsPermPrompt = false;
+	let isSearching = false;
+
+	const isGeolocatorAvailable = () => {
+		return 'geolocation' in navigator;
+	};
+
+	const updatePermission = (state: string) => {
+		searchPermitted = state === 'granted';
+		allowsPermPrompt = state === 'prompt';
+	};
+
+	const handleClick = () => {
+		if (!isGeolocatorAvailable() || (!searchPermitted && !allowsPermPrompt)) {
+			return;
+		}
+
+		if (showClearButton) {
+			showClearButton = false;
+			return;
+		}
+
+		startSearch();
+	};
+
+	const startSearch = () => {
+		isSearching = true;
+		doSearch();
+	};
+
+	const doSearch = () => {
+		navigator.geolocation.getCurrentPosition(
+			apiFoundLocation, //
+			apiNotFoundLocation
+		);
+	};
+
+	const apiFoundLocation = (result: GeolocationPosition) => {
+		// https://developer.mozilla.org/en-US/docs/Web/API/GeolocationCoordinates
+		isSearching = false;
+		showClearButton = true;
+
+		const coords: null | GeolocationCoords = extractCoords(result);
+		if (!coords) {
+			return;
+		}
+
+		if (onLocationFound) {
+			onLocationFound({ center: coords });
+		}
+	};
+
+	const apiNotFoundLocation = (err: GeolocationPositionError) => {
+		// https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError
+		isSearching = false;
+
+		if (err.code === err.PERMISSION_DENIED) {
+			logError("Insufficient permissions to access user's location.");
+			if (navigator.userAgent.includes('Firefox/')) {
+				updatePermission('denied');
+			}
+		} else if (err.code === err.TIMEOUT) {
+			logError('User location search timed out.');
+		} else {
+			logError('User location unavailable.');
+		}
+
+		if (onSearchError) {
+			onSearchError(err);
+		}
+	};
+
+	const logError = (...msg: string[]) => {
+		console.error(`[Geolocator]`, ...msg);
+	};
+
+	const extractCoords = (result: GeolocationPosition): null | GeolocationCoords => {
+		const lng = result?.coords?.longitude;
+		const lat = result?.coords?.latitude;
+
+		if (!isValidCoords(lng, lat)) {
+			logError(
+				'Invalid location provided by browser', //
+				JSON.stringify(result, null, 2)
+			);
+			return null;
+		}
+
+		return [lng, lat];
+	};
+
+	const isValidCoords = (lng: number, lat: number): boolean => {
+		// 0,0 is a valid coordinate (null island)
+		// But, actually, it's not because maps are limited to Greater London area!
+		// But there might be a case for no limit so better safe than sorry.
+		return (!!lng || lng === 0) && (!!lat || lat === 0);
+	};
+
+	onMount(() => {
+		navigator.permissions //
+			.query({ name: 'geolocation' }) //
+			.then((perm) => {
+				updatePermission(perm.state);
+
+				// Works in Chromium (Chrome, Edge, Vivaldi, etc) but not Firefox.
+				// No reliable workaround found for Firefox yet.
+				perm.onchange = () => updatePermission(perm.state);
+			});
+	});
+</script>
+
+<div class="pointer-events-auto w-10 h-10">
+	{#if !searchPermitted && !allowsPermPrompt}
+		<div class="!bg-core-grey-800 w-10 h-10 p-1">
+			<TargetIcon
+				disabled
+				class="w-8 h-8 p-0.5 stroke-core-grey-400"
+				title="Please enable browser geolocation permissions"
+			/>
+		</div>
+	{:else if isSearching}
+		<div class="!bg-core-grey-800 w-10 h-10 p-1">
+			<Spinner
+				title="Searching for location..."
+				alt="Spinning wheel indicating that location search is in progress"
+				class="w-8 h-8 p-0.5 stroke-[12]"
+			/>
+		</div>
+	{:else if showClearButton}
+		<Button
+			variant="square"
+			emphasis="secondary"
+			title="Clear location marker"
+			role="search"
+			aria-label="Clear location"
+			class="!bg-core-grey-800"
+			on:click={handleClick}
+		>
+			<Icon src={XMark} class="w-8 h-8 p-0.5 stroke-white" />
+		</Button>
+	{:else}
+		<Button
+			variant="square"
+			emphasis="secondary"
+			title="Find my location"
+			role="search"
+			aria-label="Find my location"
+			class="!bg-core-grey-800"
+			on:click={handleClick}
+		>
+			<TargetIcon class="w-8 h-8 p-0.5 stroke-white" />
+		</Button>
+	{/if}
+</div>

--- a/packages/ui/src/lib/geolocation/TargetIcon.svelte
+++ b/packages/ui/src/lib/geolocation/TargetIcon.svelte
@@ -1,0 +1,21 @@
+<script>
+	export let title = '';
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	aria-hidden="true"
+	stroke-width="1.5"
+	stroke="currentColor"
+	fill="none"
+	{...$$props}
+>
+	<title>{title}</title>
+	<circle cx="12" cy="12" r="3.5" />
+	<circle cx="12" cy="12" r="8" />
+	<line x1="12" y1="4" x2="12" y2="0" />
+	<line x1="20" y1="12" x2="24" y2="12" />
+	<line x1="12" y1="20" x2="12" y2="24" />
+	<line x1="4" y1="12" x2="0" y2="12" />
+</svg>

--- a/packages/ui/src/lib/geolocation/types.ts
+++ b/packages/ui/src/lib/geolocation/types.ts
@@ -1,0 +1,45 @@
+export type GeolocationCoords = [lng: number, lat: number];
+
+export type GeolocationBounds = [minLng: number, minLat: number, maxLng: number, maxLat: number];
+
+// GeolocationUnamed represents a geographical location with a center point
+// and possible bounding box.
+export interface GeolocationUnamed {
+	center: GeolocationCoords;
+	bounds?: GeolocationBounds;
+}
+
+// GeolocationNamed represents a named and possible addressed location. Named
+// locations must be unique within a collection.
+export interface GeolocationNamed extends GeolocationUnamed {
+	id: string;
+
+	// name is the short human-readable name of the location presented to the
+	// user.
+	name?: string;
+
+	// address in the human-readable address presented to the user.
+	address?: string;
+
+	// otherProps allows adapters to store or pass adapter specific information.
+	[otherProps: string]: unknown;
+}
+
+// Geolocation represents either a named or unamed location.
+export type Geolocation = GeolocationUnamed | GeolocationNamed;
+
+// GeolocationSearchError represents an error thrown by a geolocation or
+// or geolocator search.
+export type GeolocationSearchError = Error | GeolocationPositionError;
+
+// OnGeolocationSearchResult is invoked when a Geocoder or Geolocator
+// finds a result or a suggested result is selected by the user.
+export type OnGeolocationSearchResult = (loc: Geolocation) => void;
+
+// OnGeolocationSearchError is invoked when an adapter promise rejects a
+// search request.
+export type OnGeolocationSearchError = (err: GeolocationSearchError) => void;
+
+// OnSuggestionListInteraction is invoked when a keyboard, mouse, or touch
+// event occurs in the suggestion list, except when a suggestion is selected.
+export type OnSuggestionListInteraction = (event: Event, geolocation: GeolocationNamed) => void;

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -57,4 +57,13 @@ export { default as Toaster } from './toaster/Toaster.svelte';
 export * from './toaster/toaster';
 export * from './toaster/types';
 
+export * from './geolocation/types';
+export * from './geolocation/GeocoderAdapter';
+export * from './geolocation/GeocoderAdapterList';
+export * from './geolocation/GeocoderAdapterList';
+export * from './geolocation/GeocoderAdapterOSPlaces';
+export { default as Geocoder } from './geolocation/Geocoder.svelte';
+export { default as Geolocator } from './geolocation/Geolocator.svelte';
+export { default as GeocoderSuggestionList } from './geolocation/GeocoderSuggestionList.svelte';
+
 export { classNames } from './utils/classNames';


### PR DESCRIPTION
**What does this change?**
The appshell relies on an innerwidth calculation to position the sidebar, this transitions in the sidebar to display only after innerwidth is not 0 - therefore avoiding 'loading jank'

**Why?**
better ui experience

**How?**
waits for the variable to be dynamically set on initial page load and the transitions in the sidebar

**Related issues**:
#283 

**Does this introduce new dependencies?**
no

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
n/a

**Is it complete?**
y

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
