### PR TITLE
allow SidebarSection component to accept a SidebarSectionTitle compon…

### DIFF
--- a/.changeset/sfsdf-fsdfsdf-fsdfsdf.md
+++ b/.changeset/sfsdf-fsdfsdf-fsdfsdf.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: the `<SidebarSection>` component can now accept a `<SidebarSectionTitle>` component inside the `title` slot.

--- a/packages/ui/src/lib/sidebar/elements/sidebarSection/SidebarSection.stories.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarSection/SidebarSection.stories.svelte
@@ -11,6 +11,7 @@
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 	import SidebarHint from '../sidebarHint/SidebarHint.svelte';
 	import SidebarGroupTitle from './sidebarGroupTitle/SidebarGroupTitle.svelte';
+	import SidebarSectionTitle from './sidebarSectionTitle/SidebarSectionTitle.svelte';
 </script>
 
 <Template let:args>
@@ -24,6 +25,39 @@
 <Story name="With Titled Group" source>
 	<SidebarSection title="Section Title">
 		Section Content
+		<div>
+			<SidebarGroupTitle>
+				Pay Attention to this group
+				<SidebarHint slot="hint" hintType="modal" hintLabel="why">
+					Beacuse it's Awesome!
+				</SidebarHint>
+			</SidebarGroupTitle>
+			Grouped content
+		</div>
+	</SidebarSection>
+</Story>
+
+<!-- You can add a subtitle or hint text by providing a `<SidebarSection>` component within the `title` slot. -->
+<Story name="With SidebarSectionTitle component" source>
+	<SidebarSection title="Section Title">
+		<svelte:fragment slot="title">
+			<SidebarSectionTitle>
+				<svelte:fragment>The title of this section</svelte:fragment>
+
+				<svelte:fragment slot="subTitle">The sub-title of ths section.</svelte:fragment>
+
+				<SidebarHint slot="hint" hintLabel="About">
+					This popover should provide some additional explanation about this section.
+				</SidebarHint>
+			</SidebarSectionTitle>
+		</svelte:fragment>
+
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+		labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+		laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+		voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+		non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
 		<div>
 			<SidebarGroupTitle>
 				Pay Attention to this group

--- a/packages/ui/src/lib/sidebar/elements/sidebarSection/SidebarSection.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarSection/SidebarSection.svelte
@@ -8,7 +8,7 @@
 	import SidebarSectionTitle from './sidebarSectionTitle/SidebarSectionTitle.svelte';
 
 	/**
-	 * The title of this section.
+	 * The title of this section. Note tat rather than supplying a title, you can supply a `<SidebarSectionTitle>` component in the `title` slot.
 	 */
 	export let title = '';
 
@@ -25,7 +25,13 @@
 
 <section>
 	<div class={sectionClasses}>
-		<SidebarSectionTitle>{title}</SidebarSectionTitle>
+		{#if $$slots.title}
+			<!-- An optional `<SidebarSectionTitle>` component, which can accept a subtitle. -->
+			<slot name="title" />
+		{:else}
+			<SidebarSectionTitle>{title}</SidebarSectionTitle>
+		{/if}
+
 		<!-- The content to be displayed inside this section. -->
 		<slot />
 	</div>

--- a/packages/ui/src/lib/sidebar/elements/sidebarSection/SidebarSection.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarSection/SidebarSection.svelte
@@ -18,7 +18,7 @@
 	const themeClasses = [darkThemeClasses, lightThemeClasses];
 
 	$: sectionClasses = classNames(
-		'border-b border-core-grey-600 space-y-2 pb-2 text-sm',
+		'border-b border-core-grey-600 space-y-4 pb-2 text-sm',
 		...themeClasses
 	);
 </script>

--- a/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarGroupTitle/SidebarGroupTitle.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarGroupTitle/SidebarGroupTitle.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <div class={groupTitleClasses}>
-	<h3 class="font-bold text-sm">
+	<h3 class="font-semibold text-sm leading-snug">
 		<!-- The title. -->
 		<slot />
 	</h3>

--- a/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarSectionTitle/SidebarSectionTitle.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarSection/sidebarSectionTitle/SidebarSectionTitle.svelte
@@ -17,7 +17,7 @@
 
 <header class={headerClasses}>
 	<div class="flex justify-between items-end">
-		<h1 class="font-bold text-base">
+		<h1 class="font-semibold text-base leading-snug">
 			<!-- The title of the section. -->
 			<slot />
 		</h1>
@@ -29,7 +29,7 @@
 	</div>
 
 	{#if $$slots.subTitle}
-		<div class="text-sm">
+		<div class="text-xs leading-snug mb-2">
 			<!-- Optional longer subtitle to display below the main title. -->
 			<slot name="subTitle" />
 		</div>


### PR DESCRIPTION
This changes the `<SidebarSection>` component so that it can accept a `<SidebarSectionTitle>` component inside the `title` slot. This allows the use of a subtitle and help/hint text.