### PR TITLE
export contents of observablePlotFragments

### DIFF
--- a/.changeset/dsdfsd-dsfsdf-fsdfsd.md
+++ b/.changeset/dsdfsd-dsfsdf-fsdfsd.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/charts': patch
+---
+
+FIXED: export the exports from observablePlotFragments.ts from package

--- a/packages/charts/src/lib/index.js
+++ b/packages/charts/src/lib/index.js
@@ -5,3 +5,5 @@ export { default as SubTitle } from './chartContainer/SubTitle.svelte';
 export { default as Title } from './chartContainer/Title.svelte';
 
 export { default as ObservablePlot } from './observablePlot/ObservablePlot.svelte';
+
+export * from './observablePlotFragments/observablePlotFragments';


### PR DESCRIPTION
**What does this change?**
This exports the exports defined in observablePlotFragments from the `charts` package.