### PR TITLE
Hint icons

### DIFF
--- a/.changeset/ten-ads-smell.md
+++ b/.changeset/ten-ads-smell.md
@@ -2,4 +2,4 @@
 "@ldn-viz/ui": minor
 ---
 
-changes hint icons to be mini theme
+CHANGED: changes hint icons to be mini theme

--- a/.changeset/ten-ads-smell.md
+++ b/.changeset/ten-ads-smell.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/ui": minor
+---
+
+changes hint icons to be mini theme

--- a/packages/ui/src/lib/popover/Popover.svelte
+++ b/packages/ui/src/lib/popover/Popover.svelte
@@ -40,7 +40,7 @@
 
 		<Icon
 			src={InformationCircle}
-			theme="solid"
+			theme="mini"
 			class="w-[18px] h-[18px] ml-0.5"
 			aria-hidden="true"
 		/>

--- a/packages/ui/src/lib/sidebar/elements/sidebarHint/SidebarHintModal.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarHint/SidebarHintModal.svelte
@@ -35,7 +35,7 @@
 	class="!p-0 !text-core-grey-400 dark:!text-core-grey-300"
 >
 	{hintLabel}
-	<Icon src={InformationCircle} theme="solid" class="w-[18px] h-[18px] ml-0.5" aria-hidden="true" />
+	<Icon src={InformationCircle} theme="mini" class="w-[18px] h-[18px] ml-0.5" aria-hidden="true" />
 </Button>
 
 <Modal bind:isOpen title={modalTitle} description={modalDescription} width={modalWidth}>

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -76,7 +76,7 @@
 
 			<Icon
 				src={InformationCircle}
-				theme="solid"
+				theme="mini"
 				class="w-[18px] h-[18px] ml-0.5"
 				aria-hidden="true"
 			/>


### PR DESCRIPTION
**What does this change?**
changes hint Icons to use mini theme

**Why?**
the smaller icons give better clarity

**How?**
specify mini theme

**Related issues**:
#430 

**Does this introduce new dependencies?**
no

**How is it tested?**
-

**How is it documented?**
Storybook - with more coming in docs

**Are light and dark themes considered?**
n/a

**Is it complete?**

- [x] Have you included changeset file?
- [na] If this adds a new component, is it exported via `index.js`?
