### PR TITLE
Tweak button alignment

### DIFF
--- a/.changeset/button-alignment.md
+++ b/.changeset/button-alignment.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+FIXED: fix alignment of tooltip trigger button

--- a/packages/ui/src/lib/button/Button.stories.svelte
+++ b/packages/ui/src/lib/button/Button.stories.svelte
@@ -33,7 +33,7 @@
 </script>
 
 <script lang="ts">
-	import { ArrowDownCircle } from '@steeze-ui/heroicons';
+	import { ArrowDownCircle, Camera } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 
@@ -112,6 +112,13 @@
 	}}
 >
 	<Button class="w-full">Custom classes applied</Button>
+</Story>
+
+<Story name="With Icon">
+	<Button>
+		Download as PNG
+		<Icon src={Camera} theme="solid" class="ml-2 w-6 h-6" aria-hidden="true" />
+	</Button>
 </Story>
 
 <Story name="With Link">

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -188,7 +188,7 @@
 	);
 </script>
 
-<div>
+<div class="flex">
 	<svelte:element
 		this={href ? 'a' : 'button'}
 		type={href ? undefined : type}


### PR DESCRIPTION
**What does this change?**

Fix alignment of tooltip trigger icon by applying flex class to outer `div` of `Button` component.


Before:

![image](https://github.com/user-attachments/assets/9123b1b0-ebd2-4068-8494-9f4f80f12466)


After:

![image](https://github.com/user-attachments/assets/8dcbfe59-2ca6-4c61-8900-2587ef0403df)


**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
