### PR TITLE
Axis token

### DIFF
--- a/packages/themes/tokens/design-tokens.tokens.json
+++ b/packages/themes/tokens/design-tokens.tokens.json
@@ -2099,7 +2099,7 @@
           "chart": {
             "axis": {
               "type": "color",
-              "value": "{semantic.dark-mode.color.text.secondary}"
+              "value": "{semantic.dark-mode.color.text.primary}"
             },
             "grid": {
               "type": "color",


### PR DESCRIPTION
**What does this change?**
Fixes the chart axis token to be correct value

adresses: #403 