### PR TITLE
[docs] add more docs for Header components

### DIFF
--- a/packages/ui/src/lib/header/Header.stories.svelte
+++ b/packages/ui/src/lib/header/Header.stories.svelte
@@ -1,19 +1,21 @@
 <script context="module" lang="ts">
 	import Header from './Header.svelte';
+	import HeaderItem from './HeaderItem.svelte';
+	import HeaderRight from './HeaderRight.svelte';
+	import HeaderTitle from './HeaderTitle.svelte';
+	import NavLink from './NavLink.svelte';
+	import NavLinks from './NavLinks.svelte';
+
 	export const meta = {
 		title: 'Ui/Header',
-		component: Header
+		component: Header,
+		subcomponents: { HeaderItem, HeaderRight, HeaderTitle, NavLink, NavLinks },
+		description: 'TEST!'
 	};
 </script>
 
 <script lang="ts">
 	import { Story, Template } from '@storybook/addon-svelte-csf';
-
-	import NavLink from './NavLink.svelte';
-	import NavLinks from './NavLinks.svelte';
-	import HeaderTitle from './HeaderTitle.svelte';
-	import HeaderRight from './HeaderRight.svelte';
-	import HeaderItem from './HeaderItem.svelte';
 </script>
 
 <Template let:args>

--- a/packages/ui/src/lib/header/Header.stories.svelte
+++ b/packages/ui/src/lib/header/Header.stories.svelte
@@ -9,7 +9,7 @@
 	export const meta = {
 		title: 'Ui/Header',
 		component: Header,
-		subcomponents: { HeaderItem, HeaderRight, HeaderTitle, NavLink, NavLinks },
+		subcomponents: { HeaderItem, HeaderRight, HeaderTitle, NavLink, NavLinks }
 	};
 </script>
 

--- a/packages/ui/src/lib/header/Header.stories.svelte
+++ b/packages/ui/src/lib/header/Header.stories.svelte
@@ -10,7 +10,6 @@
 		title: 'Ui/Header',
 		component: Header,
 		subcomponents: { HeaderItem, HeaderRight, HeaderTitle, NavLink, NavLinks },
-		description: 'TEST!'
 	};
 </script>
 

--- a/packages/ui/src/lib/header/Header.svelte
+++ b/packages/ui/src/lib/header/Header.svelte
@@ -1,5 +1,22 @@
+<!--
+@component
+This is a test...
+-->
+
+<script context="module" lang="ts">
+	/**
+	 * The `<Header>` component appears at the top of a page.
+	 * It typically includes the app name, links to other pages (if the app has multiple pages), and a login/logout control (if the app requires authentication).
+	 *
+	 * @component
+	 */
+
+	//export let a='';
+</script>
+
 <nav
 	class="w-screen flex items-center px-4 py-[.5rem] bg-core-grey-900 text-white text-left h-[50px] border-l-[5px] border-core-blue-500"
 >
+	<!-- Contents of the header (typically a combination of `<HeaderTitle>`, `<HeaderRight>`, `<NavLinks>`, and `<HeaderItem>` components) -->
 	<slot />
 </nav>

--- a/packages/ui/src/lib/header/Header.svelte
+++ b/packages/ui/src/lib/header/Header.svelte
@@ -1,8 +1,3 @@
-<!--
-@component
-This is a test...
--->
-
 <script context="module" lang="ts">
 	/**
 	 * The `<Header>` component appears at the top of a page.
@@ -10,8 +5,6 @@ This is a test...
 	 *
 	 * @component
 	 */
-
-	//export let a='';
 </script>
 
 <nav

--- a/packages/ui/src/lib/header/HeaderItem.svelte
+++ b/packages/ui/src/lib/header/HeaderItem.svelte
@@ -1,3 +1,7 @@
+<!--
+	`<HeaderItem>` is a container for content that appears in a `<Header>` but isn't a `NavLink` or `HeaderTitle`.
+-->
 <div class="flex flex-col px-4 py-2">
+	<!-- contents -->
 	<slot />
 </div>

--- a/packages/ui/src/lib/header/HeaderRight.svelte
+++ b/packages/ui/src/lib/header/HeaderRight.svelte
@@ -1,3 +1,8 @@
+<!--
+	A container for content to be positioned at the right-hand side of a `<Header>`.
+-->
+
 <div class="flex flex-grow items-center justify-end">
+	<!-- Contents of the header (typically a combination of `<NavLinks>` and `<HeaderItem>`) -->
 	<slot />
 </div>

--- a/packages/ui/src/lib/header/HeaderTitle.svelte
+++ b/packages/ui/src/lib/header/HeaderTitle.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
-	export let base = ''; // typcally imported from '$app/paths' then pased as prop
+	/**
+	 * Typically imported from `$app/paths` then passed as prop.
+	 * Used to construct link to homepage.
+	 */
+	export let base = '';
 </script>
 
-<a href={base || '/'}><span class="mr-4 text-lg"><slot /></span></a>
+<a href={base || '/'}
+	><span class="mr-4 text-lg">
+		<!-- The app title, possibly including an icon. -->
+		<slot />
+	</span></a
+>

--- a/packages/ui/src/lib/header/NavLink.svelte
+++ b/packages/ui/src/lib/header/NavLink.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+	/**
+	 * `<NavLink>` represents a single link.
+	 * The background color changes to indicate whether the target of the link is the current page.
+	 * */
 	import type { Readable } from 'svelte/store';
 
 	// really a Page is
@@ -6,9 +10,19 @@
 	// and the page store is Readable<Page<Record<string, string>, string | null>>
 	// but we use Readable<{url: {pathname: string}} as an approximation to avoid a dependency on SvelteKit
 
-	export let base = ''; // typcally imported from '$app/paths' then pased as prop
-	export let page: Readable<{ url?: { pathname: string } }>; // typically imported from '$app/stores then passed as prop
+	/**
+	 * The base URL: typically imported from `$app/paths` then passed as prop
+	 */
+	export let base = '';
 
+	/**
+	 * The current page store (typically imported from `$app/stores` then passed as prop).
+	 */
+	export let page: Readable<{ url?: { pathname: string } }>;
+
+	/**
+	 * The target of the link.
+	 */
 	export let target = '';
 
 	let classes: string;
@@ -34,6 +48,7 @@
 
 <div class={classes}>
 	<a href={`${base}/${target}`}>
+		<!-- contents of the link (text and/or an icon) -->
 		<slot />
 	</a>
 </div>

--- a/packages/ui/src/lib/header/NavLinks.svelte
+++ b/packages/ui/src/lib/header/NavLinks.svelte
@@ -1,3 +1,9 @@
+<!--
+A container for `<NavLink>` components.
+@component
+-->
+
 <div class="flex items-center">
+	<!-- one or more `<NavLink>` components -->
 	<slot />
 </div>


### PR DESCRIPTION
This adds some more docs for the header components.

It isn't perfect - for some reaosn Storybook doesn't seem to pick up `@component` comments for components with no props - but it is an improvement on the current docs.