### PR TITLE
enable registration of event handlers for svelte plots

### DIFF
--- a/packages/charts/src/lib/observablePlot/ObservablePlot.stories.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.stories.svelte
@@ -130,7 +130,7 @@
 					y: 'culmen_depth_mm',
 					stroke: 'black',
 					fill: 'white',
-					render: addClick(tooltipStore),
+					render: registerTooltip(tooltipStore),
 
 					/* need to expose as a channel before including in tooltip */
 					channels: {
@@ -250,7 +250,6 @@
 	</div>
 </Story>
 
-<Story name="Area chart">
 <!-- 
 	The example stories show how defaults can be over-riden to achieve chart specific styling.
 	For example the tratment of the Y axis relys on an insetLeft property on the Plot.X and manipulation of the margin and Plot.axisY component

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.stories.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.stories.svelte
@@ -49,7 +49,7 @@
 	} from './demo_data';
 
 	import DemoTooltip from './DemoTooltip.svelte';
-	import { addClick } from './ObservablePlot.svelte';
+	import { addEventHandler, registerTooltip } from './ObservablePlot.svelte';
 
 	const spec = {
 		style: {
@@ -79,6 +79,9 @@
 			Plot.dot(penguins, { x: 'culmen_length_mm', y: 'culmen_depth_mm' })
 		]
 	};
+
+	let clickedValue = undefined;
+	let clickedIndex = undefined;
 
 	const tooltipStore = writable();
 </script>
@@ -154,7 +157,6 @@
 				Plot.dot(penguins, {
 					x: 'culmen_length_mm',
 					y: 'culmen_depth_mm',
-					render: addClick(tooltipStore),
 					stroke: 'black',
 					fill: 'white',
 
@@ -221,7 +223,7 @@
 				Plot.dot(penguins, {
 					x: 'culmen_length_mm',
 					y: 'culmen_depth_mm',
-					render: addClick(tooltipStore),
+					render: registerTooltip(tooltipStore),
 					stroke: 'black',
 					fill: 'white'
 				})
@@ -234,6 +236,64 @@
 	>
 		<DemoTooltip slot="tooltip" />
 	</ObservablePlot>
+</Story>
+
+<!--
+	Using the `addEventHandler` function we can register an event handler for events (e.g, `click`, `mouseenter`, `mouseleave`) triggered by user interaction with an SVG mark.
+-->
+<Story name="With custom click interaction">
+	<ObservablePlot
+		spec={{
+			style: {
+				fontFamily: 'Roboto',
+				fontSize: '12pt',
+				color: '#666666'
+			},
+
+			grid: true,
+			marginBottom: 50,
+
+			x: {
+				labelAnchor: 'center',
+				labelArrow: 'none',
+				label: 'Culmen length/mm'
+			},
+
+			y: {
+				insetTop: 20,
+				labelArrow: 'none'
+			},
+
+			marks: [
+				Plot.ruleY([0], { stroke: '#666666' }),
+				Plot.ruleX([0], { stroke: '#666666' }),
+				Plot.dot(penguins, {
+					x: 'culmen_length_mm',
+					y: 'culmen_depth_mm',
+					render: addEventHandler('click', (ev, d) => {
+						clickedIndex = d.index;
+						clickedValue = penguins[d.index];
+					}),
+					stroke: 'black',
+					r: 5,
+					fill: (d, i) => {
+						return clickedIndex !== undefined && i === clickedIndex ? 'red' : 'white';
+					}
+				})
+			]
+		}}
+		title="Penguin Culmens"
+		subTitle="A scatterplot of depth against length"
+		data={penguins}
+		{tooltipStore}
+	>
+		<DemoTooltip slot="tooltip" />
+	</ObservablePlot>
+
+	<div>
+		Selected point:
+		<pre>{JSON.stringify(clickedValue, null, 2)}</pre>
+	</div>
 </Story>
 
 <Story name="Area chart">

--- a/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
+++ b/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
@@ -96,7 +96,7 @@ type generateAnnotationsConfig = {
 	 * However, if a mark is an `option` rather than `channel`, but the specified value is a function, then the function will be evaluated for the datum.
 	 * This means that you can specify `dx` as a function, without worrying about the fact the Observable Plot doesn't (currently) support this.
 	 */
-	options: Record<string, number | string | ((x: any) => any)>; // any; // object with ket
+	options?: Record<string, number | string | ((x: any) => any)>; // any; // object with ket
 
 	/**
 	 * Additional objects, expressed as functions that will be evaluated before Plot's mark function is called.
@@ -104,7 +104,7 @@ type generateAnnotationsConfig = {
 	 * this will be pre-processed so that plot sees either `fill: 'black'` (specifying a color constant) or `fill: 'GDPType` (speficying a field to be encoded using a color scale).
 	 * If this was not pre-processed, Observable Plot would apply a color encoding to the string literatal `'GDPType'` rather than the value of the field with that name.
 	 */
-	optionsToEval: Record<string, (x: any) => any>;
+	optionsToEval?: Record<string, (x: any) => any>;
 };
 
 export const preprocessOptions = (data: any[], config: generateAnnotationsConfig) => {


### PR DESCRIPTION
This provides a helper function to enable the registration of event handlers for marks in an Observable Plot plot.