### PR TITLE
make text in SidebarTabLabel non-selectable

### DIFF
--- a/.changeset/jnofiw-jspdfm-ndkls.md
+++ b/.changeset/jnofiw-jspdfm-ndkls.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: make text in `SidebarTabLabel` component non-selectable.

--- a/packages/ui/src/lib/sidebar/elements/sidebarTabs/SidebarTabLabel.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarTabs/SidebarTabLabel.svelte
@@ -55,7 +55,7 @@
 		horizontal: 'text-base py-2 px-4 flex items-center select-none'
 	};
 
-	$: tabLabelClasses = classNames(...themeClasses, orientationClasses[orientation]);
+	$: tabLabelClasses = classNames(...themeClasses, orientationClasses[orientation], 'select-none');
 </script>
 
 <div


### PR DESCRIPTION
This makes the text in SidebarTabLabel non-selectable.