### PR TITLE
Remove MapApp component

### DIFF
--- a/.changeset/map-app-del.md
+++ b/.changeset/map-app-del.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/map': major
+---
+
+REMOVED: `MapApp` component from maps package as replaced by `AppShell`.

--- a/packages/maps/src/lib/index.js
+++ b/packages/maps/src/lib/index.js
@@ -1,7 +1,6 @@
 // Map
 export * from './map/Map.svelte';
 export { default as Map } from './map/Map.svelte';
-export { default as MapApp } from './map/MapApp.svelte';
 
 // Controls
 export { default as MapControlFullscreen } from './mapControlFullscreen/MapControlFullscreen.svelte';

--- a/packages/maps/src/lib/map/Map.stories.svelte
+++ b/packages/maps/src/lib/map/Map.stories.svelte
@@ -54,25 +54,6 @@
 
 <Story name="Light OS Basemap">
 	<MapApp>
-		<div class="text-white space-y-4 m-2">
-			<p>
-				This is our default light basemap - it's the OS's <a
-					class="underline"
-					href="https://github.com/OrdnanceSurvey/OS-Vector-Tile-API-Stylesheets"
-				>
-					OS_VTS_3857_Light.json</a
-				> stylesheet. Like all OS base maps it requires an OS access token.
-			</p>
-
-			<p>
-				If you're creating a full page map, as opposed to a map integrated into a dashboard or data
-				explorer, then wrap the <code>{'<Map>'}</code>,
-				<code>{'<Sidebar>'}</code> and other map components within a
-				<code>{'<MapApp>'}</code> component. It manages no-script messages and layout that accounts for
-				different browser overlays.
-			</p>
-		</div>
-
 		<Map
 			options={{
 				style: os_light_vts,
@@ -84,17 +65,6 @@
 
 <Story name="Greyscale OS Basemap">
 	<MapApp>
-		<div class="text-white space-y-4 m-2">
-			<p>
-				This is the greyscale basemap used on the Cool Spaces map. - it's very similar to the OS's <a
-					class="underline"
-					href="https://github.com/OrdnanceSurvey/OS-Vector-Tile-API-Stylesheets"
-				>
-					OS_VTS_3857_Greyscale.json</a
-				> stylesheet, with a few tweaks.
-			</p>
-		</div>
-
 		<Map
 			options={{
 				style: greyStyle,
@@ -121,17 +91,6 @@
 
 <Story name="Dark OS Basemap">
 	<MapApp>
-		<div class="text-white space-y-4 m-2">
-			<p>
-				This was created by the OS, inspired by Mike Brondbjerg's dark gray theme with muted
-				buildings. It is <a
-					class="underline"
-					href="https://github.com/OrdnanceSurvey/OS-Vector-Tile-API-Stylesheets"
-					>OS_VTS_3857_Dark.json</a
-				>
-			</p>
-		</div>
-
 		<Map
 			options={{
 				style: darkStyle,
@@ -143,20 +102,6 @@
 
 <Story name="Properties">
 	<MapApp>
-		<div class="text-white space-y-4 m-2">
-			<p>
-				The <code>{'whenMapLoads'}</code> and <code>{'whenMapUnloads'}</code> props are functions
-				called when the <code>{'<Map>'}</code> component mounts and unmounts respectively. In this example
-				a simple click listener is attached to the map which prints out the layer IDs where a feature
-				exists at the click location.
-			</p>
-
-			<p>
-				The <code>{'options'}</code> prop allows users to override and extend the GLA default MapLibre
-				options. Use it to specify a map style specification and append the OS key.
-			</p>
-		</div>
-
 		<Map
 			{whenMapLoads}
 			{whenMapUnloads}

--- a/packages/maps/src/lib/mapControlFullscreen/MapControlFullscreen.stories.svelte
+++ b/packages/maps/src/lib/mapControlFullscreen/MapControlFullscreen.stories.svelte
@@ -9,7 +9,6 @@
 	import MapControlFullscreen from '../mapControlFullscreen/MapControlFullscreen.svelte';
 
 	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
-	let map = null;
 </script>
 
 <Meta
@@ -26,29 +25,14 @@
 
 <Story name="Fullscreen Button">
 	<MapApp>
-		<div class="text-white space-y-4 m-2">
-			<p>
-				The fullscreen button is usually positioned in the bottom left corner above the refresh page
-				button.
-			</p>
-
-			<p>
-				If this page is embedded then clicking the button takes the user to the map page else the <a
-					class="underline"
-					href="https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API">Fullscreen API</a
-				> is invoked. The button icon will change depending on the mode.
-			</p>
-		</div>
-
 		<Map
-			whenMapLoads={(m) => (map = m)}
 			options={{
 				style: os_light_vts,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>
 			<MapControlGroup position="BottomLeft">
-				<MapControlFullscreen {map} />
+				<MapControlFullscreen />
 			</MapControlGroup>
 		</Map>
 	</MapApp>

--- a/packages/maps/src/lib/mapControlPan/MapControlPan.stories.svelte
+++ b/packages/maps/src/lib/mapControlPan/MapControlPan.stories.svelte
@@ -25,25 +25,6 @@
 
 <Story name="Pan Buttons">
 	<MapApp>
-		<div class="text-white space-y-4 m-2">
-			<p>
-				The zoom buttons are usually positioned in the top left corner under the location search.
-				They enable <a
-					class="underline"
-					href="https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/#zoomin"
-				>
-					zoom in
-				</a>
-				and
-				<a
-					class="underline"
-					href="https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/#zoomout"
-				>
-					zoom out
-				</a> by one zoom level per click.
-			</p>
-		</div>
-
 		<Map
 			options={{
 				style: os_light_vts,

--- a/packages/maps/src/lib/mapControlRefresh/MapControlRefresh.stories.svelte
+++ b/packages/maps/src/lib/mapControlRefresh/MapControlRefresh.stories.svelte
@@ -25,13 +25,6 @@
 
 <Story name="Refresh Button">
 	<MapApp>
-		<div class="text-white space-y-4 m-2">
-			<p>
-				The refresh page button is usually positioned in the bottom left corner under the fullscreen
-				button.
-			</p>
-		</div>
-
 		<Map
 			options={{
 				style: os_light_vts,

--- a/packages/maps/src/lib/mapControlZoom/MapControlZoom.stories.svelte
+++ b/packages/maps/src/lib/mapControlZoom/MapControlZoom.stories.svelte
@@ -25,25 +25,6 @@
 
 <Story name="Zoom Buttons">
 	<MapApp>
-		<div class="text-white space-y-4 m-2">
-			<p>
-				The zoom buttons are usually positioned in the top left corner under the location search.
-				They enable <a
-					class="underline"
-					href="https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/#zoomin"
-				>
-					zoom in
-				</a>
-				and
-				<a
-					class="underline"
-					href="https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/#zoomout"
-				>
-					zoom out
-				</a> by one zoom level per click.
-			</p>
-		</div>
-
 		<Map
 			options={{
 				style: os_light_vts,


### PR DESCRIPTION
**What does this change?**

Removes the `<MapApp>` component that was used as an application shell for maps.

**Why?**

It's been replaced by `<AppShell>`.

**How?**

Removed from _packages/maps/src/lib/index.js_.

- [x] Have you included changeset file?
