### PR TITLE
add .npmignore file for themes package

### DIFF
--- a/.changeset/sfsd-sfsdf-sfsdf.md
+++ b/.changeset/sfsd-sfsdf-sfsdf.md
@@ -1,0 +1,6 @@
+---
+'@ldn-viz/themes': patch
+---
+
+FIXED: include the generated CSS in published package
+ 

--- a/packages/themes/.npmignore
+++ b/packages/themes/.npmignore
@@ -1,0 +1,1 @@
+colors.css


### PR DESCRIPTION
**What does this change?**

Adds a `.npmignore` file - without this, npm exlcudes the files listed in `.gitignore`, so the generated CSS files aren't included in the published package and can't be accessed from other projects.
