### PR TITLE
Fix same-site issues with embedded apps & CookieControl

### DIFF
--- a/.changeset/fix-embedded-analytics.md
+++ b/.changeset/fix-embedded-analytics.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+FIXED: `AnalyticsAndCookieConsent` component that when embedded due to tighter main website polices.

--- a/packages/ui/src/lib/analytics/AnalyticsAndCookieConsent.svelte
+++ b/packages/ui/src/lib/analytics/AnalyticsAndCookieConsent.svelte
@@ -173,22 +173,23 @@
 		};
 
 		ldnVizCivic.isCookieControlManagedByParent = function () {
-			if (!window.top || window === window.top) {
+			if (window.location === window.parent.location) {
 				return false;
 			}
 
 			try {
-				const londonGovDomains = ['london.gov.uk'];
-				const url = new URL(window.top.location.href);
+				const londonGovDomains = ['.london.gov.uk'];
+				const url = document.referrer;
+				const hostname = new URL(url).hostname;
 
-				for (const d of londonGovDomains) {
-					if (url.hostname.toLowerCase().endsWith(d)) {
+				for (const domain of londonGovDomains) {
+					if (hostname.endsWith(domain)) {
 						return true;
 					}
 				}
 
 				return false;
-			} catch (e) {
+			} catch (err) {
 				return false;
 			}
 		};
@@ -202,7 +203,7 @@
 		ldnVizCivic.reloadWhenCookieControlAdded = function () {
 			if (ldnVizCivic.hasCookieControl()) {
 				clearInterval(ldnVizCivic.intervalId);
-				console.warn(`[${ldnVizCivic.appName}] CookieControl has been added, reloading myself`);
+				console.warn(`[${ldnVizCivic.appName}] CookieControl detected, reloading myself`);
 				window.location.reload();
 			}
 		};
@@ -223,8 +224,6 @@
 	</script>
 
 	<script>
-		window.dataLayer = window.dataLayer || [];
-
 		(function (w, d, s, l, i) {
 			w[l] = w[l] || [];
 			w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });


### PR DESCRIPTION
**What does this change?**

Fixes an issue with `<AnalyticsAndCookieConsent>` component when embedded.

**Why?**

Tighter restrictions on the main website `www.london.gov.uk` caused a drop in permission when accessing the URL of `window.top`.

**How?**

This solution uses `document.referrer` to get the parent page URL instead.

The Digital Team are currently looking in to attributes and permissions issues regarding embedded apps (e.g. _Geolocation_ via _SameSite_ & _Secure_ policies). Their solution may prevent other future issues such as these.

**How is it tested?**

In Cool Spaces and Wild & Free apps.

**Is it complete?**

- [x] Have you included changeset file?
