### PR TITLE
correctly set justValue when multiple is enabled for Select

### DIFF
--- a/.changeset/fix-select-multi-justvalue.md
+++ b/.changeset/fix-select-multi-justvalue.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: `Select` now correctly sets `justValue` prop when `multiple` is enabled

--- a/packages/ui/src/lib/select/Select.stories.svelte
+++ b/packages/ui/src/lib/select/Select.stories.svelte
@@ -20,6 +20,7 @@
 	];
 
 	let justValue: number | null;
+	let justValueMulti: number[] | null;
 	let error = '';
 </script>
 
@@ -154,6 +155,22 @@
 		<Button on:click={() => (justValue = null)}>Clear</Button>
 
 		<Select {items} bind:justValue id="labelled-input" />
+	</div>
+</Story>
+
+<Story name="Binding to justValue - multi">
+	<div class="w-[500px] flex flex-col gap-2">
+		<p>
+			You can bind directly to <code>justValue</code>, rather than <code>value</code> (which is an
+			object including the <code>label</code> as well as <code>value</code>)
+		</p>
+
+		<div>Current value: <span class="font-bold">{justValueMulti}</span></div>
+
+		<Button on:click={() => (justValueMulti = [1, 3])}>Reset to 1 and 3</Button>
+		<Button on:click={() => (justValueMulti = null)}>Clear</Button>
+
+		<Select {items} bind:justValue={justValueMulti} id="labelled-input" multiple />
 	</div>
 </Story>
 

--- a/packages/ui/src/lib/select/Select.svelte
+++ b/packages/ui/src/lib/select/Select.svelte
@@ -165,17 +165,36 @@
 
 	// respond to external change in justValue
 	const applyChangeFromjustValue = (newjustValue: any) => {
-		if (!value || newjustValue != value[itemValueField]) {
-			value = items.find((f) => f[itemValueField] === newjustValue);
+		if (multiple) {
+			// in this case, newjustValue and newValue are both arrays
+			if (
+				!value ||
+				JSON.stringify(newjustValue) != JSON.stringify(value.map((v) => v[itemValueField]))
+			) {
+				// check array cmp
+				value = items.filter((f) => (newjustValue ?? []).includes(f[itemValueField]));
+			}
+		} else {
+			if (!value || newjustValue != value[itemValueField]) {
+				value = items.find((f) => f[itemValueField] === newjustValue);
+			}
 		}
 	};
 	$: applyChangeFromjustValue(justValue);
 
 	// respond to changes in selection
 	const updatejustValueFromSelection = (newValue: { [key: string]: any }) => {
-		const newjustValue = newValue && newValue[itemValueField];
-		if (justValue !== newjustValue) {
-			justValue = newjustValue;
+		if (multiple) {
+			// in this case, newjustValue and newValue are both arrays
+			const newjustValue = newValue && newValue.map((v) => v[itemValueField]);
+			if (JSON.stringify(justValue) !== JSON.stringify(newjustValue)) {
+				justValue = newjustValue;
+			}
+		} else {
+			const newjustValue = newValue && newValue[itemValueField];
+			if (justValue !== newjustValue) {
+				justValue = newjustValue;
+			}
 		}
 	};
 	$: updatejustValueFromSelection(value);

--- a/packages/ui/src/lib/select/Select.svelte
+++ b/packages/ui/src/lib/select/Select.svelte
@@ -171,7 +171,6 @@
 				!value ||
 				JSON.stringify(newjustValue) != JSON.stringify(value.map((v) => v[itemValueField]))
 			) {
-				// check array cmp
 				value = items.filter((f) => (newjustValue ?? []).includes(f[itemValueField]));
 			}
 		} else {


### PR DESCRIPTION
**What does this change?**

Until this fix, `justValue` would remain `undefined` for a `Select` component with `multiple` select enabled.


**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
