### PR TITLE
update PlaceholderImage component

### DIFF
--- a/.changeset/change-placeholder-image.md
+++ b/.changeset/change-placeholder-image.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: the `PlaceholderImage` component now contains a small fixed-size icon within a container. It no longer accepts props to control its styling.

--- a/packages/ui/src/lib/placeholderImage/PlaceholderImage.stories.svelte
+++ b/packages/ui/src/lib/placeholderImage/PlaceholderImage.stories.svelte
@@ -6,62 +6,14 @@
 	export const meta = {
 		title: 'Ui/PlaceholderImage',
 		component: PlaceholderImage,
-		argTypes: {
-			bgClass: {
-				control: { type: 'text' },
-				table: {
-					defaultValue: { summary: '' },
-					type: { summary: 'string' }
-				}
-			},
-			$$restprops: {
-				description: 'Any other props are passed through to `<svg>` element',
-				table: {
-					category: 'properties'
-				}
-			}
-		},
 		args: {}
 	};
 </script>
 
-<script>
-	let strokeClass = 'stroke-core-grey-400';
-</script>
-
 <Template let:args>
-	<div class="max-w-md">
+	<div class="max-w-md h-96">
 		<PlaceholderImage {...args} />
 	</div>
 </Template>
 
 <Story name="Default" source />
-
-<Story name="Stroke">
-	<div class="max-w-md">
-		<PlaceholderImage strokeClass="stroke-core-red-400 stroke-2" />
-	</div>
-</Story>
-
-<Story name="Changing stroke">
-	<Button on:click={() => (strokeClass = 'stroke-core-red-400')} condition="error">Make red</Button>
-	<Button on:click={() => (strokeClass = 'stroke-core-blue-600')}>Make blue</Button>
-
-	<div class="max-w-md">
-		<PlaceholderImage {strokeClass} />
-	</div>
-</Story>
-
-<Story name="Width and height">
-	<PlaceholderImage width="160" height="200" />
-</Story>
-
-<Story name="Width and height as classes">
-	<PlaceholderImage otherClasses="w-40 h-52" />
-</Story>
-
-<Story name="Fixed background colour">
-	<div class="max-w-md">
-		<PlaceholderImage bgClass="bg-core-grey-600" />
-	</div>
-</Story>

--- a/packages/ui/src/lib/placeholderImage/PlaceholderImage.svelte
+++ b/packages/ui/src/lib/placeholderImage/PlaceholderImage.svelte
@@ -10,43 +10,10 @@
 	 * @component
 	 */
 
-	import { classNames } from '../utils/classNames';
-
-	/**
-	 * Background classes to apply to both the `<svg>` and `<path>`.
-	 */
-	export let bgClass = `fill-white dark:fill-core-grey-800`;
-
-	/**
-	 * Classes to apply to the stroke.
-	 */
-	export let strokeClass = 'stroke-core-blue-600';
-
-	/**
-	 * Other classes to apply to the `<svg>`.
-	 */
-	export let otherClasses = '';
-
-	$: {
-		$$restProps.class = classNames(strokeClass, bgClass, otherClasses);
-	}
+	import { Photo } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
 </script>
 
-<svg
-	xmlns="http://www.w3.org/2000/svg"
-	viewBox="0 0 24 20"
-	preserveAspectRatio="none"
-	vector-effect="non-scaling-stroke"
-	fill="none"
-	stroke-width="0.5"
-	{...$$restProps}
->
-	<g transform="translate(0 -2)">
-		<path
-			class={bgClass}
-			stroke-linecap="round"
-			stroke-linejoin="round"
-			d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z"
-		/>
-	</g>
-</svg>
+<div class="bg-core-grey-200 text-core-grey-400 w-full h-full flex items-center justify-center">
+	<Icon src={Photo} class="h-12 w-12 p-1 stroke-1" />
+</div>

--- a/packages/ui/src/lib/placeholderImage/PlaceholderImage.svelte
+++ b/packages/ui/src/lib/placeholderImage/PlaceholderImage.svelte
@@ -15,5 +15,5 @@
 </script>
 
 <div class="bg-core-grey-200 text-core-grey-400 w-full h-full flex items-center justify-center">
-	<Icon src={Photo} class="h-12 w-12 p-1 stroke-1" />
+	<Icon src={Photo} class="h-8 w-8" />
 </div>


### PR DESCRIPTION
**What does this change?**

The `PlaceholderImage` component now contains a small fixed-size icon within a container. It no longer accepts props to control its styling

See https://github.com/Greater-London-Authority/ldn-viz-tools/issues/374

