### PR TITLE
Set selected location in Geocoder as query text 

### DIFF
--- a/.changeset/geocoder-selected-name.md
+++ b/.changeset/geocoder-selected-name.md
@@ -1,0 +1,6 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: `Geocoder` selected location now appears as query text on selection.
+ADDED: adds reactively updating `selected` property to `Geocoder` 

--- a/.changeset/geocoder-selected-name.md
+++ b/.changeset/geocoder-selected-name.md
@@ -3,4 +3,5 @@
 ---
 
 CHANGED: `Geocoder` selected location now appears as query text on selection.
-ADDED: adds reactively updating `selected` property to `Geocoder` 
+CHANGED: adds reactively updating `selected` property to `Geocoder`. 
+CHANGED: `GeocoderSuggestionList` now highlights the currently selected item when the list is reopened.

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlGeocoder.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlGeocoder.svelte
@@ -13,6 +13,7 @@
 
 	import type {
 		Geolocation,
+		GeolocationNamed,
 		OnGeolocationSearchResult,
 		OnGeolocationSearchError,
 		GeocoderAdapter
@@ -54,6 +55,7 @@
 
 	const zoomLevel = 16;
 	const delay = 500;
+	let selected: null | GeolocationNamed = null;
 
 	const onLocationSelectedGeocoder = (location: Geolocation) => {
 		if (!$mapStore) {
@@ -80,12 +82,19 @@
 	{classes}
 	{inputClasses}
 	bind:showClearButton
+	bind:selected
 	let:onSuggestionEvent
 	let:attribution
 	let:suggestions
 	{...$$restProps}
 >
 	{#if suggestions.length > 0}
-		<GeocoderSuggestionList {onSuggestionEvent} {attribution} {suggestions} {maxSuggestions} />
+		<GeocoderSuggestionList
+			{onSuggestionEvent}
+			{attribution}
+			{suggestions}
+			{selected}
+			{maxSuggestions}
+		/>
 	{/if}
 </Geocoder>

--- a/packages/ui/src/lib/geolocation/Geocoder.stories.svelte
+++ b/packages/ui/src/lib/geolocation/Geocoder.stories.svelte
@@ -136,6 +136,7 @@
 					{onSuggestionEvent}
 					{attribution}
 					{suggestions}
+					{selected}
 					maxSuggestions={5}
 				/>
 			{/if}
@@ -173,6 +174,7 @@
 					{onSuggestionEvent}
 					{attribution}
 					{suggestions}
+					{selected}
 					maxSuggestions={5}
 				/>
 			{/if}

--- a/packages/ui/src/lib/geolocation/Geocoder.stories.svelte
+++ b/packages/ui/src/lib/geolocation/Geocoder.stories.svelte
@@ -23,14 +23,14 @@
 	} from './types';
 
 	let suggestions: undefined | GeolocationNamed[];
-	let selected = '';
+	let selected = {};
 
 	const formatResult = (location: Geolocation): string => {
 		return '\n' + JSON.stringify(location, null, 2);
 	};
 
 	const onLocationSelected: OnGeolocationSearchResult = (location: Geolocation) => {
-		selected = formatResult(location);
+		selected = location;
 	};
 
 	const onSearchError: OnGeolocationSearchError = (err) => {
@@ -141,7 +141,44 @@
 			{/if}
 		</Geocoder>
 		<pre class="dark:text-white whitespace-pre-wrap">
-			{selected}
+			{selected ? formatResult(selected) : formatResult({})}
+		</pre>
+	</div>
+</Story>
+
+<Story name="Selected">
+	<div class="m-6 space-y-6">
+		<p class="dark:text-white">
+			A simple geocoder with dropdown suggestions. A simple hardcoded list adapter is used here so
+			results are limited.
+		</p>
+		<p class="dark:text-white">
+			At least three characters are required before any suggestions are provided. This avoids
+			spamming the underlying Web APIs with excessively vague requests.
+		</p>
+		<p class="dark:text-white">
+			Try entering 'brick' or 'london' if you're having trouble finding any places.
+		</p>
+		<Geocoder
+			let:onSuggestionEvent
+			let:attribution
+			let:suggestions
+			adapter={listAdapter}
+			bind:selected
+			{onSearchError}
+			classes="w-72"
+		>
+			{#if suggestions?.length > 0}
+				<GeocoderSuggestionList
+					{onSuggestionEvent}
+					{attribution}
+					{suggestions}
+					maxSuggestions={5}
+				/>
+			{/if}
+		</Geocoder>
+		<pre class="dark:text-white whitespace-pre-wrap">
+			{selected ? formatResult(selected) : formatResult({})}
 		</pre>
 	</div>
 </Story>

--- a/packages/ui/src/lib/geolocation/Geocoder.svelte
+++ b/packages/ui/src/lib/geolocation/Geocoder.svelte
@@ -31,10 +31,14 @@
 		OnSuggestionListInteraction
 	} from './types';
 
-	// adapter to source location suggestions from.
+	/**
+	 * adapter to source location suggestions from.
+	 */
 	export let adapter: GeocoderAdapter;
 
-	// delay in ms after a key stroke to minimise redundant API requests.
+	/**
+	 * delay in ms after a key stroke to minimise redundant API requests.
+	 */
 	export let delay = 250;
 
 	/**
@@ -42,7 +46,9 @@
 	 */
 	export let onLocationSelected: undefined | OnGeolocationSearchResult;
 
-	// called when the adapter promise rejects a search request.
+	/**
+	 * called when the adapter promise rejects a search request.
+	 */
 	export let onSearchError: undefined | OnGeolocationSearchError;
 
 	/**
@@ -50,6 +56,11 @@
 	 * changes to search results.
 	 */
 	export let suggestions: GeolocationNamed[] = [];
+
+	/**
+	 * The currently selected location.
+	 */
+	export let selected = null;
 
 	/**
 	 * a space-separated list of additional classes applied to the root container.
@@ -74,6 +85,7 @@
 	let container: HTMLElement;
 	let input: HTMLInputElement;
 	let query = '';
+	let silentQueryUpdate = false;
 	let showSuggestionList = false;
 
 	const updateSuggestionsNow = async () => {
@@ -109,6 +121,16 @@
 
 	const onSelect = (suggestion: Geolocation) => {
 		closeSuggestionsList();
+		selected = suggestion;
+
+		if (suggestion.address) {
+			query = suggestion.address;
+			silentQueryUpdate = true;
+		} else if (suggestion.name) {
+			query = suggestion.name;
+			silentQueryUpdate = true;
+		}
+
 		onLocationSelected && onLocationSelected(suggestion);
 	};
 
@@ -120,8 +142,7 @@
 		const clickEvent = event as PointerEvent;
 
 		if (pressEvent.key === 'Enter' || clickEvent.type === 'click') {
-			closeSuggestionsList();
-			onLocationSelected && onLocationSelected(suggestion);
+			onSelect(suggestion);
 			return;
 		}
 
@@ -243,13 +264,18 @@
 	const clearSearch = () => {
 		showClearButton = false;
 		query = '';
+		selected = null;
 		suggestions = [];
 		showSuggestionList = false;
 	};
 
 	$: {
 		query;
-		scheduleUpdate();
+		if (!silentQueryUpdate) {
+			scheduleUpdate();
+		} else {
+			silentQueryUpdate = false;
+		}
 	}
 </script>
 

--- a/packages/ui/src/lib/geolocation/Geocoder.svelte
+++ b/packages/ui/src/lib/geolocation/Geocoder.svelte
@@ -85,7 +85,7 @@
 	let container: HTMLElement;
 	let input: HTMLInputElement;
 	let query = '';
-	let silentQueryUpdate = false;
+	let silentQueryTextUpdate = false;
 	let showSuggestionList = false;
 
 	const updateSuggestionsNow = async () => {
@@ -123,12 +123,12 @@
 		closeSuggestionsList();
 		selected = suggestion;
 
-		if (suggestion.address) {
-			query = suggestion.address;
-			silentQueryUpdate = true;
-		} else if (suggestion.name) {
+		if (suggestion.name) {
 			query = suggestion.name;
-			silentQueryUpdate = true;
+			silentQueryTextUpdate = true;
+		} else if (suggestion.address) {
+			query = suggestion.address;
+			silentQueryTextUpdate = true;
 		}
 
 		onLocationSelected && onLocationSelected(suggestion);
@@ -271,10 +271,10 @@
 
 	$: {
 		query;
-		if (!silentQueryUpdate) {
+		if (!silentQueryTextUpdate) {
 			scheduleUpdate();
 		} else {
-			silentQueryUpdate = false;
+			silentQueryTextUpdate = false;
 		}
 	}
 </script>
@@ -315,6 +315,7 @@
 		<!-- component that will render the list of suggestions (e.g, `<GeocoderSuggestionList>`)-->
 		<slot
 			attribution={adapter?.attribution ? adapter.attribution() : undefined}
+			{selected}
 			{suggestions}
 			{onSuggestionEvent}
 		/>

--- a/packages/ui/src/lib/geolocation/GeocoderSuggestionList.svelte
+++ b/packages/ui/src/lib/geolocation/GeocoderSuggestionList.svelte
@@ -17,11 +17,26 @@
 	// event occurs in the suggestion list, except when a suggestion is selected.
 	export let onSuggestionEvent: OnSuggestionListInteraction;
 
+	/**
+	 * The currently selected location in the parent `Geocoder`.
+	 */
+	export let selected: null | GeolocationNamed = null;
+
 	// Mouse highlight only
 	let highlighted: null | GeolocationNamed = null;
 
 	const highlightFirstSuggestion = (suggestions: GeolocationNamed[]) => {
-		highlighted = suggestions.length > 0 ? suggestions[0] : null;
+		const containsSelected =
+			selected &&
+			suggestions.find((s) => {
+				return s.id === selected.id;
+			});
+
+		if (containsSelected) {
+			highlighted = selected;
+		} else {
+			highlighted = suggestions.length > 0 ? suggestions[0] : null;
+		}
 	};
 
 	$: highlightFirstSuggestion(suggestions);


### PR DESCRIPTION
**What does this change?**

Updates `<Geocoder>` so that the input's text is the address or name of the selected location when a location is selected.

**Why?**

So users know what they selected.

**Related issues**:

Addresses: #333 

**How is it tested?**

Storybook.

**How is it documented?**

Storybook.

**Is it complete?**

- [x] Have you included changeset file?
