### PR TITLE
Unfix sidebar header

### DIFF
--- a/.changeset/unfix-sidebar-header.md
+++ b/.changeset/unfix-sidebar-header.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: unfix `SidebarHeader` component so it scrolls with other sidebar content.

--- a/packages/ui/src/lib/sidebar/Sidebar.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.svelte
@@ -83,14 +83,14 @@
 					$$slots.tabs && placement === 'left' ? 'ml-[80px]' : ''
 				)}
 			>
-				{#if $$slots.header}
-					<div class="p-6 pb-0">
-						<!-- typically contains a `<SidebarHeader>` -->
-						<slot name="header" />
-					</div>
-				{/if}
-
 				{#if $$slots.unstyledContent}
+					{#if $$slots.header}
+						<div class="pb-4">
+							<!-- typically contains a `<SidebarHeader>` -->
+							<slot name="header" />
+						</div>
+					{/if}
+
 					<!-- can be used to display completely unstyled content - usually not required-->
 					<slot name="unstyledContent" />
 
@@ -98,7 +98,14 @@
 					<slot name="footer" />
 				{:else}
 					<div class="overflow-y-auto flex flex-col h-full pt-6 px-6">
-						{#if $$slots.sections}
+						{#if $$slots.header}
+							<div class="pb-4">
+								<!-- typically contains a `<SidebarHeader>` -->
+								<slot name="header" />
+							</div>
+						{/if}
+
+						{#if $$slots.sections || $$slots.header}
 							<div class="space-y-4">
 								<!-- contains main sidebar content - typically a sequence of `<SidebarSection>`s -->
 								<slot name="sections" />


### PR DESCRIPTION
**What does this change?**

Unfix the sidebar header so it scrolls with the section content

**Why?**

Because on small screens it leaves next to no real estate for the content. Users find it hard to see content.

**Is it complete?**

- [x] Have you included changeset file?
