### PR TITLE
Multi column encodings

### DIFF
--- a/.changeset/table-context-columns.svelte
+++ b/.changeset/table-context-columns.svelte
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/tables': minor
+---
+
+ADDED: the visual encoding applied to cells can also depend on the values in other column(s)

--- a/packages/tables/src/lib/core/renderers/TextCellWithUncertainty.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/TextCellWithUncertainty.stories.svelte
@@ -1,0 +1,33 @@
+<script context="module">
+	import TextCellWithUncertainty from './TextCellWithUncertainty.svelte';
+	export const meta = {
+		title: 'Tables/Encodings/TextCellWithUncertainty',
+		component: TextCellWithUncertainty,
+
+		argTypes: {
+			alignText: {
+				options: ['left', 'right', 'center'],
+				control: { type: 'radio' }
+			}
+		},
+
+		args: {
+			alignText: 'left'
+		}
+	};
+</script>
+
+<script lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+</script>
+
+<Template let:args>
+	<TextCellWithUncertainty value={'500 cars'} colorScale={() => 'red'} {...args} />
+</Template>
+
+<Story name="Default" source />
+
+<Story name="Example" source>
+	<TextCellWithUncertainty value={'Value that is known'} contextVals={[true]} />
+	<TextCellWithUncertainty value={'Value that is merely estimated'} contextVals={[false]} />
+</Story>

--- a/packages/tables/src/lib/core/renderers/TextCellWithUncertainty.svelte
+++ b/packages/tables/src/lib/core/renderers/TextCellWithUncertainty.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	/**
+	 * The `TextCellWithUncertainty` component formats a single value as text and displays it in a table cell.
+	 * The first entry of `contextVals` is interpreted as indicating whether the value is uncertain;
+	 * @component
+	 */
+	import { format } from 'd3-format';
+	import { classNames } from '../../utils/utilityFns.js';
+	import { Tooltip } from '@ldn-viz/ui';
+
+	export let value: number | string;
+
+	export let contextVals: boolean[] = [false];
+	export let alignText = 'left' | 'right' | 'center' | undefined;
+
+	export let formatString;
+	$: f = format(formatString ?? '');
+
+	const alignmentClasses = {
+		left: 'justify-start',
+		right: 'justify-end',
+		center: 'justify-center'
+	};
+
+	let alignmentClass;
+	$: alignmentClass = alignmentClasses[alignText ?? 'center'];
+
+	$: textColor = contextVals.length > 0 && !contextVals[0] ? 'rgb(134, 139, 142)' : 'black';
+</script>
+
+<!--
+<div class={classNames(`flex h-full p-2 items-center`, alignmentClass)}>
+  <span style="padding-right: 0.25em">{formatString ? f(value) : value}</span>
+    {#if contextVals.length >0 && contextVals[0]}
+    <Tooltip hintLabel="est"> This value is estimated, rather than known.</Tooltip>
+  {/if}
+</div>
+-->
+
+<div class={classNames(`flex h-full p-2 items-center`, alignmentClass)}>
+	<span style:color={textColor}>{formatString ? f(value) : value}</span>
+</div>

--- a/packages/tables/src/lib/core/renderers/TextCellWithUncertainty.svelte
+++ b/packages/tables/src/lib/core/renderers/TextCellWithUncertainty.svelte
@@ -6,7 +6,6 @@
 	 */
 	import { format } from 'd3-format';
 	import { classNames } from '../../utils/utilityFns.js';
-	import { Tooltip } from '@ldn-viz/ui';
 
 	export let value: number | string;
 
@@ -27,15 +26,6 @@
 
 	$: textColor = contextVals.length > 0 && !contextVals[0] ? 'rgb(134, 139, 142)' : 'black';
 </script>
-
-<!--
-<div class={classNames(`flex h-full p-2 items-center`, alignmentClass)}>
-  <span style="padding-right: 0.25em">{formatString ? f(value) : value}</span>
-    {#if contextVals.length >0 && contextVals[0]}
-    <Tooltip hintLabel="est"> This value is estimated, rather than known.</Tooltip>
-  {/if}
-</div>
--->
 
 <div class={classNames(`flex h-full p-2 items-center`, alignmentClass)}>
 	<span style:color={textColor}>{formatString ? f(value) : value}</span>

--- a/packages/tables/src/lib/introduction.mdx
+++ b/packages/tables/src/lib/introduction.mdx
@@ -14,7 +14,8 @@ It includes support for rendering visualizations inside table cells, and for ren
 
 - `core/lib`: these _functions_ manipulate tabular data, and create scales used by the renderers
 - `core/aggregateRenderers`: these _components_ render a visual encoding of an _array of values_ corresponding to the values of a particular column for multiple rows (provided as the `values` prop).
-- `core/renderers`: these _components_ render a visual encoding of a _single value_ corresponding to a single table cell (provided as the `value` prop)
+- `core/renderers`: these _components_ render a visual encoding of a _single value_ corresponding to a single table cell (provided as the `value` prop).
+  If requested by the specification, the value of additional columns for the same row will be provided as the `contextVals` prop.
 
 2. `table/`
 

--- a/packages/tables/src/lib/table/TableComplex.stories.svelte
+++ b/packages/tables/src/lib/table/TableComplex.stories.svelte
@@ -426,12 +426,73 @@
 		]
 	};
 
+	////
+	import TextCellWithUncertainty from '../core/renderers/TextCellWithUncertainty.svelte';
+
+	const dataUncertain = [
+		{
+			Name: 'Bar',
+			Age: 18,
+			age_known: true,
+			Sex: 'Female',
+			sex_known: true
+		},
+		{
+			Name: 'Foo',
+			Age: 12,
+			age_known: false,
+			Sex: 'Male',
+			sex_known: true
+		},
+		{
+			Name: 'Baz',
+			Age: 22,
+			age_known: true,
+			Sex: 'Male',
+			sex_known: false
+		},
+		{
+			Name: 'Foobar',
+			Age: 22,
+			age_known: false,
+			Sex: 'Male',
+			sex_known: false
+		}
+	];
+	const tableSpecUncertain = {
+		showColSummaries: false,
+		columns: [
+			{
+				short_label: 'Name',
+				cell: { renderer: 'TextCell', width: '100px' }
+			},
+
+			{
+				short_label: 'Age',
+				cell: { renderer: TextCellWithUncertainty, width: '100px', contextFields: ['age_known'] }
+			},
+
+			{
+				short_label: 'Sex',
+				cell: { renderer: TextCellWithUncertainty, width: '100px', contextFields: ['sex_known'] }
+			}
+		]
+	};
+
 	export let page = 1;
 </script>
 
 <Template let:args>
 	<Table data={dataBenchmarks} tableSpec={tableSpecBenchmarks} {...args} />
 </Template>
+
+<!--
+This example shows how the encoding used for a column can be influenced by the value of a second column.
+ In this case, some fields also have associated fields that record whether the value is known or merely estimated.
+ -->
+<Story name="Table with uncertain values in columns">
+	<Table data={dataUncertain} tableSpec={tableSpecUncertain} />
+</Story>
 
 <Story name="High Streets Benchmark Table" source>
 	<Table data={dataBenchmarks} tableSpec={tableSpecBenchmarks} allowSorting />

--- a/packages/tables/src/lib/table/rows/DataRow.svelte
+++ b/packages/tables/src/lib/table/rows/DataRow.svelte
@@ -26,6 +26,9 @@
 								colorScale={table.scales[col.short_label]}
 								posScale={table.posScales[col.short_label]}
 								value={row[col.short_label]}
+								contextVals={col.cell.contextFields
+									? col.cell.contextFields.map((c) => row[c])
+									: []}
 								extent={table.extents[col.short_label]}
 								{...col.cell}
 							/>


### PR DESCRIPTION
This enables the visual encoding applied to table cells to also depend on the values in other column(s).