### PR TITLE
separate out stories for CheckboxGroup and RadioButtonGroup

### DIFF
--- a/packages/ui/src/lib/checkBox/Checkbox.stories.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.stories.svelte
@@ -1,6 +1,5 @@
 <script context="module" lang="ts">
 	import Checkbox from './Checkbox.svelte';
-	import CheckboxGroup from './CheckboxGroup.svelte';
 
 	export const meta = {
 		title: 'Ui/Checkbox',
@@ -48,35 +47,13 @@
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 
 	let checked = false;
-
-	let selectedOptions: string[] = ['bus', 'underground'];
-
-	let optionsForGroup = [
-		{ id: 'bus', label: 'Bus stops', color: '#00AEEF' },
-		{
-			id: 'train',
-			label: 'Train stations',
-			color: '#008D48',
-			hint: 'Excluding underground stations'
-		},
-		{ id: 'underground', label: 'Underground stations', color: '#9E0059' },
-		{ id: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
-	];
 </script>
 
 <Template let:args>
 	<Checkbox {...args} />
 </Template>
 
-<Story
-	name="Default"
-	source
-	parameters={{
-		options: {
-			showPanel: true
-		}
-	}}
-/>
+<Story name="Default" source />
 
 <Story name="Single checkbox">
 	<Checkbox bind:checked id="single_id" label="Foo" />
@@ -91,20 +68,6 @@
 <Story name="Single checkbox with hint">
 	<Checkbox bind:checked id="hint_id" label="Foo" hint="A helpful hint" />
 	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">Checked: {checked}</p>
-</Story>
-
-<Story name="Checkbox Group" id="CheckboxGroupStory">
-	<CheckboxGroup options={optionsForGroup} bind:selectedOptions />
-	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">
-		selectedOptions: {JSON.stringify(selectedOptions)}
-	</p>
-</Story>
-
-<Story name="Checkbox Group - disabled buttons">
-	<CheckboxGroup options={optionsForGroup} bind:selectedOptions buttonsHidden />
-	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">
-		selectedOptions: {JSON.stringify(selectedOptions)}
-	</p>
 </Story>
 
 <Story name="Single colored checkbox">

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
@@ -1,0 +1,64 @@
+<script context="module" lang="ts">
+	import CheckboxGroup from './CheckboxGroup.svelte';
+
+	export const meta = {
+		title: 'Ui/CheckboxGroup',
+		component: CheckboxGroup,
+		argTypes: {
+			color: {
+				control: { type: 'color' }
+			},
+			label: {
+				control: { type: 'text' },
+				table: {
+					defaultValue: { summary: '' },
+					type: { summary: 'string' }
+				}
+			},
+			id: {
+				control: { type: 'text' },
+				table: {
+					defaultValue: { summary: '' },
+					type: { summary: 'string' }
+				}
+			}
+		},
+		args: {
+			label: 'Label for Checkbox'
+		}
+	};
+</script>
+
+<script lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+
+	let selectedOptions: string[] = ['bus', 'underground'];
+
+	let optionsForGroup = [
+		{ id: 'bus', label: 'Bus stops', color: '#00AEEF' },
+		{
+			id: 'train',
+			label: 'Train stations',
+			color: '#008D48',
+			hint: 'Excluding underground stations'
+		},
+		{ id: 'underground', label: 'Underground stations', color: '#9E0059' },
+		{ id: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
+	];
+</script>
+
+<Template let:args>
+	<CheckboxGroup options={optionsForGroup} bind:selectedOptions {...args} />
+	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Template>
+
+<Story name="Default" source />
+
+<Story name="Checkbox Group - disabled buttons">
+	<CheckboxGroup options={optionsForGroup} bind:selectedOptions buttonsHidden />
+	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>

--- a/packages/ui/src/lib/radioButton/RadioButton.stories.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButton.stories.svelte
@@ -1,16 +1,8 @@
 <script lang="ts">
 	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 	import RadioButton from './RadioButton.svelte';
-	import RadioButtonGroup from './RadioButtonGroup.svelte';
 
 	let selectedId: string;
-
-	let optionsForGroup = [
-		{ id: 'bus', label: 'Bus stops', color: '#00AEEF' },
-		{ id: 'train', label: 'Train stations', color: '#008D48' },
-		{ id: 'underground', label: 'Underground stations', color: '#9E0059' },
-		{ id: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
-	];
 </script>
 
 <Meta title="Ui/RadioButton" component={RadioButton} />
@@ -35,16 +27,6 @@
 		<p>selectedId: {selectedId}</p>
 		<p>Checked: {!!selectedId}</p>
 	</div>
-</Story>
-
-<Story name="RadioGroup">
-	<RadioButtonGroup options={optionsForGroup} name="station-type" bind:selectedId />
-	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">Selected id: {selectedId}</p>
-</Story>
-
-<Story name="RadioGroup - no clear button">
-	<RadioButtonGroup options={optionsForGroup} name="station-type" bind:selectedId buttonsHidden />
-	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">Selected id: {selectedId}</p>
 </Story>
 
 <Story name="Single Colored RadioButton">

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
+	import RadioButtonGroup from './RadioButtonGroup.svelte';
+
+	let selectedId: string;
+
+	let optionsForGroup = [
+		{ id: 'bus', label: 'Bus stops', color: '#00AEEF' },
+		{ id: 'train', label: 'Train stations', color: '#008D48' },
+		{ id: 'underground', label: 'Underground stations', color: '#9E0059' },
+		{ id: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
+	];
+</script>
+
+<Meta title="Ui/RadioButtonGroup" component={RadioButtonGroup} />
+
+<Template let:args>
+	<RadioButtonGroup options={optionsForGroup} name="station-type" bind:selectedId {...args} />
+	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">Selected id: {selectedId}</p>
+</Template>
+
+<Story name="Default" source />
+
+<Story name="RadioGroup">
+	<RadioButtonGroup options={optionsForGroup} name="station-type" bind:selectedId />
+	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">Selected id: {selectedId}</p>
+</Story>
+
+<Story name="RadioGroup - no clear button">
+	<RadioButtonGroup options={optionsForGroup} name="station-type" bind:selectedId buttonsHidden />
+	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">Selected id: {selectedId}</p>
+</Story>


### PR DESCRIPTION
This separates the stories for the `Checkbox`/`CheckboxGroup` and `RadioButton`/`RadioButtonGroup` components.

It is intended to address https://github.com/Greater-London-Authority/ldn-viz-tools/issues/297