### PR TITLE
Increase text size on tooltips

### DIFF
--- a/.changeset/ghjghj_sdf_gfhio.md
+++ b/.changeset/ghjghj_sdf_gfhio.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+Increase Tooltip component text size for accessibility.

--- a/.changeset/ghjghj_sdf_gfhio.md
+++ b/.changeset/ghjghj_sdf_gfhio.md
@@ -2,4 +2,4 @@
 '@ldn-viz/ui': minor
 ---
 
-Increase Tooltip component text size for accessibility.
+CHANGED: Increase Tooltip component text size for accessibility.

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -70,7 +70,7 @@
 
 {#if showTooltip}
 	<div
-		class="absolute max-w-[200px] text-xs p-2 bg-core-grey-100 text-core-grey-700 dark:bg-core-grey-700 dark:text-core-grey-50 shadow-md z-50"
+		class="absolute max-w-[200px] text-sm p-2 bg-core-grey-100 text-core-grey-700 dark:bg-core-grey-700 dark:text-core-grey-50 shadow-md z-50"
 		use:floatingContent={dynamicOptions}
 	>
 		<slot />


### PR DESCRIPTION
**What does this change?**

Increases text size to `text-sm` for tooltip popup content.

**Why?**

Because current size is too small. Project clients requested it be increased for accessibility.

**How is it documented?**

Stories.

**Is it complete?**

- [x] Have you included changeset file?
