### PR TITLE
WIP: start refactor of modals and tooltips

### DIFF
--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -6,12 +6,15 @@
 	 * **Alternatives**: to display shorter messages less intrusively, consider using a [Tooltip](./?path=/docs/ui-tooltip--documentation).
 	 * @component
 	 */
+	
+	import { setContext } from 'svelte';
 
 	import { createDialog } from '@melt-ui/svelte';
 	import { XMark } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
 	import { writable } from 'svelte/store';
 	import Button from '../button/Button.svelte';
+	import Trigger from '../tooltip/Trigger.svelte';
 	import { classNames } from '../utils/classNames';
 
 	/**
@@ -51,6 +54,9 @@
 		| '7xl'
 		| 'full' = 'md';
 
+	export let hintLabel = 'More info';
+	export let showTrigger = false;
+
 	const hasChildren = Object.keys($$slots).length > 0;
 
 	const widthClasses = {
@@ -72,7 +78,25 @@
 		'inline-block w-full max-h-full flex flex-col overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl pointer-events-auto',
 		widthClasses[width]
 	);
+
+	setContext('triggerFuncs', {
+		triggerClick: (element) => {
+			$open = true;
+		}
+	});
 </script>
+
+{#if showTrigger}
+	{#if $$slots.hint}
+		<Trigger>
+			<svelte:fragment slot="hint">
+				<slot name="hint" />
+			</svelte:fragment>
+		</Trigger>
+	{:else}
+		<Trigger {hintLabel} />
+	{/if}
+{/if}
 
 <div {...$portalled} use:$portalled.action>
 	{#if $open}

--- a/packages/ui/src/lib/sidebar/elements/sidebarHint/SidebarHint.stories.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarHint/SidebarHint.stories.svelte
@@ -28,7 +28,17 @@
 	</SidebarHint></Template
 >
 
-<Story name="Default (Modal)" source />
+<Story name="Default (tooltip)" source />
+
+<Story name="Modal" source>
+	<SidebarHint hintType="modal">
+		'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+		labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+		laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+		voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+		non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+	</SidebarHint>
+</Story>
 
 <Story name="Modal width" source>
 	<SidebarHint hintType="modal" modalWidth="5xl">

--- a/packages/ui/src/lib/sidebar/elements/sidebarHint/SidebarHint.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarHint/SidebarHint.svelte
@@ -4,6 +4,7 @@
 	 * @component
 	 */
 
+	import Modal from '../../../modal/Modal.svelte';
 	import Tooltip from '../../../tooltip/Tooltip.svelte';
 	import SidebarHintModal from './SidebarHintModal.svelte';
 
@@ -57,8 +58,12 @@
 		<slot />
 	</Tooltip>
 {:else if hintType === 'modal'}
-	<SidebarHintModal {hintLabel} {modalTitle} {modalDescription} {modalWidth}>
+	<Modal title={modalTitle || ''} description={modalDescription} width={modalWidth} showTrigger>
+		<svelte:fragment slot="hintText">
+			{hintLabel}
+		</svelte:fragment>
+
 		<!-- The help message. -->
 		<slot />
-	</SidebarHintModal>
+	</Modal>
 {/if}

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -11,11 +11,8 @@
 	import { writable, type Writable } from 'svelte/store';
 	import { floatingContent } from './tooltip';
 
-	import { InformationCircle } from '@steeze-ui/heroicons';
-	import { Icon } from '@steeze-ui/svelte-icon';
-
-	import Button from '../button/Button.svelte';
-	import { floatingRef } from '../tooltip/tooltip.js';
+	import { setContext } from 'svelte';
+	import Trigger from './Trigger.svelte';
 
 	/**
 	 * text that appears in the tooltip target, next to the icon
@@ -28,8 +25,6 @@
 	export let hintSize: 'sm' | 'md' | 'lg' | undefined = undefined;
 
 	let showTooltip = false;
-
-	let element: HTMLSpanElement;
 
 	const arrowRef: Writable<HTMLElement> = writable();
 	let dynamicOptions = {};
@@ -53,35 +48,17 @@
 			}
 		};
 	}
-</script>
 
-<Button variant="text" size={hintSize} class="!p-0 !text-core-grey-400 dark:!text-core-grey-300">
-	<span
-		use:floatingRef
-		bind:this={element}
-		on:mouseenter={() => {
+	setContext('triggerFuncs', {
+		triggerMouseEnter: (element) => {
 			showTooltip = true;
 			floatingRef(element);
-		}}
-		on:mouseleave|stopPropagation={() => (showTooltip = false)}
-		role="tooltip"
-		class="inline-flex items-center"
-	>
-		{#if $$slots.hint}
-			<!-- if present, replaces the default `hintLabel` and icon  -->
-			<slot name="hint" />
-		{:else}
-			{hintLabel}
+		},
+		triggerMouseLeave: () => (showTooltip = false)
+	});
+</script>
 
-			<Icon
-				src={InformationCircle}
-				theme="solid"
-				class="w-[18px] h-[18px] ml-0.5"
-				aria-hidden="true"
-			/>
-		{/if}
-	</span>
-</Button>
+<Trigger {hintSize} {hintLabel} />
 
 {#if showTooltip}
 	<div

--- a/packages/ui/src/lib/tooltip/Trigger.svelte
+++ b/packages/ui/src/lib/tooltip/Trigger.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { InformationCircle } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+
+	import { getContext } from 'svelte';
+	import Button from '../button/Button.svelte';
+	import { floatingRef } from '../tooltip/tooltip.js';
+
+	/**
+	 * text that appears in the tooltip target, next to the icon
+	 */
+	export let hintLabel = 'what is this?';
+
+	/**
+	 * text size for the tooltip target
+	 */
+	export let hintSize: 'sm' | 'md' | 'lg' | undefined = undefined;
+
+	const { triggerMouseEnter, triggerMouseLeave, triggerClick } = getContext('triggerFuncs');
+	let element;
+</script>
+
+<Button variant="text" size={hintSize} class="!p-0 !text-core-grey-400 dark:!text-core-grey-300">
+	<span
+		use:floatingRef
+		bind:this={element}
+		on:mouseenter={() => triggerMouseEnter(element)}
+		on:mouseleave|stopPropagation={triggerMouseLeave}
+        on:click={triggerClick}
+		role="tooltip"
+		class="inline-flex items-center"
+	>
+		{#if $$slots.hint}
+			<!-- if present, replaces the default `hintLabel` and icon  -->
+			<slot name="hint" />
+		{:else}
+			{hintLabel}
+
+			<Icon
+				src={InformationCircle}
+				theme="solid"
+				class="w-[18px] h-[18px] ml-0.5"
+				aria-hidden="true"
+			/>
+		{/if}
+	</span>
+</Button>


### PR DESCRIPTION
The idea is that each "help provider" (tooltip, popover, modal) can render both its "trigger" and it's content.

There is a standard `Trigger` component: it receives a context containing functions to call when it is interacted with.

This is a very incomplete WIP that I've added as a draft PR so I don't forget the idea.