### PR TITLE
Fix missing key in checkboxgroup each block

### DIFF
--- a/.changeset/check_box_each.md
+++ b/.changeset/check_box_each.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+CHANGED: added key to `#each` in `CheckboxGroup` to avoid checkboxes being duplicated if options changes.

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -91,7 +91,7 @@
 	{/if}
 
 	<div class={buttonsHidden ? '' : 'pl-[28px]'}>
-		{#each options as option}
+		{#each options as option (option.id)}
 			<Checkbox
 				id={option.id}
 				name={option.name}


### PR DESCRIPTION
**What does this change?**

Adds a key to the `<CheckboxGroup>` each Svelte block.

**Why?**

Avoids the each block showing the same entry multiple times when the options are updated. This mostly affects hot reloading in dev mode but may affect a production app in cases where a `<CheckboxGroup>` options is updated via other options.

**How is it tested?**

Temp storybook. Removed before commit.

**Is it complete?**

- [x] Have you included changeset file?
