### PR TITLE
Default hint label

### DIFF
--- a/.changeset/default-input-hintext.md
+++ b/.changeset/default-input-hintext.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+CHANGED: the default hintLabel for an input is now "what is this?" (rather than an empty string)

--- a/packages/ui/src/lib/input/Input.stories.svelte
+++ b/packages/ui/src/lib/input/Input.stories.svelte
@@ -53,11 +53,7 @@
 
 <Story name="With tooltip - default hintLabel">
 	<div class="w-96">
-		<Input
-			label="Tooltip"
-			name="tooltip-input"
-			hintLabel="optional hint label"
-		/>
+		<Input label="Tooltip" name="tooltip-input" hintLabel="optional hint label" />
 	</div>
 </Story>
 

--- a/packages/ui/src/lib/input/Input.stories.svelte
+++ b/packages/ui/src/lib/input/Input.stories.svelte
@@ -51,7 +51,17 @@
 	</div>
 </Story>
 
-<Story name="With tooltip">
+<Story name="With tooltip - default hintLabel">
+	<div class="w-96">
+		<Input
+			label="Tooltip"
+			name="tooltip-input"
+			hintLabel="optional hint label"
+		/>
+	</div>
+</Story>
+
+<Story name="With tooltip - custom hintLabel">
 	<div class="w-96">
 		<Input
 			label="Tooltip"

--- a/packages/ui/src/lib/input/Input.svelte
+++ b/packages/ui/src/lib/input/Input.svelte
@@ -71,7 +71,7 @@
 	/**
 	 * Text to be displayed next to icon in tooltip trigger.
 	 */
-	export let hintLabel = 'what is this?';
+	export let hintLabel = 'more info';
 
 	/**
 	 * If `false`, then `required` attribute is applied to `<input>`.

--- a/packages/ui/src/lib/input/Input.svelte
+++ b/packages/ui/src/lib/input/Input.svelte
@@ -71,7 +71,7 @@
 	/**
 	 * Text to be displayed next to icon in tooltip trigger.
 	 */
-	export let hintLabel = '';
+	export let hintLabel = 'what is this?';
 
 	/**
 	 * If `false`, then `required` attribute is applied to `<input>`.


### PR DESCRIPTION
**What does this change?**

This setsa default hintLabel for Input components. 

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
