### PR TITLE
Align text and icon in tooltip trigger

### DIFF
--- a/.changeset/fosff-ndsf-dad.md
+++ b/.changeset/fosff-ndsf-dad.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: changed alignment of help icon in `Tooltip` trigger

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -51,7 +51,7 @@
 		}}
 		on:mouseleave|stopPropagation={() => (showTooltip = false)}
 		role="tooltip"
-		class="inline-flex"
+		class="inline-flex items-center"
 	>
 		{#if $$slots.hint}
 			<slot name="hint" />


### PR DESCRIPTION
This changes the alignment of the icon in the trigger of the `<Tooltip>` component.

Before:

![image](https://github.com/Greater-London-Authority/ldn-viz-tools/assets/338833/690a5105-eeab-4d22-8b41-e427595a2f95)


After:

![image](https://github.com/Greater-London-Authority/ldn-viz-tools/assets/338833/dd58fba0-2a2c-4655-8fa8-51c28e03be0e)
