### PR TITLE
CheckboxGroup and InputGroup group spacing

### DIFF
--- a/.changeset/rare-terms-marry.md
+++ b/.changeset/rare-terms-marry.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/ui": minor
+---
+
+vertical spacing for input and checkbox groups

--- a/.changeset/rare-terms-marry.md
+++ b/.changeset/rare-terms-marry.md
@@ -2,4 +2,4 @@
 "@ldn-viz/ui": minor
 ---
 
-vertical spacing for input and checkbox groups
+FIXED: correct vertical spacing for `InputGroup` and `CheckboxGroup`

--- a/packages/ui/src/lib/checkBox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.svelte
@@ -96,7 +96,7 @@
 			: ''}
 		{...$$restProps}
 	/>
-	<span class="mx-2 form-label">{label}</span>
+	<span class="ml-2 form-label">{label}</span>
 	{#if hint}
 		<Tooltip {hintLabel}>
 			{hint}

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
@@ -46,8 +46,10 @@
 <Story name="Checkbox Group - externally updated">
 	<Button on:click={() => (selectedOptions = ['bus', 'train'])}>Select bus and train!</Button>
 
-	<CheckboxGroup options={optionsForGroup} bind:selectedOptions buttonsHidden />
-	<p class="mt-8 text-core-grey-500 dark:text-core-grey-200 italic">
+	<div class="my-4">
+		<CheckboxGroup options={optionsForGroup} bind:selectedOptions buttonsHidden />
+	</div>
+	<p class="text-core-grey-500 dark:text-core-grey-200 italic">
 		selectedOptions: {JSON.stringify(selectedOptions)}
 	</p>
 </Story>

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -6,8 +6,8 @@
 	 * @component
 	 */
 
-	import Checkbox from './Checkbox.svelte';
 	import { randomId } from '../utils/randomId';
+	import Checkbox from './Checkbox.svelte';
 
 	/**
 	 * Each element of this array defines a checkbox, and is an object with the properties:
@@ -83,7 +83,7 @@
 	};
 </script>
 
-<div>
+<div class="flex flex-col space-y-1">
 	{#if !buttonsHidden}
 		<!--
 			form="" should prevent this checkbox from being included in form
@@ -100,7 +100,7 @@
 		/>
 	{/if}
 
-	<div class={buttonsHidden ? '' : 'pl-[28px]'}>
+	<div class={`flex flex-col space-y-0.25 ${buttonsHidden ? '' : 'pl-5'}`}>
 		{#each options as option (option.id)}
 			<Checkbox
 				id={option.id}

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
@@ -44,9 +44,9 @@
 	export let buttonsHidden = false;
 </script>
 
-<div>
+<div class="flex flex-col space-y-0.25">
 	{#if !buttonsHidden}
-		<Button variant="text" on:click={() => (selectedId = '')}>Clear</Button>
+		<Button variant="text" class="!px-0" on:click={() => (selectedId = '')}>Clear</Button>
 	{/if}
 	{#each options as option}
 		<RadioButton

--- a/packages/ui/src/lib/select/Select.svelte
+++ b/packages/ui/src/lib/select/Select.svelte
@@ -155,6 +155,11 @@
 	export let hideEmptyState = false;
 
 	/**
+	 * if false Chevron is not shown.
+	 */
+	export let showChevron = true;
+
+	/**
 	 * if `false` will ignore width of select
 	 */
 	export let listAutoWidth = true;
@@ -216,6 +221,7 @@
 			{floatingConfig}
 			{disabled}
 			{placeholder}
+			{showChevron}
 			on:change
 			on:input
 			on:focus


### PR DESCRIPTION
**What does this change?**
Explicitly sets vertical spacing for checkbox and radio group components

**Why?**
This was happening due to leading on the labels - which collapsed when in a text-sm context

**How?**
Added space classes to containing divs

**Related issues**:
#470 

**Does this introduce new dependencies?**
no

**How is it tested?**
storybook

**How is it documented?**
n/a

**Are light and dark themes considered?**
n/a

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
