### PR TITLE
Adds name prop to checkbox and checkbox group options

### DIFF
--- a/.changeset/xxx_yyy_zzz.md
+++ b/.changeset/xxx_yyy_zzz.md
@@ -2,4 +2,4 @@
 '@ldn-viz/ui': minor
 ---
 
-CHANGED: add `name` prop to `Checkbox` and `CheckboxGroup` options.
+CHANGED: add `name` prop to `Checkbox` and `CheckboxGroup` options so it can be used within forms.

--- a/.changeset/xxx_yyy_zzz.md
+++ b/.changeset/xxx_yyy_zzz.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: add `name` prop to `Checkbox` and `CheckboxGroup` options.

--- a/.changeset/xxx_yyy_zzz.md
+++ b/.changeset/xxx_yyy_zzz.md
@@ -2,4 +2,4 @@
 '@ldn-viz/ui': minor
 ---
 
-CHANGED: add `name` prop to `Checkbox` and `CheckboxGroup` options so it can be used within forms.
+CHANGED: add optional `name` prop to `Checkbox` and to `options` props of `CheckboxGroup` so their values can be included with form submissions.

--- a/packages/ui/src/lib/checkBox/Checkbox.stories.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.stories.svelte
@@ -22,6 +22,13 @@
 					type: { summary: 'string' }
 				}
 			},
+			name: {
+				control: { type: 'text' },
+				table: {
+					defaultValue: { summary: '' },
+					type: { summary: 'string' }
+				}
+			},
 			hint: {
 				control: { type: 'text' },
 				table: {
@@ -81,7 +88,7 @@
 </Story>
 
 <Story name="Multiple checkboxes not in group">
-	<Checkbox color="#00AEEF" label="Foo" id="foo" />
-	<Checkbox color="#008D48" label="Bar" id="bar" />
-	<Checkbox color="#9E0059" label="Baz" id="baz" />
+	<Checkbox color="#00AEEF" label="Foo" name="foo" />
+	<Checkbox color="#008D48" label="Bar" name="bar" />
+	<Checkbox color="#9E0059" label="Baz" name="baz" />
 </Story>

--- a/packages/ui/src/lib/checkBox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.svelte
@@ -1,10 +1,11 @@
 <script context="module" lang="ts">
 	export interface CheckboxProps {
+		id: string;
+		name: string;
 		color: string;
 		checked: boolean;
 		indeterminate: boolean;
 		label: string;
-		id: string;
 		disabled: boolean;
 		hint: string;
 		hintLabel: string;
@@ -13,24 +14,25 @@
 
 <script lang="ts">
 	import Tooltip from '../tooltip/Tooltip.svelte';
+	import { randomId } from '../utils/randomId';
+
+	export let id = randomId();
+	export let name = '';
 
 	/** A hex string to add a color to the box - this should correspond to the design system colors. */
 	export let color: CheckboxProps['color'] = '';
 	export let checked: CheckboxProps['checked'] = false;
 	export let indeterminate: CheckboxProps['indeterminate'] = false;
 	export let label: CheckboxProps['label'];
-	export let id: CheckboxProps['id'];
 	export let disabled: CheckboxProps['disabled'] = false;
 	export let hint: CheckboxProps['hint'] = '';
 	export let hintLabel: CheckboxProps['hintLabel'] = '';
-
-	let inputID = `input-${id}`;
 </script>
 
 <label class="flex items-center">
 	<input
-		id={inputID}
-		name={id}
+		{id}
+		{name}
 		class="form-checkbox"
 		type="checkbox"
 		bind:checked
@@ -40,6 +42,7 @@
 		style={color
 			? `--border-color: ${color}; --background-color: ${color}; --tw-ring-color: ${color}`
 			: ''}
+		{...$$restProps}
 	/>
 	<span class="mx-2 form-label">{label}</span>
 	{#if hint}

--- a/packages/ui/src/lib/checkBox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.svelte
@@ -26,10 +26,10 @@
 	import { randomId } from '../utils/randomId';
 
 	/**
-	* Value set as the `id` attribute of the `<input>` element (defaults to randomly generated value).
-	*/
+	 * Value set as the `id` attribute of the `<input>` element (defaults to randomly generated value).
+	 */
 	export let id = randomId();
-	
+
 	/**
 	 * Value set as the `name` attribute of the `<input>` element (optional, but required if providing value with a form submission)
 	 */

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
@@ -23,9 +23,7 @@
 				}
 			}
 		},
-		args: {
-			label: 'Label for Checkbox'
-		}
+		args: {}
 	};
 </script>
 
@@ -35,15 +33,16 @@
 	let selectedOptions: string[] = ['bus', 'underground'];
 
 	let optionsForGroup = [
-		{ id: 'bus', label: 'Bus stops', color: '#00AEEF' },
+		{ id: 'bus', name: 'bus', label: 'Bus stops', color: '#00AEEF' },
 		{
 			id: 'train',
+			name: 'train',
 			label: 'Train stations',
 			color: '#008D48',
 			hint: 'Excluding underground stations'
 		},
-		{ id: 'underground', label: 'Underground stations', color: '#9E0059' },
-		{ id: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
+		{ id: 'underground', name: 'underground', label: 'Underground stations', color: '#9E0059' },
+		{ id: 'taxi', name: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
 	];
 </script>
 

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
@@ -3,8 +3,8 @@
 
 	export const meta = {
 		title: 'Ui/CheckboxGroup',
-		component: CheckboxGroup,
-	}
+		component: CheckboxGroup
+	};
 </script>
 
 <script lang="ts">

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -7,6 +7,7 @@
 
 	export let options: {
 		id: string;
+		name?: string;
 		label: string;
 		disabled?: boolean;
 		color?: string;
@@ -54,7 +55,12 @@
 
 <div>
 	{#if !buttonsHidden}
+		<!--
+			form="" should prevent this checkbox from being included in form
+			submissions.
+		-->
 		<Checkbox
+			form=""
 			id={selectAllId}
 			label="Select all"
 			color="#3787D2"
@@ -68,6 +74,7 @@
 		{#each options as option}
 			<Checkbox
 				id={option.id}
+				name={option.name}
 				label={option.label}
 				color={option.color}
 				disabled={option.disabled}

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -15,6 +15,7 @@
 	/**
 	 * Each element of this array defines a checkbox, and is an object with the properties:
 	 * * `id` (string)
+	 * * `name` (string, optional) - used to set the `name` attribute of the `<input>` element
 	 * * `label` (string) - the text displayed next to the checkbox
 	 * * `disabled` (boolean, optional) - if `true`, users cannot change whether the checkbox is checked
 	 * * `color` (string, optional) - CSS color of the checkbox

--- a/packages/ui/src/lib/utils/randomId.ts
+++ b/packages/ui/src/lib/utils/randomId.ts
@@ -1,5 +1,5 @@
 // randomId returns a random twelve character string. It is suitable as a
-// unique ID for non-cryptographic applicaitons, e.g. HTML element id.
+// unique ID for non-cryptographic applications, e.g. HTML element id.
 export const randomId = () => {
 	const uuid = crypto.randomUUID();
 	return uuid.slice(uuid.length - 12);

--- a/packages/ui/src/lib/utils/randomId.ts
+++ b/packages/ui/src/lib/utils/randomId.ts
@@ -1,0 +1,6 @@
+// randomId returns a random twelve character string. It is suitable as a
+// unique ID for non-cryptographic applicaitons, e.g. HTML element id.
+export const randomId = () => {
+	const uuid = crypto.randomUUID();
+	return uuid.slice(uuid.length - 12);
+};


### PR DESCRIPTION
**What does this change?**

Adds the `name` prop to `<Checkbox>` and `<CheckboxGroup>` options.

**Why?**

So they can be used within HTML forms.

**How is it tested?**

Storybook.

**How is it documented?**

Storybook.

**Is it complete?**

- [x] Have you included changeset file?
