### PR TITLE
don't use the crypto API to generate random ids

### DIFF
--- a/.changeset/sdad_adasd_fsdf.md
+++ b/.changeset/sdad_adasd_fsdf.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': major
+---
+
+CHANGED: fix errors that occured when using components in non-secure context without specifying an id

--- a/packages/ui/src/lib/utils/randomId.ts
+++ b/packages/ui/src/lib/utils/randomId.ts
@@ -1,11 +1,11 @@
 // randomId returns a random twelve character string. It is suitable as a
 // unique ID for non-cryptographic applications, e.g. HTML element id.
 export const randomId = () => {
-    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+	const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
 	let result = '';
-	for (let i=0; i < 12; i++) {
-      result += characters.charAt(Math.floor(Math.random() * characters.length));
-    }
-    return result;
+	for (let i = 0; i < 12; i++) {
+		result += characters.charAt(Math.floor(Math.random() * characters.length));
+	}
+	return result;
 };

--- a/packages/ui/src/lib/utils/randomId.ts
+++ b/packages/ui/src/lib/utils/randomId.ts
@@ -1,6 +1,11 @@
 // randomId returns a random twelve character string. It is suitable as a
 // unique ID for non-cryptographic applications, e.g. HTML element id.
 export const randomId = () => {
-	const uuid = crypto.randomUUID();
-	return uuid.slice(uuid.length - 12);
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+	let result = '';
+	for (let i=0; i < 12; i++) {
+      result += characters.charAt(Math.floor(Math.random() * characters.length));
+    }
+    return result;
 };


### PR DESCRIPTION
Currently, ids are randomly generated using the `crypto.randomUUID()` function. 

However, the Crypto web api is only available in a secure context, which results in errors when serving apps over HTTP during local development/testing.