### PR TITLE
Node mailer util

### DIFF
--- a/.changeset/yuy_iuiu_oioi.md
+++ b/.changeset/yuy_iuiu_oioi.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+ADD: Utility function for easy posting to node-mailer on apps.london.gov.uk.

--- a/packages/utils/src/mailer/mailer.ts
+++ b/packages/utils/src/mailer/mailer.ts
@@ -1,0 +1,42 @@
+export type PostMailOptions = {
+  // Optional email address of a cc recipient. If this is form data being
+  // entered by a user then it will likely be their email address so they
+  // recieve a notification email.
+  email?: string;
+};
+
+export type PostMail = (
+  // App name as defined in the node-mailer config.
+  app: string,
+  // Title used in the email subject line.
+  title: string,
+  // Message to use as the email body.
+  message: string | object,
+  // Additional options.
+  options: PostMailOptions
+) => Promise<undefined>;
+
+export const postMail: PostMail = (app, title, message, options = {}) => {
+  const { email = 'noreply@london.gov.uk' } = options;
+
+  const data = {
+    correspondent: email,
+    app,
+    title,
+    message
+  };
+
+  return fetch('https://apps.london.gov.uk/node-mailer/mail/send', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  })
+    .then((res) => res.text())
+    .then((text) => {
+      // This is copied from older apps.
+      if (text.includes('Message accepted for delivery')) {
+        return;
+      }
+      throw new Error('Message could not be delivered or response lost in transmission');
+    });
+};

--- a/packages/utils/src/main.ts
+++ b/packages/utils/src/main.ts
@@ -1,3 +1,5 @@
 export { getColorRamp, getThresholdBreaksColorsLabels } from './colors/scales';
 
 export { theme, ldnColors } from './colors/theme';
+
+export { postMail, type PostMail, type PostMailOptions } from './mailer/mailer';


### PR DESCRIPTION
**What does this change?**

Adds the `postMail` function to the utils package that posts mail via node-mailer instance.

**Why?**

Because the API is easy to forget and error handling is non-standard. It's doubles up as documentation for sending requests to node-mailer.

**How is it tested?**

Used and tested in https://dev.ldn-gis.co.uk/cool-spaces/

**How is it documented?**

TypeScript and file comments.

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
