### PR TITLE
Fix map geolocator so the pin can be cleared as intended

### DIFF
--- a/.changeset/fix-geolocator-pin.md
+++ b/.changeset/fix-geolocator-pin.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/tables': patch
+---
+
+FIXED: fix `<MapControlGeolocator>` so the pin can be cleared as intended

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlGeolocator.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlGeolocator.svelte
@@ -46,4 +46,4 @@
 	$: !showClearButton && clearFeature('geolocator', $mapStore);
 </script>
 
-<Geolocator onLocationFound={flyToLocation} {onSearchError} bind:showClearButton />
+<Geolocator allowClearButton onLocationFound={flyToLocation} {onSearchError} bind:showClearButton />


### PR DESCRIPTION
**What does this change?**

Fixes the `<MapControlGeolocator>` so the button for clearing the map pin is shown as intended.

**Why?**

The clear button should show after a successful search and pin drop but it was not.

**How is it tested?**

Storybook.

**Is it complete?**

- [x] Have you included changeset file?
