### PR TITLE
Restore chevron to select component

### DIFF
--- a/.changeset/metal-crabs-look.md
+++ b/.changeset/metal-crabs-look.md
@@ -2,4 +2,4 @@
 "@ldn-viz/ui": minor
 ---
 
-Reinstate select chevron
+FIXED: Reinstate select chevron

--- a/.changeset/metal-crabs-look.md
+++ b/.changeset/metal-crabs-look.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/ui": minor
+---
+
+Reinstate select chevron

--- a/packages/ui/src/lib/select/Select.svelte
+++ b/packages/ui/src/lib/select/Select.svelte
@@ -155,7 +155,7 @@
 	export let hideEmptyState = false;
 
 	/**
-	 * if false Chevron is not shown.
+	 * if `false`, then Chevron is not shown.
 	 */
 	export let showChevron = true;
 

--- a/packages/ui/src/lib/select/Select.svelte
+++ b/packages/ui/src/lib/select/Select.svelte
@@ -155,6 +155,11 @@
 	export let hideEmptyState = false;
 
 	/**
+	 * if false Chevron is not shown.
+	 */
+	export let showChevron = true;
+
+	/**
 	 * if `false` will ignore width of select
 	 */
 	export let listAutoWidth = true;
@@ -216,6 +221,7 @@
 			{floatingConfig}
 			{disabled}
 			{placeholder}
+			{showChevron}
 			on:change
 			on:input
 			on:focus


### PR DESCRIPTION
**What does this change?**
Fixes missing chevron on select 

**Why?**
it was removed by mistake

**How?**
default showChevron prop to true

**Related issues**:
#475 

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
