### PR TITLE
Fix navlinks highlighting

### DIFF
--- a/.changeset/dfsas_fdsf_dfdsf.md
+++ b/.changeset/dfsas_fdsf_dfdsf.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: fix highlighting in `NavLink` component.

--- a/packages/ui/src/lib/header/NavLink.svelte
+++ b/packages/ui/src/lib/header/NavLink.svelte
@@ -33,7 +33,7 @@
 		if (!page) {
 			// no page store provided - we don't know whether or not we're on the page this links points at
 			classes = nonHighlightedClasses;
-		} else if (!target && $page.url?.pathname === '/') {
+		} else if (!target && $page.route?.header === '/') {
 			// we're currently on the homepage, and that is what this link points at
 			classes = highlightedClasses;
 		} else if (!!target && ($page.url?.pathname || '').endsWith(target)) {

--- a/packages/ui/src/lib/header/NavLink.svelte
+++ b/packages/ui/src/lib/header/NavLink.svelte
@@ -33,7 +33,7 @@
 		if (!page) {
 			// no page store provided - we don't know whether or not we're on the page this links points at
 			classes = nonHighlightedClasses;
-		} else if (!target && $page.route?.header === '/') {
+		} else if (!target && $page.route?.id === '/') {
 			// we're currently on the homepage, and that is what this link points at
 			classes = highlightedClasses;
 		} else if (!!target && ($page.url?.pathname || '').endsWith(target)) {


### PR DESCRIPTION
Currently a `NavLink` to the homepage (`/` route) of an app will never be highlighted when the app is deployed in production, as URLs have the structure `/<app-name>/route` rather than just `/route`, so `$page.url?pathname` will not match `/`.