### PR TITLE
Update Input and InputWrapper

### DIFF
--- a/.changeset/a_b_c.md
+++ b/.changeset/a_b_c.md
@@ -1,0 +1,10 @@
+---
+'@ldn-viz/ui': major
+---
+
+CHANGED: update `Input` to allow textarea type.
+CHANGED: update `Input` to pass `$$restProps` to the input element to account for differences in properties for different input types.
+CHANGED: update `Input` to export the bindable input element value.
+CHANGED: update `Input` to allow a format value function to be passed that formats the value when unfocusing the input.
+CHANGED: update `InputWrapper` to allow tooltip hints in the label.
+CHANGED: update `Input` and `InputWrapper` with aria and accessibility attributes.

--- a/.changeset/a_b_c.md
+++ b/.changeset/a_b_c.md
@@ -8,3 +8,4 @@ CHANGED: update `Input` to export the bindable input element value.
 CHANGED: update `Input` to allow a format value function to be passed that formats the value when unfocusing the input.
 CHANGED: update `InputWrapper` to allow tooltip hints in the label.
 CHANGED: update `Input` and `InputWrapper` with aria and accessibility attributes.
+CHANGED: update `Select` with `InputWrapper` changes.

--- a/.changeset/a_b_c.md
+++ b/.changeset/a_b_c.md
@@ -9,3 +9,4 @@ CHANGED: update `Input` to allow a format value function to be passed that forma
 CHANGED: update `InputWrapper` to allow tooltip hints in the label.
 CHANGED: update `Input` and `InputWrapper` with aria and accessibility attributes.
 CHANGED: update `Select` with `InputWrapper` changes.
+CHANGED: changed props relating to tooltips - removed boolean `hint` prop, renamed `hintTooltipContent` -> `hint`, renamed `hintText` -> `hintLabel`

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
 	import Checkbox from './Checkbox.svelte';
-
-	const uuidLength = 36;
-	const lastTwelveUuidChars = uuidLength - 12;
-	const selectAllId = crypto.randomUUID().slice(lastTwelveUuidChars);
+	import { randomId } from '../utils/randomId';
 
 	export let options: {
 		id: string;
@@ -55,7 +52,7 @@
 <div>
 	{#if !buttonsHidden}
 		<Checkbox
-			id={selectAllId}
+			id={randomId()}
 			label="Select all"
 			color="#3787D2"
 			checked={allCheckboxesCheckedOrDisabled}

--- a/packages/ui/src/lib/input/Input.stories.svelte
+++ b/packages/ui/src/lib/input/Input.stories.svelte
@@ -19,7 +19,7 @@
 	<div class="w-96 flex flex-col gap-4">
 		<Input name="bind-value-input" bind:value placeholder="Type here..." />
 		<div class="h-4">
-			<span class="font-medium">Value:</span>
+			<span class="font-medium dark:text-white">Value:</span>
 			{value}
 		</div>
 	</div>
@@ -117,7 +117,6 @@
 			name="email-input"
 			hint="Brings up the email keypad on touch screens"
 		/>
-		<Input type="range" label="Range" name="range-input" value="0" min="-10" max="10" />
 		<Input type="time" label="Time" name="time-input" />
 		<Input type="date" label="Date" name="date-input" />
 		<Input type="datetime-local" label="Datetime local" name="datetime-local-input" />

--- a/packages/ui/src/lib/input/Input.stories.svelte
+++ b/packages/ui/src/lib/input/Input.stories.svelte
@@ -12,13 +12,6 @@
 					disable: true
 				}
 			},
-			/*
-			type: {
-				options: ['color', 'date', 'datetime-local', 'email'],
-				control: { type: 'select' }
-			},
-			*/
-
 			descriptionAlignment: {
 				options: ['left', 'right'],
 				control: { type: 'select' }

--- a/packages/ui/src/lib/input/Input.stories.svelte
+++ b/packages/ui/src/lib/input/Input.stories.svelte
@@ -111,7 +111,11 @@
 
 <Story name="Custom format function">
 	<div class="w-96">
-		<Input label="Type a number" description="It will be rounded to 2 d.p. when the input loses focus" format={round} />
+		<Input
+			label="Type a number"
+			description="It will be rounded to 2 d.p. when the input loses focus"
+			format={round}
+		/>
 	</div>
 </Story>
 

--- a/packages/ui/src/lib/input/Input.stories.svelte
+++ b/packages/ui/src/lib/input/Input.stories.svelte
@@ -1,6 +1,8 @@
 <script>
 	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 	import Input from './Input.svelte';
+
+	let value = '';
 </script>
 
 <Meta title="Ui/Input" component={Input} />
@@ -13,72 +15,112 @@
 
 <Story name="Default" source />
 
+<Story name="Binding on value">
+	<div class="w-96 flex flex-col gap-4">
+		<Input name="bind-value-input" bind:value placeholder="Type here..." />
+		<div class="h-4">
+			<span class="font-medium">Value:</span>
+			{value}
+		</div>
+	</div>
+</Story>
+
 <Story name="With Label">
-	<div class="w-96">
-		<Input label="Label" id="labelled-input" />
+	<div class="w-96 flex flex-col gap-4">
+		<Input name="labelled-input-required" label="Label" />
+		<Input name="labelled-input-optional" label="Label" optional />
 	</div>
 </Story>
 
-<Story name="More Chrome">
+<Story name="With tooltip">
 	<div class="w-96">
 		<Input
-			label="Label"
-			id="labelled-input"
-			placeholder="Placeholder text"
-			hint
-			hintText="Tooltip text"
-			hintTooltipContent="A brief contextual help message"
-			description="descriptive text"
-			optional
+			label="Tooltip"
+			name="tooltip-input"
+			hint="Contextual help text"
+			hintLabel="optional hint label"
 		/>
 	</div>
 </Story>
 
-<Story name="Description alignment">
-	<div class="w-96">
+<Story name="With description">
+	<div class="w-96 flex flex-col gap-4">
 		<Input
 			label="Label"
-			id="labelled-input"
-			placeholder="Placeholder text"
-			hint
-			hintText="Tooltip text"
-			hintTooltipContent="A brief contextual help message"
-			description="descriptive text"
+			name="left-aligned-description-input"
+			description="Left aligned descriptive text (default)."
+		/>
+		<Input
+			label="Label"
+			name="right-aligned-description-input"
+			description="Right aligned descriptive text."
 			descriptionAlignment="right"
-			optional
 		/>
 	</div>
 </Story>
 
-<Story name="Error">
+<Story name="With error">
+	<div class="w-96">
+		<Input label="Description" name="description-input" error="Error text" />
+	</div>
+</Story>
+
+<Story name="With custom input mode">
 	<div class="w-96">
 		<Input
-			label="Label"
-			id="labelled-input"
-			placeholder="Placeholder text"
-			hint
-			hintText="Tooltip text"
-			hintTooltipContent="A brief contextual help message"
-			description="descriptive text"
-			optional
-			error
-			errorMessage="something has gone wrong here"
+			type="number"
+			label="Input mode"
+			inputmode="decimal"
+			name="input-mode-input"
+			hint="Using 'decimal' input mode here rather than 'numeric'"
 		/>
 	</div>
 </Story>
 
 <Story name="Disabled">
 	<div class="w-96">
+		<Input label="Disabled" name="disabled-input" disabled />
+	</div>
+</Story>
+
+<Story name="Alternative types">
+	<div class="w-96 flex flex-col gap-4">
 		<Input
-			label="Label"
-			id="labelled-input"
-			placeholder="Placeholder text"
-			hint
-			hintText="Tooltip text"
-			hintTooltipContent="A brief contextual help message"
-			description="descriptive text"
-			disabled
-			optional
+			type="textarea"
+			label="Textarea"
+			name="textarea-input"
+			rows="5"
+			hint="Three rows by default"
 		/>
+		<Input
+			type="number"
+			label="Number"
+			name="number-input"
+			hint="Brings up the numeric keypad on touch screens"
+		/>
+		<Input type="password" label="Password" name="password-input" hint="No formatting by default" />
+		<Input
+			type="url"
+			label="URL"
+			name="url-input"
+			hint="Brings up the URL keypad on touch screens"
+		/>
+		<Input
+			type="tel"
+			label="Phone"
+			name="tel-input"
+			hint="Brings up the telephone keypad on touch screens"
+		/>
+		<Input
+			type="email"
+			label="Email"
+			name="email-input"
+			hint="Brings up the email keypad on touch screens"
+		/>
+		<Input type="range" label="Range" name="range-input" value="0" min="-10" max="10" />
+		<Input type="time" label="Time" name="time-input" />
+		<Input type="date" label="Date" name="date-input" />
+		<Input type="datetime-local" label="Datetime local" name="datetime-local-input" />
+		<Input type="file" label="File" name="file-input" />
 	</div>
 </Story>

--- a/packages/ui/src/lib/input/Input.stories.svelte
+++ b/packages/ui/src/lib/input/Input.stories.svelte
@@ -4,14 +4,34 @@
 
 	export const meta = {
 		title: 'Ui/Input',
-		component: Input
+		component: Input,
+		argTypes: {
+			// this is a module export, not a prop, so don't include it in table
+			trimInput: {
+				table: {
+					disable: true
+				}
+			},
+			/*
+			type: {
+				options: ['color', 'date', 'datetime-local', 'email'],
+				control: { type: 'select' }
+			},
+			*/
+
+			descriptionAlignment: {
+				options: ['left', 'right'],
+				control: { type: 'select' }
+			}
+		}
 	};
 </script>
 
-<script>
+<script lang="ts">
 	let value = '';
-</script>
 
+	const round = (x: string) => Math.round(+x * 100) / 100;
+</script>
 
 <Template let:args>
 	<div class="w-96">
@@ -86,6 +106,12 @@
 <Story name="Disabled">
 	<div class="w-96">
 		<Input label="Disabled" name="disabled-input" disabled />
+	</div>
+</Story>
+
+<Story name="Custom format function">
+	<div class="w-96">
+		<Input label="Type a number" description="It will be rounded to 2 d.p. when the input loses focus" format={round} />
 	</div>
 </Story>
 

--- a/packages/ui/src/lib/input/Input.svelte
+++ b/packages/ui/src/lib/input/Input.svelte
@@ -85,6 +85,10 @@
 		'm-0',
 		error ? 'border-core-red-400 dark:border-core-red-400' : '',
 		$$restProps.disabled ? 'cursor-not-allowed ' : '',
+		'dark:bg-core-grey-600',
+		'dark:text-white',
+		'placeholder-core-grey-400',
+		'dark:placeholder-core-grey-300',
 		'form-input'
 	);
 </script>
@@ -187,10 +191,7 @@
 		-webkit-appearance: none;
 	}
 
-	input,
 	textarea {
 		appearance: textfield;
-		@apply bg-core-grey-600 text-white;
-		@apply placeholder-core-grey-300;
 	}
 </style>

--- a/packages/ui/src/lib/input/Input.svelte
+++ b/packages/ui/src/lib/input/Input.svelte
@@ -1,16 +1,26 @@
 <script lang="ts" context="module">
 	export type FormatFunction = (
-		value,
-		details: {
-			name: string;
-			type: string;
-			disabled: boolean;
+		value: string,
+		details?: {
+			name?: string;
+			type?: string;
+			disabled?: boolean;
 		}
 	) => string;
 
-	export const trimInputFormatter: FormatFunction = (value) => {
-		return value && typeof value === 'string' ? value.trim() : value;
-	};
+	export type InputMode =
+		| 'none'
+		| 'search'
+		| 'text'
+		| 'tel'
+		| 'url'
+		| 'email'
+		| 'numeric'
+		| 'decimal'
+		| null
+		| undefined;
+
+	export const trimInput: FormatFunction = (value) => value.trim();
 </script>
 
 <script lang="ts">
@@ -19,7 +29,7 @@
 	import { randomId } from '../utils/randomId';
 
 	export let type = 'text';
-	export let inputmode: undefined | string = undefined;
+	export let inputmode: InputMode = undefined;
 
 	export let id = randomId();
 	export let label = '';
@@ -34,7 +44,7 @@
 	export let optional = false;
 	export let disabled = false;
 
-	export let format: null | FormatFunction = trimInputFormatter;
+	export let format: null | FormatFunction = trimInput;
 	export let value = '';
 	export let error = '';
 
@@ -47,18 +57,18 @@
 		inputmode = inputmode ? inputmode : 'numeric';
 	}
 
-	if (type === 'password' && format === trimInputFormatter) {
+	if (type === 'password' && format === trimInput) {
 		// Form input values rarely need to keep leading and trailing whitespace
-		// but passwords are an exception so default to no formatting for them.
+		// but passwords are an exception so default to no formatting.
 		format = null;
 	}
 
 	const discriptionId = `${id}-description`;
 	const errorId = `${id}-error`;
-	let input;
+	let input: HTMLInputElement | HTMLTextAreaElement;
 
-	// Svelte does not allow bind:type and bind:value simultaneously for input
-	// elements so this function acts as the input change handler.
+	// Svelte does not allow bind:type and bind:value simultaneously so this
+	// function acts as the input change handler.
 	const formatAndUpdateValue = () => {
 		if (!format) {
 			return;
@@ -70,13 +80,13 @@
 			disabled: !!$$restProps.disabled
 		});
 
-		// Protect form cyclic reactivity.
+		// Protect from cyclic reactivity.
 		if (input.value !== value) {
 			input.value = value;
 		}
 	};
 
-	const updateValue = (event) => {
+	const updateValue = () => {
 		// input.value will be an empty string if the value is invalid.
 		value = input.value;
 	};

--- a/packages/ui/src/lib/input/Input.svelte
+++ b/packages/ui/src/lib/input/Input.svelte
@@ -63,7 +63,7 @@
 		format = null;
 	}
 
-	const discriptionId = `${id}-description`;
+	const descriptionId = `${id}-description`;
 	const errorId = `${id}-error`;
 	let input: HTMLInputElement | HTMLTextAreaElement;
 
@@ -106,7 +106,7 @@
 <InputWrapper
 	{label}
 	{id}
-	{discriptionId}
+	discriptionId={descriptionId}
 	{description}
 	{descriptionAlignment}
 	{hintLabel}
@@ -129,7 +129,7 @@
 			{value}
 			{disabled}
 			required={!optional}
-			aria-describedby={discriptionId}
+			aria-describedby={descriptionId}
 			aria-errormessage={errorId}
 			aria-invalid={!!error}
 			on:blur={formatAndUpdateValue}
@@ -166,7 +166,7 @@
 			{value}
 			{disabled}
 			required={!optional}
-			aria-describedby={discriptionId}
+			aria-describedby={descriptionId}
 			aria-errormessage={errorId}
 			aria-invalid={!!error}
 			on:blur={formatAndUpdateValue}

--- a/packages/ui/src/lib/input/Input.svelte
+++ b/packages/ui/src/lib/input/Input.svelte
@@ -24,28 +24,80 @@
 </script>
 
 <script lang="ts">
-	import InputWrapper from './InputWrapper.svelte';
 	import { classNames } from '../utils/classNames';
 	import { randomId } from '../utils/randomId';
+	import InputWrapper from './InputWrapper.svelte';
 
+	/**
+	 * The `type` of the `<input>` element (see [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types)).
+	 */
 	export let type = 'text';
+
+	/**
+	 * The `inputmode` of the `<input>` element, which provides a hint about what type of virtual keyboard to display.
+	 */
 	export let inputmode: InputMode = undefined;
 
+	/**
+	 * The `id` of the `<input>` element: defaults to a randomly-generated value.
+	 */
 	export let id = randomId();
+
+	/**
+	 * Text displayed above the `<input>` element.
+	 */
 	export let label = '';
+
+	/**
+	 * The `name` of the `<input>` element. Defaults to same value as `id`. Optional, unless value of the input needs to be included with a form submission.
+	 */
 	export let name = id;
 
+	/**
+	 * Text that appears below the `<input>` element, in smaller font than the `label`.
+	 */
 	export let description = '';
+
+	/**
+	 * Determines which edge of the `<input>` the description is aligned with.
+	 */
 	export let descriptionAlignment: 'left' | 'right' = 'left';
 
+	/**
+	 * Help text to be displayed in tooltip
+	 */
 	export let hint = '';
+
+	/**
+	 * Text to be displayed next to icon in tooltip trigger.
+	 */
 	export let hintLabel = '';
 
+	/**
+	 * If `false`, then `required` attribute is applied to `<input>`.
+	 */
 	export let optional = false;
+
+	/**
+	 * If `true`, then user is prevented from interacting with the `<input>`.
+	 */
 	export let disabled = false;
 
+	/**
+	 * Function that will be applied to transform the value when the input element loses focus.
+	 * By default, it trims leading and trailing whitespace (but does nothing if `type` is `password`).
+	 */
 	export let format: null | FormatFunction = trimInput;
+
+	/**
+	 * The value of the input. Can be bound to and externally modified.
+	 */
 	export let value = '';
+
+	/**
+	 * Message to be displayed below `<input>` in red text (replacing description).
+	 * If set, then the border of the `<input>` is also red.
+	 */
 	export let error = '';
 
 	let inputType = type;
@@ -106,7 +158,7 @@
 <InputWrapper
 	{label}
 	{id}
-	discriptionId={descriptionId}
+	{descriptionId}
 	{description}
 	{descriptionAlignment}
 	{hintLabel}

--- a/packages/ui/src/lib/input/InputWrapper.svelte
+++ b/packages/ui/src/lib/input/InputWrapper.svelte
@@ -3,16 +3,16 @@
 	import { classNames } from '../utils/classNames';
 
 	export let label = '';
-	export let id: string;
+	export let id: undefined | string = undefined;
 
-	export let discriptionId: string;
+	export let discriptionId: undefined | string = undefined;
 	export let description = '';
 	export let descriptionAlignment: 'left' | 'right' = 'left';
 
 	export let hintLabel = '';
 	export let hint = '';
 
-	export let errorId: string;
+	export let errorId: undefined | string = undefined;
 	export let error = '';
 
 	export let disabled = false;

--- a/packages/ui/src/lib/input/InputWrapper.svelte
+++ b/packages/ui/src/lib/input/InputWrapper.svelte
@@ -5,7 +5,7 @@
 	export let label = '';
 	export let id: undefined | string = undefined;
 
-	export let discriptionId: undefined | string = undefined;
+	export let descriptionId: undefined | string = undefined;
 	export let description = '';
 	export let descriptionAlignment: 'left' | 'right' = 'left';
 
@@ -56,7 +56,7 @@
 			{@html error}
 		</span>
 	{:else if description}
-		<span class={descriptionClass} id={discriptionId}>
+		<span class={descriptionClass} id={descriptionId}>
 			{@html description}
 		</span>
 	{/if}

--- a/packages/ui/src/lib/input/InputWrapper.svelte
+++ b/packages/ui/src/lib/input/InputWrapper.svelte
@@ -1,28 +1,22 @@
 <script lang="ts">
-	import Tooltip from '../tooltip/Tooltip.svelte';
+	import { Tooltip } from '@ldn-viz/ui';
 	import { classNames } from '../utils/classNames';
 
 	export let label = '';
+	export let id: string;
+
+	export let discriptionId: string;
 	export let description = '';
 	export let descriptionAlignment: 'left' | 'right' = 'left';
 
-	export let hint = false;
-	export let hintLabel = 'what is this?';
-	export let hintTooltipContent = 'A brief contextual help text';
+	export let hintLabel = '';
+	export let hint = '';
 
-	export let error = false;
-	export let errorMessage = '';
+	export let errorId: string;
+	export let error = '';
+
 	export let disabled = false;
 	export let optional = false;
-
-	// TODO: hint below?
-	// prefix and suffix slots
-
-	export let id: string;
-
-	//const id = crypto.randomUUID() ;
-
-	let descriptionClass: string;
 
 	$: descriptionClass = classNames(
 		error ? 'text-core-red-400 dark:text-core-red-400' : '',
@@ -35,30 +29,35 @@
 	$: labelClasses = classNames(
 		error ? 'text-core-red-400 dark:text-core-red-400' : '',
 		disabled ? 'text-core-grey-300 dark:text-core-grey-400' : '',
-		'form-label'
+		'form-label',
+		'font-medium'
 	);
 </script>
 
 <div class="flex flex-col space-y-2">
-	<div class="flex justify-between">
+	<div class="flex justify-between [&>div]:text-sm">
 		{#if label}
 			<label for={id} class={labelClasses}>
-				{label}{#if optional}&nbsp;(optional){/if}
+				{@html label}{#if optional}&nbsp;(optional){/if}
 			</label>
 		{/if}
 
 		{#if hint}
 			<Tooltip {hintLabel}>
-				{hintTooltipContent}
+				{hint}
 			</Tooltip>
 		{/if}
 	</div>
 
-	<slot {id} />
+	<slot />
 
-	{#if description && !errorMessage}
-		<span class={descriptionClass}>{description}</span>
-	{:else if errorMessage}
-		<span class={descriptionClass}>{errorMessage}</span>
+	{#if error}
+		<span class={descriptionClass} id={errorId}>
+			{@html error}
+		</span>
+	{:else if description}
+		<span class={descriptionClass} id={discriptionId}>
+			{@html description}
+		</span>
 	{/if}
 </div>

--- a/packages/ui/src/lib/select/Select.stories.svelte
+++ b/packages/ui/src/lib/select/Select.stories.svelte
@@ -20,6 +20,7 @@
 	];
 
 	let justValue: number;
+	let error = '';
 </script>
 
 <Template let:args>
@@ -153,5 +154,18 @@
 		<Button on:click={() => (justValue = null)}>Clear</Button>
 
 		<Select {items} bind:justValue id="labelled-input" />
+	</div>
+</Story>
+
+<Story name="Setting and clearing error message">
+	<div class="w-[500px] flex flex-col gap-2">
+		<div>
+			<Button on:click={() => (error = 'OH NO')}>Set error</Button>
+			<Button on:click={() => (error = '')}>Clear error</Button>
+		</div>
+
+		<span><code>error is:</code> {error}</span>
+
+		<Select {items} id="labelled-input" {error} />
 	</div>
 </Story>

--- a/packages/ui/src/lib/select/Select.stories.svelte
+++ b/packages/ui/src/lib/select/Select.stories.svelte
@@ -54,9 +54,8 @@
 			{items}
 			label="Label"
 			id="labelled-input"
-			hint
-			hintText="Tooltip text"
-			hintTooltipContent="A brief contextual help message"
+			hintLabel="Tooltip text"
+			hint="A brief contextual help message"
 		/>
 	</div>
 </Story>
@@ -74,9 +73,8 @@
 			label="Label"
 			id="labelled-input"
 			placeholder="Placeholder text"
-			hint
-			hintText="Tooltip text"
-			hintTooltipContent="A brief contextual help message"
+			hintLabel="Tooltip text"
+			hint="A brief contextual help message"
 			description="descriptive text"
 			descriptionAlignment="right"
 			optional
@@ -91,9 +89,8 @@
 			label="Label"
 			id="labelled-input"
 			placeholder="Placeholder text"
-			hint
-			hintText="Tooltip text"
-			hintTooltipContent="A brief contextual help message"
+			hintLabel="Tooltip text"
+			hint="A brief contextual help message"
 			description="descriptive text"
 			optional
 			multiple
@@ -114,13 +111,11 @@
 			label="Label"
 			id="labelled-input"
 			placeholder="Placeholder text"
-			hint
-			hintText="Tooltip text"
-			hintTooltipContent="A brief contextual help message"
+			hintLabel="Tooltip text"
+			hint="A brief contextual help message"
 			description="descriptive text"
 			optional
-			error
-			errorMessage="something has gone wrong here"
+			error="something has gone wrong here"
 		/>
 	</div>
 </Story>
@@ -132,9 +127,8 @@
 			label="Label"
 			id="labelled-input"
 			placeholder="Placeholder text"
-			hint
-			hintText="Tooltip text"
-			hintTooltipContent="A brief contextual help message"
+			hintLabel="Tooltip text"
+			hint="A brief contextual help message"
 			description="descriptive text"
 			disabled
 			optional
@@ -146,7 +140,7 @@
 	<div class="w-[500px] flex flex-col gap-2">
 		<p>
 			You can bind directly to <code>justValue</code>, rather than <code>value</code> (which is an
-			object including the <code>label</code> as well as <code>vlaue</code>)
+			object including the <code>label</code> as well as <code>value</code>)
 		</p>
 
 		<div>Current value: <span class="font-bold">{justValue}</span></div>

--- a/packages/ui/src/lib/select/Select.stories.svelte
+++ b/packages/ui/src/lib/select/Select.stories.svelte
@@ -141,7 +141,7 @@
 	</div>
 </Story>
 
-<Story name="Binidng to justValue">
+<Story name="Binding to justValue">
 	<div class="w-[500px] flex flex-col gap-2">
 		<p>
 			You can bind directly to <code>justValue</code>, rather than <code>value</code> (which is an

--- a/packages/ui/src/lib/select/Select.svelte
+++ b/packages/ui/src/lib/select/Select.svelte
@@ -17,7 +17,6 @@
 	export let placeholder = 'Select an option';
 	export let disabled = false;
 	export let error = '';
-	export let hasError = !!error;
 
 	export let labelField = 'label';
 
@@ -104,7 +103,7 @@
 			{itemId}
 			{loadOptions}
 			{containerStyles}
-			{hasError}
+			hasError={!!error}
 			{filterSelectedItems}
 			{required}
 			{closeListOnChange}

--- a/packages/ui/src/lib/select/Select.svelte
+++ b/packages/ui/src/lib/select/Select.svelte
@@ -5,16 +5,19 @@
 	 * @component
 	 */
 
+	import { randomId } from '../utils/randomId';
+
 	import SvelteSelect from 'svelte-select';
 	import InputWrapper from '../input/InputWrapper.svelte';
 
 	export let items: { [key: string]: any }[];
 
-	export let id: string;
+	export let id = randomId();
 	export let name = '';
 	export let placeholder = 'Select an option';
 	export let disabled = false;
-	export let error = false;
+	export let error = '';
+	export let hasError = !!error;
 
 	export let labelField = 'label';
 
@@ -101,7 +104,7 @@
 			{itemId}
 			{loadOptions}
 			{containerStyles}
-			hasError={error}
+			{hasError}
 			{filterSelectedItems}
 			{required}
 			{closeListOnChange}

--- a/packages/ui/src/lib/utils/randomId.ts
+++ b/packages/ui/src/lib/utils/randomId.ts
@@ -1,0 +1,6 @@
+// randomId returns a random twelve character string. It is suitable as a
+// unique ID for non-cryptographic applicaitons, e.g. HTML element id.
+export const randomId = () => {
+	const uuid = crypto.randomUUID();
+	return uuid.slice(uuid.length - 12);
+};


### PR DESCRIPTION
**What does this change?**

Updates: 

1. `Input` to allow textarea type.
2. `Input` to pass `$$restProps` to the input element to account for differences in properties for different input types.
3. `Input` to export the bindable input element value.
4. `Input` to allow a format value function to be passed that formats the value when unfocusing the input.
5. `InputWrapper` to allow tooltip hints in the label.
6. `Input` and `InputWrapper` with aria and accessibility attributes.

**Why?**

So the input is usable and accessible with HTML forms and multiple input types.

**How is it tested?**

Storybook

**How is it documented?**

Stroybook

**Is it complete?**

- [x] Have you included changeset file?
