### PR TITLE
Add placeholder image component

### DIFF
--- a/.changeset/place-holder-image.md
+++ b/.changeset/place-holder-image.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+ADDED: `PlaceholderImage` component to show while waiting for the real image to load or where an image is expected but not available.


### PR DESCRIPTION
**What does this change?**

Adds the `<PlaceholderImage>` component.

**Why?**

A good placeholder image will fill a space where an image is expected but not available at page or widget load. This can be used to avoid an image, that was lazy loaded, changing the layout of a page or widget after presentation. This can be jarring for some users.

**How is it tested?**

Storybook

**How is it documented?**

Storybook

**Are light and dark themes considered?**

Yes

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
