### PR TITLE
Remove `hasError` prop from `Select`

### DIFF
--- a/.changeset/dscsdf_dda_swwd.md
+++ b/.changeset/dscsdf_dda_swwd.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': major
+---
+
+CHANGED: removed `hasError` prop from `Select` component

--- a/packages/ui/src/lib/select/Select.svelte
+++ b/packages/ui/src/lib/select/Select.svelte
@@ -29,7 +29,6 @@
 	export let itemId = 'value';
 	export let loadOptions: any = undefined;
 	export let containerStyles = '';
-	export let hasError = error;
 	export let filterSelectedItems = true;
 	export let required = false;
 	export let closeListOnChange = true;
@@ -96,7 +95,7 @@
 			{itemId}
 			{loadOptions}
 			{containerStyles}
-			{hasError}
+			hasError={error}
 			{filterSelectedItems}
 			{required}
 			{closeListOnChange}


### PR DESCRIPTION
This modifies `Select` so that it only has an `error` prop (rather than an `error` and `hasError` props)

This should address https://github.com/Greater-London-Authority/ldn-viz-tools/issues/295

@PaulioRandall, I don't know whether this touches on your planned changes to the `Select`