### PR TITLE
replace use of deprecated <Meta> tag in stories

### DIFF
--- a/packages/ui/src/lib/colorLegends/ColorLegend.stories.svelte
+++ b/packages/ui/src/lib/colorLegends/ColorLegend.stories.svelte
@@ -1,6 +1,14 @@
-<script lang="ts">
-	import { Meta, Story } from '@storybook/addon-svelte-csf';
+<script context="module" lang="ts">
+	import { Story } from '@storybook/addon-svelte-csf';
+	import ColorLegend from './ColorLegend.svelte';
 
+	export const meta = {
+		title: 'Ui/Legends/ColorLegend',
+		component: ColorLegend
+	};
+</script>
+
+<script lang="ts">
 	import { cumsum } from 'd3-array';
 
 	import {
@@ -33,7 +41,6 @@
 	import { range } from 'd3-array';
 
 	import Button from '../button/Button.svelte';
-	import ColorLegend from './ColorLegend.svelte';
 
 	const continuousColorScale = scaleSequential(interpolateBlues).domain([0, 10]);
 
@@ -55,8 +62,6 @@
 	let scale;
 	let randomThresholdScale;
 </script>
-
-<Meta title="Ui/Legends/ColorLegend" component={ColorLegend} />
 
 <Story name="Sequential color scale">
 	<ColorLegend color={scaleSequential([0, 100], interpolateViridis)} title="Temperature (°F)" />

--- a/packages/ui/src/lib/colorLegends/ColorLegendOrdinalHorizontal.stories.svelte
+++ b/packages/ui/src/lib/colorLegends/ColorLegendOrdinalHorizontal.stories.svelte
@@ -1,15 +1,20 @@
-<script lang="ts">
-	import { Meta, Story } from '@storybook/addon-svelte-csf';
-
-	import { scaleOrdinal } from 'd3-scale';
+<script context="module" lang="ts">
+	import { Story } from '@storybook/addon-svelte-csf';
 	import ColorLegendOrdinalHorizontal from './ColorLegendOrdinalHorizontal.svelte';
+
+	export const meta = {
+		title: 'Ui/Legends/ColorLegendOrdinalHorizontal',
+		component: ColorLegendOrdinalHorizontal
+	};
+</script>
+
+<script lang="ts">
+	import { scaleOrdinal } from 'd3-scale';
 
 	const ordinalScale = scaleOrdinal()
 		.domain(['A', 'B', 'C', 'D'])
 		.range(['#c5dcf2', '#8fb4db', '#628dba', '#3b6894', '#18446c']);
 </script>
-
-<Meta title="Ui/Legends/ColorLegendOrdinalHorizontal" component={ColorLegendOrdinalHorizontal} />
 
 <Story name="Categorical color scale">
 	<div class="w-[400px]">

--- a/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.stories.svelte
+++ b/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.stories.svelte
@@ -1,4 +1,5 @@
 <script context="module" lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
 	import ImageDownloadButton from './ImageDownloadButton.svelte';
 
 	export const meta = {
@@ -20,9 +21,6 @@
 <script lang="ts">
 	import { Camera } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
-
-	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
-
 	import LogoByCiu from '../logos/LogoByCIU.svelte';
 
 	let svgRef;
@@ -30,8 +28,6 @@
 	let svgRef3;
 	let htmlRef: HTMLElement;
 </script>
-
-<Meta title="Ui/ImageDownloadButton" component={ImageDownloadButton} />
 
 <Template let:args>
 	<svg bind:this={svgRef} width="100" height="100">

--- a/packages/ui/src/lib/input/Input.stories.svelte
+++ b/packages/ui/src/lib/input/Input.stories.svelte
@@ -1,9 +1,13 @@
-<script>
-	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
-	import Input from './Input.svelte';
-</script>
+<script context="module" lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
 
-<Meta title="Ui/Input" component={Input} />
+	import Input from './Input.svelte';
+
+	export const meta = {
+		title: 'Ui/Input',
+		component: Input
+	};
+</script>
 
 <Template let:args>
 	<div class="w-96">

--- a/packages/ui/src/lib/logos/Logos.stories.svelte
+++ b/packages/ui/src/lib/logos/Logos.stories.svelte
@@ -1,13 +1,16 @@
-<script>
-	import { Meta, Story } from '@storybook/addon-svelte-csf';
+<script context="module" lang="ts">
+	import { Story } from '@storybook/addon-svelte-csf';
 
 	import LogoByCIU from './LogoByCIU.svelte';
 	import LogoCIU from './LogoCIU.svelte';
 	import LogoLOTI from './LogoLOTI.svelte';
 	import LogoMayor from './LogoMayor.svelte';
-</script>
 
-<Meta title="Ui/Logos" component={LogoLOTI} />
+	export const meta = {
+		title: 'Ui/Logos',
+		component: LogoLOTI
+	};
+</script>
 
 <Story name="Mayor of London">
 	<div class="text-core-grey-800 dark:text-white">

--- a/packages/ui/src/lib/placardButton/PlacardButton.stories.svelte
+++ b/packages/ui/src/lib/placardButton/PlacardButton.stories.svelte
@@ -1,13 +1,16 @@
-<script>
+<script context="module" lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+
 	import { DocumentArrowDown } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
 
-	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
-
 	import PlacardButton from './PlacardButton.svelte';
-</script>
 
-<Meta title="Ui/PlacardButton" component={PlacardButton} />
+	export const meta = {
+		title: 'Ui/PlacardButton',
+		component: PlacardButton
+	};
+</script>
 
 <Template let:args>
 	<div class="max-w-xl">

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
@@ -1,6 +1,14 @@
-<script lang="ts">
-	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
+<script context="module" lang="ts">
 	import RadioButtonGroup from './RadioButtonGroup.svelte';
+
+	export const meta = {
+		title: 'Ui/RadioButtonGroup',
+		component: RadioButtonGroup
+	};
+</script>
+
+<script lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
 
 	let selectedId: string;
 
@@ -11,8 +19,6 @@
 		{ id: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
 	];
 </script>
-
-<Meta title="Ui/RadioButtonGroup" component={RadioButtonGroup} />
 
 <Template let:args>
 	<RadioButtonGroup options={optionsForGroup} name="station-type" bind:selectedId {...args} />

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
@@ -1,4 +1,5 @@
 <script context="module" lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
 	import RadioButtonGroup from './RadioButtonGroup.svelte';
 
 	export const meta = {
@@ -8,8 +9,6 @@
 </script>
 
 <script lang="ts">
-	import { Story, Template } from '@storybook/addon-svelte-csf';
-
 	let selectedId: string;
 
 	let optionsForGroup = [

--- a/packages/ui/src/lib/select/Select.stories.svelte
+++ b/packages/ui/src/lib/select/Select.stories.svelte
@@ -1,9 +1,15 @@
-<script lang="ts">
-	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
-
+<script context="module" lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
 	import Select from './Select.svelte';
-	import Button from '../button/Button.svelte';
 
+	export const meta = {
+		title: 'Ui/Select',
+		component: Select
+	};
+</script>
+
+<script lang="ts">
+	import Button from '../button/Button.svelte';
 	type Item = { label: string; value: number };
 	let value: Item;
 
@@ -15,8 +21,6 @@
 
 	let justValue: number;
 </script>
-
-<Meta title="Ui/Select" component={Select} />
 
 <Template let:args>
 	<Select {...args} />

--- a/packages/ui/src/lib/spinners/Spinner.stories.svelte
+++ b/packages/ui/src/lib/spinners/Spinner.stories.svelte
@@ -1,11 +1,15 @@
-<script>
-	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
+<script context="module" lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+
+	import Button from '../button/Button.svelte';
 
 	import Spinner from './Spinner.svelte';
-	import Button from '../button/Button.svelte';
-</script>
 
-<Meta title="Ui/Spinner" component={Spinner} />
+	export const meta = {
+		title: 'Ui/Spinner',
+		component: Spinner
+	};
+</script>
 
 <Template let:args>
 	<div class="text-core-grey-800">


### PR DESCRIPTION
This replaces the use of the deprecated `<Meta>` tag in some some stories with the now preferred approach of exporting a constant named  `meta`.

This updates the `.stories.svelte` files for UI components.