### PR TITLE
fix storybook controls so that they update component in default stories

### DIFF
--- a/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.stories.svelte
+++ b/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.stories.svelte
@@ -16,10 +16,19 @@
 <Meta title="Ui/ImageDownloadButton" component={ImageDownloadButton} />
 
 <Template let:args>
-	<ImageDownloadButton {...args}>I'm an image download button!</ImageDownloadButton>
+	<svg bind:this={svgRef} width="100" height="100">
+		<rect x="0" y="0" width="100" height="100" fill="red" />
+		<circle cx="10" cy="10" r="10" fill="blue" />
+	</svg>
+
+	<ImageDownloadButton {...args} svgNode={svgRef}>
+		I'm an image download button!
+	</ImageDownloadButton>
 </Template>
 
-<Story name="Default">
+<Story name="Default" source />
+
+<Story name="Default - with image">
 	<svg bind:this={svgRef} width="100" height="100">
 		<rect x="0" y="0" width="100" height="100" fill="red" />
 		<circle cx="10" cy="10" r="10" fill="blue" />

--- a/packages/ui/src/lib/input/Input.stories.svelte
+++ b/packages/ui/src/lib/input/Input.stories.svelte
@@ -1,16 +1,17 @@
 <script>
-	import { Meta, Story } from '@storybook/addon-svelte-csf';
-
+	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 	import Input from './Input.svelte';
 </script>
 
 <Meta title="Ui/Input" component={Input} />
 
-<Story name="Default">
+<Template let:args>
 	<div class="w-96">
-		<Input id="default" />
+		<Input {...args} />
 	</div>
-</Story>
+</Template>
+
+<Story name="Default" source />
 
 <Story name="With Label">
 	<div class="w-96">

--- a/packages/ui/src/lib/modal/Modal.stories.svelte
+++ b/packages/ui/src/lib/modal/Modal.stories.svelte
@@ -25,8 +25,12 @@
 </script>
 
 <Template let:args>
-	<Modal {...args}>This content is the child of the modal!</Modal>
+	<Button on:click={() => ($isOpen = true)}>Open modal!</Button>
+
+	<Modal bind:isOpen {...args}></Modal>
 </Template>
+
+<Story name="Default" source />
 
 <Story name="Description only">
 	<Button on:click={() => ($isOpen = true)}>Open modal!</Button>

--- a/packages/ui/src/lib/nonIdealState/NonIdealState.stories.svelte
+++ b/packages/ui/src/lib/nonIdealState/NonIdealState.stories.svelte
@@ -2,18 +2,20 @@
 	import { QuestionMarkCircle } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
 
-	import { Meta, Story } from '@storybook/addon-svelte-csf';
+	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 
 	import NonIdealState from './NonIdealState.svelte';
 </script>
 
 <Meta title="Ui/NonIdealState" component={NonIdealState} />
 
-<Story name="Default">
+<Template let:args>
 	<div class="w-96 h-96">
-		<NonIdealState>The server did not respond.</NonIdealState>
+		<NonIdealState {...args}>The server did not respond.</NonIdealState>
 	</div>
-</Story>
+</Template>
+
+<Story name="Default" source />
 
 <Story name="Custom title">
 	<div class="w-96 h-96">

--- a/packages/ui/src/lib/placardButton/PlacardButton.stories.svelte
+++ b/packages/ui/src/lib/placardButton/PlacardButton.stories.svelte
@@ -2,12 +2,27 @@
 	import { DocumentArrowDown } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
 
-	import { Meta, Story } from '@storybook/addon-svelte-csf';
+	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 
 	import PlacardButton from './PlacardButton.svelte';
 </script>
 
 <Meta title="Ui/PlacardButton" component={PlacardButton} />
+
+<Template let:args>
+	<div class="max-w-xl">
+		<PlacardButton {...args}>
+			<span slot="body">
+				The full dataset that this explorer is based on is available for download from the London
+				Datastore, along with other documents like the Technical Report, which contains the
+				questionnaires from the survey.
+			</span>
+			<span slot="footer">The Survey of Londoners on London Datastore</span>
+		</PlacardButton>
+	</div>
+</Template>
+
+<Story name="Default" source />
 
 <Story name="With Body Only">
 	<div class="max-w-xl">

--- a/packages/ui/src/lib/spinners/Spinner.stories.svelte
+++ b/packages/ui/src/lib/spinners/Spinner.stories.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { Meta, Story } from '@storybook/addon-svelte-csf';
+	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 
 	import Spinner from './Spinner.svelte';
 	import Button from '../button/Button.svelte';
@@ -7,11 +7,13 @@
 
 <Meta title="Ui/Spinners" component={Spinner} />
 
-<Story name="Default">
+<Template let:args>
 	<div class="text-core-grey-800">
-		<Spinner class="w-40" />
+		<Spinner class="w-40" {...args} />
 	</div>
-</Story>
+</Template>
+
+<Story name="Default" source />
 
 <Story name="Thickness">
 	<div class="text-core-grey-800">

--- a/packages/ui/src/lib/tabs/Tabs.stories.svelte
+++ b/packages/ui/src/lib/tabs/Tabs.stories.svelte
@@ -3,7 +3,14 @@
 
 	export const meta = {
 		title: 'Ui/Tabs',
-		component: TabList
+		component: TabList,
+
+		argTypes: {
+			orientation: {
+				options: ['horizontal', 'vertical'],
+				control: { type: 'radio' }
+			}
+		}
 	};
 </script>
 

--- a/packages/ui/src/lib/tabs/Tabs.stories.svelte
+++ b/packages/ui/src/lib/tabs/Tabs.stories.svelte
@@ -22,20 +22,13 @@
 		<TabLabel tabId="averages">Averages of charge events</TabLabel>
 		<TabLabel tabId="histograms">Histograms of charge events</TabLabel>
 	</TabList>
-</Template>
-
-<Story name="Default">
-	<TabList bind:selectedValue>
-		<TabLabel tabId="aggregates">Aggregated counts across London</TabLabel>
-		<TabLabel tabId="chargers">Details of chargers</TabLabel>
-		<TabLabel tabId="averages">Averages of charge events</TabLabel>
-		<TabLabel tabId="histograms">Histograms of charge events</TabLabel>
-	</TabList>
 
 	<div class="text-black dark:text-white p-4">
 		<p>Selected value is: <code>{selectedValue}</code></p>
 	</div>
-</Story>
+</Template>
+
+<Story name="Default" source />
 
 <Story name="Vertical">
 	<div class="flex">

--- a/packages/ui/src/lib/tooltip/Tooltip.stories.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.stories.svelte
@@ -26,9 +26,7 @@
 	<Tooltip {...args}>This is some text</Tooltip>
 </Template>
 
-<Story name="Default">
-	<Tooltip>This is some text</Tooltip>
-</Story>
+<Story name="Default" source />
 
 <Story name="Hint Size">
 	<Tooltip hintSize="sm">This is some text</Tooltip>


### PR DESCRIPTION
This fixes storybook controls so that they update the components in defult stories.

For the controls to work, the default `<Story>` tag must be empty - it's contents should instead be set in the `<Template>`.