### PR TITLE
Adds PageMetadata component

### DIFF
--- a/.changeset/mmm_nnn_bbb.md
+++ b/.changeset/mmm_nnn_bbb.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+ADD: PageMetadata component providing OpenGraph and other head tag info.

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -66,4 +66,6 @@ export { default as Geocoder } from './geolocation/Geocoder.svelte';
 export { default as Geolocator } from './geolocation/Geolocator.svelte';
 export { default as GeocoderSuggestionList } from './geolocation/GeocoderSuggestionList.svelte';
 
+export { default as PageMetadata } from './pageMetadata/PageMetadata.svelte';
+
 export { classNames } from './utils/classNames';

--- a/packages/ui/src/lib/pageMetadata/PageMetadata.stories.svelte
+++ b/packages/ui/src/lib/pageMetadata/PageMetadata.stories.svelte
@@ -1,0 +1,28 @@
+<script context="module">
+	import PageMetadata from './PageMetadata.svelte';
+
+	export const meta = {
+		title: 'Ui/PageMetadata',
+		component: PageMetadata
+	};
+</script>
+
+<script>
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+</script>
+
+<Template let:args>
+	<div class="max-w-xl">
+		<PageMetadata {...args} />
+	</div>
+</Template>
+
+<Story
+	name="Default"
+	source
+	args={{
+		title: 'An interesting map',
+		url: 'https://london.gov.uk/an-interesting-map',
+		description: 'This map is quite interesting.'
+	}}
+/>

--- a/packages/ui/src/lib/pageMetadata/PageMetadata.svelte
+++ b/packages/ui/src/lib/pageMetadata/PageMetadata.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	export let title;
+	export let description;
+	export let url; // Must be full URL with scheme
+
+	if (!title || !description || !url) {
+		// Minimum requirement for SEO.
+		throw new Error('Metadata component is missing either a title, description, or full URL');
+	}
+
+	// By default, assumes there is a favicon.ico file in the static folder.
+	export let favicon = url.replace(/\/?$/, '/favicon.ico');
+
+	export let type = 'website'; // https://ogp.me/#types
+	export let site = 'GLA Intelligence and Analysis Unit';
+
+	export let image = undefined;
+	export let imageAlt = undefined;
+
+	// Image size should be as close to these dimensions as possible.
+	export let imageWidth = 1200;
+	export let imageHeight = 630;
+</script>
+
+<svelte:head>
+	<link rel="icon" href={favicon} />
+
+	<title>{title}</title>
+	<meta name="description" content={description} />
+
+	<!-- OpenGraph -->
+	<meta property="og:type" content={type} />
+	<meta property="og:url" content={url} />
+	<meta property="og:locale" content="en_GB" />
+	<meta property="og:site_name" content={site} />
+	<meta property="og:determiner" content="" />
+	<meta property="og:title" content={title} />
+	<meta property="og:description" content={description} />
+	<meta property="og:image" content={image} />
+	<meta property="og:image:alt" content={imageAlt} />
+	<meta property="og:image:width" content={imageWidth.toString()} />
+	<meta property="og:image:height" content={imageHeight.toString()} />
+
+	<!-- 𝕏 / Twitter -->
+	<meta property="twitter:card" content="summary" />
+	<meta property="twitter:url" content={url} />
+	<meta property="twitter:site" content={site} />
+	<meta property="twitter:title" content={title} />
+	<meta property="twitter:description" content={description} />
+	<meta property="twitter:image" content={image} />
+	<meta property="twitter:image:alt" content={imageAlt} />
+	<meta property="twitter:image:width" content={imageWidth.toString()} />
+	<meta property="twitter:image:height" content={imageHeight.toString()} />
+
+	<!-- Pinterest -->
+	<meta property="pin:media" content={image} />
+	<meta property="pin:url" content={url} />
+	<meta property="pin:description" content={description} />
+</svelte:head>

--- a/packages/ui/src/lib/pageMetadata/PageMetadata.svelte
+++ b/packages/ui/src/lib/pageMetadata/PageMetadata.svelte
@@ -1,6 +1,28 @@
 <script lang="ts">
+	/**
+	 * The `<PageMetadata>` component adds metadata (`<meta>`) tags to the `<head>` of the page.
+	 * These tags are used for indexing by search engines, and for constructing preview links on search engine results pages (e.g. Google, DuckDuckGo), social media platforms (e.g. X/Twitter, Facebook), and communication platforms (e.g. MS Teams, WhatsApp).
+	 *
+	 * The `title`, `description` and `url` are required - if any of them are missing, then the component will throw an `Error` that prevents the site from building.
+	 *
+	 * The definitions of properties below are taken from [https://ogp.me](https://ogp.me).
+	 *
+	 * @component
+	 */
+
+	/**
+	 * "The title of your object as it should appear within the graph, e.g., 'The Rock'."
+	 */
 	export let title;
+
+	/**
+	 * "A one to two sentence description of your object."
+	 */
 	export let description;
+
+	/**
+	 * "The canonical URL of your object that will be used as its permanent ID in the graph". Should include the scheme (`http://` or `https://`).
+	 */
 	export let url; // Must be full URL with scheme
 
 	if (!title || !description || !url) {
@@ -8,17 +30,40 @@
 		throw new Error('Metadata component is missing either a title, description, or full URL');
 	}
 
-	// By default, assumes there is a favicon.ico file in the static folder.
+	/**
+	 * URL of the favicon. By default, assumes there is a favicon.ico file in the static folder.
+	 */
 	export let favicon = url.replace(/\/?$/, '/favicon.ico');
 
-	export let type = 'website'; // https://ogp.me/#types
+	/**
+	 * The object type - see [this documentation](https://ogp.me/#types)
+	 */
+	export let type = 'website';
+
+	/**
+	 * "If your object is part of a larger web site, the name which should be displayed for the overall site"
+	 */
 	export let site = 'GLA Intelligence and Analysis Unit';
 
+	/**
+	 * "An image URL which should represent your object within the graph".
+	 * If an `image` is provided, then `imageAlt` should be too.
+	 */
 	export let image = undefined;
+
+	/**
+	 * "A description of what is in the image (not a caption)."
+	 */
 	export let imageAlt = undefined;
 
-	// Image size should be as close to these dimensions as possible.
+	/**
+	 * Image width in pixels. Recommended value is 1200.
+	 */
 	export let imageWidth = 1200;
+
+	/**
+	 * Image height in pixels. Recommended value is 630.
+	 */
 	export let imageHeight = 630;
 </script>
 


### PR DESCRIPTION
**What does this change?**

Adds a `<PageMetadata>` component that allows `<head>` tag information to be supplied on per-page basis. This includes but not limited to:
- title
- description
- custom favicon
- Open Graph properties

**Why?**

1. **Search Engine Optimization** (SEO): This information is used by search engines to index our digital services
2. **Preview links**: (OpenGraph) This information is used for preview links and text within search engine results (e.g. Google, DuckDuckGo, etc), social media platforms (e.g. X/Twitter, Facebook, etc), and communication platforms (e.g. MS Teams, WhatsApp, etc)

**How is it tested?**

In various services but has been used in the following apps for 3-6 months:
- https://apps.london.gov.uk/wild-and-free
- https://apps.london.gov.uk/voter-id

**How is it documented?**

In code. This component is not really documentable via Storybook since there is no UI element.

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
