### PR TITLE
Create media query stores motion and dark mode

### DIFF
--- a/.changeset/ffa-sfa-fadas.md
+++ b/.changeset/ffa-sfa-fadas.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+ADDED: add `Theme` and `ThemeSwitcher` components

--- a/.changeset/ggs-fsgse-adasd.md
+++ b/.changeset/ggs-fsgse-adasd.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/utils': minor
+---
+
+ADDED: add `mediaQueryStore`, `prefersDarkMode`, `prefersReducedMotion` functions

--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -14,6 +14,8 @@ const config: StorybookConfig = {
 		'../src/**/*.mdx',
 		'../../../packages/ui/src/**/*.mdx',
 		'../../../packages/ui/src/**/*.stories.@(js|ts|svelte)',
+		'../../../packages/utils/src/**/*.mdx',
+		'../../../packages/utils/src/**/*.stories.@(js|ts|svelte)',
 		'../../../packages/charts/src/**/*.mdx',
 		'../../../packages/charts/src/**/*.stories.@(js|jsx|ts|tsx|svelte)',
 		'../../../packages/maps/src/**/*.mdx',

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -72,4 +72,7 @@ export { default as AnalyticsAndCookieConsent } from './analytics/AnalyticsAndCo
 export { default as PageMetadata } from './pageMetadata/PageMetadata.svelte';
 export { default as PlaceholderImage } from './placeholderImage/PlaceholderImage.svelte';
 
+export { default as Theme } from './themeSwitcher/Theme.svelte';
+export { default as themeSwitcher } from './themeSwitcher/ThemeSwitcher.svelte';
+
 export { classNames } from './utils/classNames';

--- a/packages/ui/src/lib/themeSwitcher/Theme.svelte
+++ b/packages/ui/src/lib/themeSwitcher/Theme.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { onMount } from 'svelte';
+
+	import { prefersDarkMode } from '@ldn-viz/utils';
+	import { currentThemeMode, userThemeSelectionStore } from './themeStore';
+
+	$: $prefersDarkMode, applyTheme();
+	$: $userThemeSelectionStore, applyTheme();
+
+	const applyTheme = () => {
+		if (browser) {
+			document.documentElement.classList.toggle(
+				'dark',
+				$currentThemeMode === 'dark' ? true : false
+			);
+		}
+		globalThis.localStorage?.setItem('theme', $userThemeSelectionStore);
+	};
+
+	onMount(() => {
+		applyTheme();
+	});
+</script>
+
+<!-- Prevent FOUC -->
+<svelte:head>
+	<script>
+		var userPref = globalThis.localStorage?.getItem('theme');
+		document.documentElement.classList.toggle('dark', userPref === 'dark' ? true : false);
+	</script>
+</svelte:head>

--- a/packages/ui/src/lib/themeSwitcher/Theme.svelte
+++ b/packages/ui/src/lib/themeSwitcher/Theme.svelte
@@ -23,7 +23,7 @@
 	});
 </script>
 
-<!-- Prevent FOUC -->
+<!-- Prevent FOUC (Flash of Unstyled Content) -->
 <svelte:head>
 	<script>
 		var userPref = globalThis.localStorage?.getItem('theme');

--- a/packages/ui/src/lib/themeSwitcher/ThemeSwitcher.stories.svelte
+++ b/packages/ui/src/lib/themeSwitcher/ThemeSwitcher.stories.svelte
@@ -1,0 +1,20 @@
+<script context="module">
+	import Theme from './Theme.svelte';
+	import ThemeSwitcher from './ThemeSwitcher.svelte';
+
+	export const meta = {
+		title: 'Ui/ThemeSwitcher',
+		component: ThemeSwitcher
+	};
+</script>
+
+<script lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+</script>
+
+<Template let:args>
+	<Theme />
+	<ThemeSwitcher {...args} />
+</Template>
+
+<Story name="Default" source />

--- a/packages/ui/src/lib/themeSwitcher/ThemeSwitcher.svelte
+++ b/packages/ui/src/lib/themeSwitcher/ThemeSwitcher.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	/**
+	 * The `<ThemeSwitcher>` component provides a select for the current theme - light, dark or system.
+	 *
+	 * **WIP**: Currently uses a select component pending ui design review
+	 *
+	 * **Important**: Requires the inclusion of the sibling "Theme" component. This should be implemented in the top level Layout component of the app. The theme switcher can then live at any level(s)
+	 *
+	 * @component
+	 */
+	import { Select } from '@ldn-viz/ui';
+	import { userThemeSelectionStore } from './themeStore';
+	type Theme = 'light' | 'dark' | 'system';
+
+	const themes: Theme[] = ['light', 'dark', 'system'];
+
+	function onChange(e: { detail: { [key: string]: string } }) {
+		const value = e.detail.value as Theme;
+		$userThemeSelectionStore = value;
+	}
+
+	const items = themes.map((theme) => ({ value: theme, label: theme }));
+	const initialItem = $userThemeSelectionStore;
+</script>
+
+<Select {items} value={initialItem} on:change={onChange} id="theme-switch" label="Theme" />

--- a/packages/ui/src/lib/themeSwitcher/themeStore.ts
+++ b/packages/ui/src/lib/themeSwitcher/themeStore.ts
@@ -1,0 +1,26 @@
+import { browser } from '$app/environment';
+import { prefersDarkMode } from '@ldn-viz/utils';
+import { derived, writable, type Readable } from 'svelte/store';
+
+const getLocalStorage = () => {
+	if (browser) {
+		return globalThis.localStorage?.getItem('theme') || 'light';
+	}
+	return 'light';
+};
+
+export const userThemeSelectionStore = writable(getLocalStorage());
+
+export const currentThemeMode: Readable<'light' | 'dark'> = derived(
+	[userThemeSelectionStore, prefersDarkMode],
+	([$userThemeSelectionStore, $prefersDarkMode]) => {
+		return $userThemeSelectionStore === 'dark'
+			? 'dark'
+			: $prefersDarkMode
+				? $userThemeSelectionStore === 'light'
+					? 'light'
+					: 'dark'
+				: 'light';
+	},
+	'light'
+);

--- a/packages/utils/src/main.ts
+++ b/packages/utils/src/main.ts
@@ -1,1 +1,6 @@
 export { getColorRamp, getThresholdBreaksColorsLabels } from './colors/scales';
+export {
+  mediaQueryStore,
+  prefersDarkMode,
+  prefersReducedMotion
+} from './userPreference/mediaQueryStore';

--- a/packages/utils/src/userPreference/Documentation.mdx
+++ b/packages/utils/src/userPreference/Documentation.mdx
@@ -1,0 +1,23 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Utils/Media Query Stores" />
+
+# Media Query Stores
+
+The `@ldn-viz/utils` package exposes three store factory functions.
+
+- `mediaQueryStore` accepts a CSS [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) (e.g. `'(prefers-reduced-motion)`) as an argument, and returns a Svelte store that is initialized to the value of the media query, and automatically updates if this changes
+
+- `prefersDarkMode()` is a convenience wrapper around `mediaQueryStore`: it returns a store that records whether the user has set [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) to `dark`
+
+- `prefersReducedMotion()` is a convenience wrapper around `mediaQueryStore`: it returns a store that records whether the user has enabled the [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) setting
+
+## Example use
+
+```js
+import { prefersDarkMode } from '@ldn-viz/utils';
+
+const darkMode = prefersDarkMode();
+
+$: console.log('Dark mode is ', $darkMode ? 'enabled' : 'disabled');
+```

--- a/packages/utils/src/userPreference/mediaQueryStore.ts
+++ b/packages/utils/src/userPreference/mediaQueryStore.ts
@@ -1,0 +1,39 @@
+// import { browser } from '$app/environment';
+import { BROWSER } from 'esm-env';
+import { writable } from 'svelte/store';
+
+export const mediaQueryStore = (mediaQueryString: string) => {
+  const initialiseUserPrefListner = (mediaQuery: MediaQueryList, callback: () => void) => {
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', callback);
+    } else {
+      mediaQuery.addListener(callback);
+    }
+  };
+
+  const destroyUserPrefListner = (mediaQuery: MediaQueryList, callback: () => void) => {
+    if (mediaQuery.removeEventListener) {
+      mediaQuery.removeEventListener('change', callback);
+    } else {
+      mediaQuery.removeListener(callback);
+    }
+  };
+
+  const { subscribe, set } = writable(false, () => {
+    if (BROWSER) {
+      let mql = window.matchMedia(mediaQueryString);
+
+      set(mql.matches);
+      const onchange = () => set(mql.matches);
+      initialiseUserPrefListner(mql, onchange);
+      return () => {
+        destroyUserPrefListner(mql, onchange);
+      };
+    }
+  });
+
+  return { subscribe };
+};
+
+export const prefersDarkMode = mediaQueryStore('(prefers-color-scheme:dark)');
+export const prefersReducedMotion = mediaQueryStore('(prefers-reduced-motion)');

--- a/packages/utils/src/userPreference/mediaQueryStore.ts
+++ b/packages/utils/src/userPreference/mediaQueryStore.ts
@@ -1,4 +1,3 @@
-// import { browser } from '$app/environment';
 import { BROWSER } from 'esm-env';
 import { writable } from 'svelte/store';
 


### PR DESCRIPTION
**What does this change?**
Creates a mediaQueryStore factory function that listens to user preferences. Exposes two svelte stores that have boolean values for prefersDarkMode and prefersReducedMotion

**Why?**
Used for theme switching and animation accessibility settings

**How?**
see mediaQueryStore code

**Related issues**:
#250 

**Does this introduce new dependencies?**
no

**How is it tested?**
storybook

**How is it documented?**

**Are light and dark themes considered?**
yes

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
