### PR TITLE
fix styling on Input element when type=range

### DIFF
--- a/.changeset/fix-range-input.md
+++ b/.changeset/fix-range-input.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+FIXED: fix styling of `Input` element when `type='range'`

--- a/packages/ui/src/lib/input/Input.stories.svelte
+++ b/packages/ui/src/lib/input/Input.stories.svelte
@@ -150,5 +150,6 @@
 		<Input type="date" label="Date" name="date-input" />
 		<Input type="datetime-local" label="Datetime local" name="datetime-local-input" />
 		<Input type="file" label="File" name="file-input" />
+		<Input type="range" label="Range" name="range" />
 	</div>
 </Story>

--- a/packages/ui/src/lib/input/Input.svelte
+++ b/packages/ui/src/lib/input/Input.svelte
@@ -151,7 +151,7 @@
 		'dark:text-white',
 		'placeholder-core-grey-400',
 		'dark:placeholder-core-grey-300',
-		'form-input'
+		(type === 'range') ? '' : 'form-input',
 	);
 </script>
 


### PR DESCRIPTION
**What does this change?**

Fix styling of `Input` element when `type='range'`

See https://github.com/Greater-London-Authority/ldn-viz-tools/issues/407

**Is it complete?**

- [ ] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
