### PR TITLE
edit Table stories to remove empty space below column headers

### DIFF
--- a/packages/tables/src/lib/table/Table.stories.svelte
+++ b/packages/tables/src/lib/table/Table.stories.svelte
@@ -34,6 +34,7 @@
 	];
 
 	const tableSpec = {
+		showColSummaries: false,
 		columns: [
 			{
 				short_label: 'first_name',


### PR DESCRIPTION
**What does this change?**

This removes an empty space below the column headers of the simple Table stories.
