### PR TITLE
Add utils packages to charts, maps, and ui packages

### DIFF
--- a/.changeset/missing-util-package.md
+++ b/.changeset/missing-util-package.md
@@ -1,6 +1,7 @@
 ---
 "@ldn-viz/ui": patch
 "@ldn-viz/maps": patch
+"@ldn-viz/charts": patch
 ---
 
-FIXED: adds missing `@ldn-viz/util` dependency to `package.json` of `maps` and `ui` packages.
+FIXED: adds missing `@ldn-viz/util` dependency to `package.json` of `maps`, `ui`, and `charts` packages.

--- a/.changeset/missing-util-package.md
+++ b/.changeset/missing-util-package.md
@@ -1,0 +1,6 @@
+---
+"@ldn-viz/ui": patch
+"@ldn-viz/maps": patch
+---
+
+FIXED: adds missing `@ldn-viz/util` dependency to `package.json` of `maps` and `ui` packages.

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
   "trailingComma": "none",
-  "printWidth": 100
+  "printWidth": 100,
+  "plugins": ["prettier-plugin-packagejson"]
 }

--- a/package.json
+++ b/package.json
@@ -1,30 +1,31 @@
 {
   "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "scripts": {
-    "docs": "npm run storybook -w apps/docs",
     "build": "turbo run build",
     "dev": "turbo run dev",
-    "lint": "turbo run lint",
-    "test": "turbo run test",
-    "test:unit": "turbo run test:unit",
+    "docs": "npm run storybook -w apps/docs",
     "format": "prettier --write .",
-    "publish-packages": "turbo run build && changeset version && changeset publish"
+    "lint": "turbo run lint",
+    "publish-packages": "turbo run build && changeset version && changeset publish",
+    "test": "turbo run test",
+    "test:unit": "turbo run test:unit"
+  },
+  "dependencies": {
+    "@changesets/cli": "^2.27.1",
+    "html2canvas": "^1.4.1"
   },
   "devDependencies": {
     "@ldn-viz/eslint-config-custom": "*",
     "eslint": "^8.57.0",
     "eslint-plugin-turbo": "^1.12.5",
     "prettier": "^3.2.5",
+    "prettier-plugin-packagejson": "^2.5.1",
     "prettier-plugin-svelte": "^3.2.2",
     "turbo": "^1.12.5"
   },
-  "packageManager": "npm@9.5.0",
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ],
-  "dependencies": {
-    "@changesets/cli": "^2.27.1",
-    "html2canvas": "^1.4.1"
-  }
+  "packageManager": "npm@9.5.0"
 }

--- a/packages/charts/.prettierrc
+++ b/packages/charts/.prettierrc
@@ -3,6 +3,6 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"plugins": ["prettier-plugin-svelte"],
+	"plugins": ["prettier-plugin-packagejson", "prettier-plugin-svelte"],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -60,6 +60,7 @@
 	"dependencies": {
 		"@ldn-viz/ui": "*",
 		"@observablehq/plot": "^0.6.14",
-		"layercake": "^8.1.1"
+		"layercake": "^8.1.1",
+		"@ldn-viz/utils": "*"
 	}
 }

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -1,33 +1,38 @@
 {
 	"name": "@ldn-viz/charts",
 	"version": "2.0.1",
-	"scripts": {
-		"dev": "vite dev --port 3003 --open",
-		"build": "vite build && npm run package",
-		"preview": "vite preview",
-		"package": "svelte-kit sync && svelte-package && publint",
-		"prepublishOnly": "npm run package",
-		"test": "playwright test",
-		"test:unit": "vitest run",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . && eslint src",
-		"format": "prettier --write ."
-	},
+	"type": "module",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
 	},
+	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
 	"files": [
 		"dist",
 		"!dist/**/*.test.*",
 		"!dist/**/*.spec.*"
 	],
-	"peerDependencies": {
-		"@sveltejs/kit": "^2.3.3",
-		"svelte": "^4.0.0"
+	"scripts": {
+		"build": "vite build && npm run package",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"dev": "vite dev --port 3003 --open",
+		"format": "prettier --write .",
+		"lint": "prettier --check . && eslint src",
+		"package": "svelte-kit sync && svelte-package && publint",
+		"prepublishOnly": "npm run package",
+		"preview": "vite preview",
+		"test": "playwright test",
+		"test:unit": "vitest run"
+	},
+	"dependencies": {
+		"@ldn-viz/ui": "*",
+		"@ldn-viz/utils": "*",
+		"@observablehq/plot": "^0.6.14",
+		"layercake": "^8.1.1"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.42.1",
@@ -43,6 +48,7 @@
 		"postcss": "^8.4.35",
 		"postcss-load-config": "^5.0.3",
 		"prettier": "^3.2.5",
+		"prettier-plugin-packagejson": "^2.5.1",
 		"prettier-plugin-svelte": "^3.2.2",
 		"publint": "^0.2.7",
 		"svelte": "^4.2.12",
@@ -54,13 +60,8 @@
 		"vite": "^5.1.6",
 		"vitest": "^1.3.1"
 	},
-	"svelte": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"type": "module",
-	"dependencies": {
-		"@ldn-viz/ui": "*",
-		"@observablehq/plot": "^0.6.14",
-		"layercake": "^8.1.1",
-		"@ldn-viz/utils": "*"
+	"peerDependencies": {
+		"@sveltejs/kit": "^2.3.3",
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@ldn-viz/eslint-config-custom",
   "version": "1.0.0",
-  "main": "index.js",
-  "license": "MIT",
   "private": true,
+  "license": "MIT",
+  "main": "index.js",
   "scripts": {
     "test": "echo no tests",
     "test:unit": "echo no tests"

--- a/packages/maps/.prettierrc
+++ b/packages/maps/.prettierrc
@@ -3,6 +3,6 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"plugins": ["prettier-plugin-svelte"],
+	"plugins": ["prettier-plugin-packagejson", "prettier-plugin-svelte"],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -1,34 +1,42 @@
 {
 	"name": "@ldn-viz/maps",
 	"version": "4.0.0",
-	"scripts": {
-		"dev": "vite dev --port 3004 --open",
-		"build": "vite build && npm run package",
-		"preview": "vite preview",
-		"package": "svelte-kit sync && svelte-package && publint",
-		"prepublishOnly": "npm run package",
-		"test": "playwright test",
-		"test:unit": "vitest run",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . && eslint src",
-		"format": "prettier --write ."
-	},
+	"type": "module",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
 	},
+	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
 	"files": [
 		"themes",
 		"dist",
 		"!dist/**/*.test.*",
 		"!dist/**/*.spec.*"
 	],
-	"peerDependencies": {
-		"@sveltejs/kit": "^2.3.3",
-		"svelte": "^4.0.0"
+	"scripts": {
+		"build": "vite build && npm run package",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"dev": "vite dev --port 3004 --open",
+		"format": "prettier --write .",
+		"lint": "prettier --check . && eslint src",
+		"package": "svelte-kit sync && svelte-package && publint",
+		"prepublishOnly": "npm run package",
+		"preview": "vite preview",
+		"test": "playwright test",
+		"test:unit": "vitest run"
+	},
+	"dependencies": {
+		"@deck.gl/core": "^8.9.35",
+		"@deck.gl/layers": "^8.9.35",
+		"@deck.gl/mapbox": "^8.9.35",
+		"@ldn-viz/utils": "*",
+		"@turf/turf": "6.5.0",
+		"maplibre-gl": "^4.1.0",
+		"svelte-maplibre": "^0.8.2"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.42.1",
@@ -44,6 +52,7 @@
 		"postcss": "^8.4.35",
 		"postcss-load-config": "^5.0.3",
 		"prettier": "^3.2.5",
+		"prettier-plugin-packagejson": "^2.5.1",
 		"prettier-plugin-svelte": "^3.2.2",
 		"publint": "^0.2.7",
 		"svelte": "^4.2.12",
@@ -55,16 +64,8 @@
 		"vite": "^5.1.6",
 		"vitest": "^1.3.1"
 	},
-	"svelte": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"type": "module",
-	"dependencies": {
-		"@deck.gl/core": "^8.9.35",
-		"@deck.gl/layers": "^8.9.35",
-		"@deck.gl/mapbox": "^8.9.35",
-		"@turf/turf": "6.5.0",
-		"maplibre-gl": "^4.1.0",
-		"svelte-maplibre": "^0.8.2",
-		"@ldn-viz/utils": "*"
+	"peerDependencies": {
+		"@sveltejs/kit": "^2.3.3",
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -1,70 +1,70 @@
 {
-  "name": "@ldn-viz/maps",
-  "version": "4.0.0",
-  "scripts": {
-    "dev": "vite dev --port 3004 --open",
-    "build": "vite build && npm run package",
-    "preview": "vite preview",
-    "package": "svelte-kit sync && svelte-package && publint",
-    "prepublishOnly": "npm run package",
-    "test": "playwright test",
-    "test:unit": "vitest run",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "prettier --check . && eslint src",
-    "format": "prettier --write ."
-  },
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js"
-    }
-  },
-  "files": [
-    "themes",
-    "dist",
-    "!dist/**/*.test.*",
-    "!dist/**/*.spec.*"
-  ],
-  "peerDependencies": {
-    "@sveltejs/kit": "^2.3.3",
-    "svelte": "^4.0.0"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.42.1",
-    "@sveltejs/adapter-static": "^3.0.1",
-    "@sveltejs/package": "^2.3.0",
-    "@sveltejs/vite-plugin-svelte": "^3.0.2",
-    "@typescript-eslint/eslint-plugin": "^7.2.0",
-    "@typescript-eslint/parser": "^7.2.0",
-    "autoprefixer": "^10.4.18",
-    "eslint": "^8.57.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-svelte": "^2.35.1",
-    "postcss": "^8.4.35",
-    "postcss-load-config": "^5.0.3",
-    "prettier": "^3.2.5",
-    "prettier-plugin-svelte": "^3.2.2",
-    "publint": "^0.2.7",
-    "svelte": "^4.2.12",
-    "svelte-check": "^3.6.7",
-    "svelte-preprocess": "^5.1.3",
-    "tailwindcss": "^3.4.1",
-    "tslib": "^2.6.2",
-    "typescript": "^5.4.2",
-    "vite": "^5.1.6",
-    "vitest": "^1.3.1"
-  },
-  "svelte": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "type": "module",
-  "dependencies": {
-    "@deck.gl/core": "^8.9.35",
-    "@deck.gl/layers": "^8.9.35",
-    "@deck.gl/mapbox": "^8.9.35",
-    "@turf/turf": "6.5.0",
-    "maplibre-gl": "^4.1.0",
-    "svelte-maplibre": "^0.8.2",
-    "@ldn-viz/utils": "*"
-  }
+	"name": "@ldn-viz/maps",
+	"version": "4.0.0",
+	"scripts": {
+		"dev": "vite dev --port 3004 --open",
+		"build": "vite build && npm run package",
+		"preview": "vite preview",
+		"package": "svelte-kit sync && svelte-package && publint",
+		"prepublishOnly": "npm run package",
+		"test": "playwright test",
+		"test:unit": "vitest run",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"lint": "prettier --check . && eslint src",
+		"format": "prettier --write ."
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"svelte": "./dist/index.js"
+		}
+	},
+	"files": [
+		"themes",
+		"dist",
+		"!dist/**/*.test.*",
+		"!dist/**/*.spec.*"
+	],
+	"peerDependencies": {
+		"@sveltejs/kit": "^2.3.3",
+		"svelte": "^4.0.0"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.42.1",
+		"@sveltejs/adapter-static": "^3.0.1",
+		"@sveltejs/package": "^2.3.0",
+		"@sveltejs/vite-plugin-svelte": "^3.0.2",
+		"@typescript-eslint/eslint-plugin": "^7.2.0",
+		"@typescript-eslint/parser": "^7.2.0",
+		"autoprefixer": "^10.4.18",
+		"eslint": "^8.57.0",
+		"eslint-config-prettier": "^9.1.0",
+		"eslint-plugin-svelte": "^2.35.1",
+		"postcss": "^8.4.35",
+		"postcss-load-config": "^5.0.3",
+		"prettier": "^3.2.5",
+		"prettier-plugin-svelte": "^3.2.2",
+		"publint": "^0.2.7",
+		"svelte": "^4.2.12",
+		"svelte-check": "^3.6.7",
+		"svelte-preprocess": "^5.1.3",
+		"tailwindcss": "^3.4.1",
+		"tslib": "^2.6.2",
+		"typescript": "^5.4.2",
+		"vite": "^5.1.6",
+		"vitest": "^1.3.1"
+	},
+	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"type": "module",
+	"dependencies": {
+		"@deck.gl/core": "^8.9.35",
+		"@deck.gl/layers": "^8.9.35",
+		"@deck.gl/mapbox": "^8.9.35",
+		"@turf/turf": "6.5.0",
+		"maplibre-gl": "^4.1.0",
+		"svelte-maplibre": "^0.8.2",
+		"@ldn-viz/utils": "*"
+	}
 }

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -1,69 +1,70 @@
 {
-	"name": "@ldn-viz/maps",
-	"version": "4.0.0",
-	"scripts": {
-		"dev": "vite dev --port 3004 --open",
-		"build": "vite build && npm run package",
-		"preview": "vite preview",
-		"package": "svelte-kit sync && svelte-package && publint",
-		"prepublishOnly": "npm run package",
-		"test": "playwright test",
-		"test:unit": "vitest run",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . && eslint src",
-		"format": "prettier --write ."
-	},
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
-		}
-	},
-	"files": [
-		"themes",
-		"dist",
-		"!dist/**/*.test.*",
-		"!dist/**/*.spec.*"
-	],
-	"peerDependencies": {
-		"@sveltejs/kit": "^2.3.3",
-		"svelte": "^4.0.0"
-	},
-	"devDependencies": {
-		"@playwright/test": "^1.42.1",
-		"@sveltejs/adapter-static": "^3.0.1",
-		"@sveltejs/package": "^2.3.0",
-		"@sveltejs/vite-plugin-svelte": "^3.0.2",
-		"@typescript-eslint/eslint-plugin": "^7.2.0",
-		"@typescript-eslint/parser": "^7.2.0",
-		"autoprefixer": "^10.4.18",
-		"eslint": "^8.57.0",
-		"eslint-config-prettier": "^9.1.0",
-		"eslint-plugin-svelte": "^2.35.1",
-		"postcss": "^8.4.35",
-		"postcss-load-config": "^5.0.3",
-		"prettier": "^3.2.5",
-		"prettier-plugin-svelte": "^3.2.2",
-		"publint": "^0.2.7",
-		"svelte": "^4.2.12",
-		"svelte-check": "^3.6.7",
-		"svelte-preprocess": "^5.1.3",
-		"tailwindcss": "^3.4.1",
-		"tslib": "^2.6.2",
-		"typescript": "^5.4.2",
-		"vite": "^5.1.6",
-		"vitest": "^1.3.1"
-	},
-	"svelte": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"type": "module",
-	"dependencies": {
-		"@deck.gl/core": "^8.9.35",
-		"@deck.gl/layers": "^8.9.35",
-		"@deck.gl/mapbox": "^8.9.35",
-		"@turf/turf": "6.5.0",
-		"maplibre-gl": "^4.1.0",
-		"svelte-maplibre": "^0.8.2"
-	}
+  "name": "@ldn-viz/maps",
+  "version": "4.0.0",
+  "scripts": {
+    "dev": "vite dev --port 3004 --open",
+    "build": "vite build && npm run package",
+    "preview": "vite preview",
+    "package": "svelte-kit sync && svelte-package && publint",
+    "prepublishOnly": "npm run package",
+    "test": "playwright test",
+    "test:unit": "vitest run",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "lint": "prettier --check . && eslint src",
+    "format": "prettier --write ."
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
+  "files": [
+    "themes",
+    "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.spec.*"
+  ],
+  "peerDependencies": {
+    "@sveltejs/kit": "^2.3.3",
+    "svelte": "^4.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.42.1",
+    "@sveltejs/adapter-static": "^3.0.1",
+    "@sveltejs/package": "^2.3.0",
+    "@sveltejs/vite-plugin-svelte": "^3.0.2",
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "@typescript-eslint/parser": "^7.2.0",
+    "autoprefixer": "^10.4.18",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-svelte": "^2.35.1",
+    "postcss": "^8.4.35",
+    "postcss-load-config": "^5.0.3",
+    "prettier": "^3.2.5",
+    "prettier-plugin-svelte": "^3.2.2",
+    "publint": "^0.2.7",
+    "svelte": "^4.2.12",
+    "svelte-check": "^3.6.7",
+    "svelte-preprocess": "^5.1.3",
+    "tailwindcss": "^3.4.1",
+    "tslib": "^2.6.2",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.6",
+    "vitest": "^1.3.1",
+    "@ldn-viz/utils": "*"
+  },
+  "svelte": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "type": "module",
+  "dependencies": {
+    "@deck.gl/core": "^8.9.35",
+    "@deck.gl/layers": "^8.9.35",
+    "@deck.gl/mapbox": "^8.9.35",
+    "@turf/turf": "6.5.0",
+    "maplibre-gl": "^4.1.0",
+    "svelte-maplibre": "^0.8.2"
+  }
 }

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -53,8 +53,7 @@
     "tslib": "^2.6.2",
     "typescript": "^5.4.2",
     "vite": "^5.1.6",
-    "vitest": "^1.3.1",
-    "@ldn-viz/utils": "*"
+    "vitest": "^1.3.1"
   },
   "svelte": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -65,6 +64,7 @@
     "@deck.gl/mapbox": "^8.9.35",
     "@turf/turf": "6.5.0",
     "maplibre-gl": "^4.1.0",
-    "svelte-maplibre": "^0.8.2"
+    "svelte-maplibre": "^0.8.2",
+    "@ldn-viz/utils": "*"
   }
 }

--- a/packages/tables/.prettierrc
+++ b/packages/tables/.prettierrc
@@ -3,6 +3,6 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"plugins": ["prettier-plugin-svelte"],
+	"plugins": ["prettier-plugin-packagejson", "prettier-plugin-svelte"],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -1,34 +1,46 @@
 {
 	"name": "@ldn-viz/tables",
 	"version": "1.0.0",
-	"scripts": {
-		"dev": "vite dev --port 3004 --open",
-		"build": "vite build && npm run package",
-		"preview": "vite preview",
-		"package": "svelte-kit sync && svelte-package && publint",
-		"prepublishOnly": "npm run package",
-		"test": "playwright test",
-		"test:unit": "vitest run",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . && eslint src",
-		"format": "prettier --write ."
-	},
+	"type": "module",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
 	},
+	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
 	"files": [
 		"themes",
 		"dist",
 		"!dist/**/*.test.*",
 		"!dist/**/*.spec.*"
 	],
-	"peerDependencies": {
-		"@sveltejs/kit": "^2.3.3",
-		"svelte": "^4.0.0"
+	"scripts": {
+		"build": "vite build && npm run package",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"dev": "vite dev --port 3004 --open",
+		"format": "prettier --write .",
+		"lint": "prettier --check . && eslint src",
+		"package": "svelte-kit sync && svelte-package && publint",
+		"prepublishOnly": "npm run package",
+		"preview": "vite preview",
+		"test": "playwright test",
+		"test:unit": "vitest run"
+	},
+	"dependencies": {
+		"@ldn-viz/charts": "*",
+		"@ldn-viz/themes": "*",
+		"@ldn-viz/ui": "*",
+		"@ldn-viz/utils": "*",
+		"@melt-ui/svelte": "^0.71.0",
+		"@tailwindcss/typography": "^0.5.10",
+		"chroma-js": "^2.4.2",
+		"d3": "^7.8.5",
+		"d3-scale": "^4.0.2",
+		"html2canvas": "^1.4.1",
+		"svelte-virtual-scroll-list": "^1.3.0"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.42.1",
@@ -44,6 +56,7 @@
 		"postcss": "^8.4.35",
 		"postcss-load-config": "^5.0.3",
 		"prettier": "^3.2.5",
+		"prettier-plugin-packagejson": "^2.5.1",
 		"prettier-plugin-svelte": "^3.2.2",
 		"publint": "^0.2.7",
 		"svelte": "^4.2.12",
@@ -55,20 +68,8 @@
 		"vite": "^5.1.6",
 		"vitest": "^1.3.1"
 	},
-	"svelte": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"type": "module",
-	"dependencies": {
-		"@ldn-viz/charts": "*",
-		"@ldn-viz/themes": "*",
-		"@ldn-viz/ui": "*",
-		"@ldn-viz/utils": "*",
-		"@melt-ui/svelte": "^0.71.0",
-		"@tailwindcss/typography": "^0.5.10",
-		"chroma-js": "^2.4.2",
-		"d3": "^7.8.5",
-		"d3-scale": "^4.0.2",
-		"html2canvas": "^1.4.1",
-		"svelte-virtual-scroll-list": "^1.3.0"
+	"peerDependencies": {
+		"@sveltejs/kit": "^2.3.3",
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -3,25 +3,25 @@
   "version": "2.0.1",
   "type": "module",
   "scripts": {
-    "lint": "prettier --check . && eslint . && publint",
-    "format": "prettier --check . --write",
-    "test": "echo no tests",
-    "test:unit": "echo no tests",
+    "build": "npm run build-tokens",
     "build-tokens": "node ./build.js",
-    "build": "npm run build-tokens"
+    "format": "prettier --check . --write",
+    "lint": "prettier --check . && eslint . && publint",
+    "test": "echo no tests",
+    "test:unit": "echo no tests"
+  },
+  "dependencies": {
+    "@tailwindcss/forms": "^0.5.7",
+    "@tailwindcss/typography": "^0.5.10",
+    "mini-svg-data-uri": "^1.4.4"
   },
   "devDependencies": {
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.2.5",
     "publint": "^0.2.7",
-    "tailwindcss": "^3.4.1",
     "style-dictionary": "^3.9.2",
-    "style-dictionary-utils": "^2.4.1"
-  },
-  "dependencies": {
-    "@tailwindcss/forms": "^0.5.7",
-    "@tailwindcss/typography": "^0.5.10",
-    "mini-svg-data-uri": "^1.4.4"
+    "style-dictionary-utils": "^2.4.1",
+    "tailwindcss": "^3.4.1"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,85 +1,85 @@
 {
-  "name": "@ldn-viz/ui",
-  "version": "11.0.0",
-  "scripts": {
-    "dev": "vite dev --port 3005 --open",
-    "build:sveltekit": "vite build && npm run package",
-    "build:tailwind": "postcss src/app.postcss -o dist/ldn-viz-ui.css",
-    "build": "npm run build:sveltekit && npm run build:tailwind",
-    "preview": "vite preview",
-    "package": "svelte-kit sync && svelte-package && publint",
-    "prepublishOnly": "npm run package",
-    "test": "playwright test",
-    "test:unit": "vitest run",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "prettier --check . && eslint src",
-    "format": "prettier --write ."
-  },
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js"
-    }
-  },
-  "files": [
-    "dist",
-    "!dist/**/*.test.*",
-    "!dist/**/*.spec.*"
-  ],
-  "peerDependencies": {
-    "@sveltejs/kit": "^2.3.3",
-    "svelte": "^4.2.12"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.42.1",
-    "@sveltejs/adapter-static": "^3.0.1",
-    "@sveltejs/package": "^2.3.0",
-    "@sveltejs/vite-plugin-svelte": "^3.0.2",
-    "@types/d3": "^7.4.3",
-    "@typescript-eslint/eslint-plugin": "^7.2.0",
-    "@typescript-eslint/parser": "^7.2.0",
-    "autoprefixer": "^10.4.18",
-    "eslint": "^8.57.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-svelte": "^2.35.1",
-    "postcss": "^8.4.35",
-    "postcss-load-config": "^5.0.3",
-    "prettier": "^3.2.5",
-    "prettier-plugin-svelte": "^3.2.2",
-    "publint": "^0.2.7",
-    "svelte": "^4.2.12",
-    "svelte-check": "^3.6.7",
-    "svelte-preprocess": "^5.1.3",
-    "tailwindcss": "^3.4.1",
-    "tslib": "^2.6.2",
-    "typescript": "^5.4.2",
-    "vite": "^5.1.6",
-    "vitest": "^1.3.1",
-    "@ldn-viz/docs": "*"
-  },
-  "svelte": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "main": "./dist/index.js",
-  "type": "module",
-  "dependencies": {
-    "@melt-ui/svelte": "^0.76.0",
-    "@steeze-ui/heroicons": "^2.3.0",
-    "@steeze-ui/svelte-icon": "^1.5.0",
-    "@storybook/addon-svelte-csf": "^4.1.2",
-    "@types/d3-dsv": "^3.0.7",
-    "d3-array": "^3.2.4",
-    "d3-axis": "^3.0.0",
-    "d3-dsv": "^3.0.1",
-    "d3-format": "^3.1.0",
-    "d3-interpolate": "^3.0.1",
-    "d3-scale": "^4.0.2",
-    "d3-selection": "^3.0.0",
-    "html2canvas": "^1.4.1",
-    "postcss-cli": "^11.0.0",
-    "postcss-discard-comments": "^6.0.2",
-    "svelte-floating-ui": "^1.5.8",
-    "svelte-select": "^5.8.3",
-    "@ldn-viz/utils": "*"
-  }
+	"name": "@ldn-viz/ui",
+	"version": "11.0.0",
+	"scripts": {
+		"dev": "vite dev --port 3005 --open",
+		"build:sveltekit": "vite build && npm run package",
+		"build:tailwind": "postcss src/app.postcss -o dist/ldn-viz-ui.css",
+		"build": "npm run build:sveltekit && npm run build:tailwind",
+		"preview": "vite preview",
+		"package": "svelte-kit sync && svelte-package && publint",
+		"prepublishOnly": "npm run package",
+		"test": "playwright test",
+		"test:unit": "vitest run",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"lint": "prettier --check . && eslint src",
+		"format": "prettier --write ."
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"svelte": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist",
+		"!dist/**/*.test.*",
+		"!dist/**/*.spec.*"
+	],
+	"peerDependencies": {
+		"@sveltejs/kit": "^2.3.3",
+		"svelte": "^4.2.12"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.42.1",
+		"@sveltejs/adapter-static": "^3.0.1",
+		"@sveltejs/package": "^2.3.0",
+		"@sveltejs/vite-plugin-svelte": "^3.0.2",
+		"@types/d3": "^7.4.3",
+		"@typescript-eslint/eslint-plugin": "^7.2.0",
+		"@typescript-eslint/parser": "^7.2.0",
+		"autoprefixer": "^10.4.18",
+		"eslint": "^8.57.0",
+		"eslint-config-prettier": "^9.1.0",
+		"eslint-plugin-svelte": "^2.35.1",
+		"postcss": "^8.4.35",
+		"postcss-load-config": "^5.0.3",
+		"prettier": "^3.2.5",
+		"prettier-plugin-svelte": "^3.2.2",
+		"publint": "^0.2.7",
+		"svelte": "^4.2.12",
+		"svelte-check": "^3.6.7",
+		"svelte-preprocess": "^5.1.3",
+		"tailwindcss": "^3.4.1",
+		"tslib": "^2.6.2",
+		"typescript": "^5.4.2",
+		"vite": "^5.1.6",
+		"vitest": "^1.3.1",
+		"@ldn-viz/docs": "*"
+	},
+	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"main": "./dist/index.js",
+	"type": "module",
+	"dependencies": {
+		"@melt-ui/svelte": "^0.76.0",
+		"@steeze-ui/heroicons": "^2.3.0",
+		"@steeze-ui/svelte-icon": "^1.5.0",
+		"@storybook/addon-svelte-csf": "^4.1.2",
+		"@types/d3-dsv": "^3.0.7",
+		"d3-array": "^3.2.4",
+		"d3-axis": "^3.0.0",
+		"d3-dsv": "^3.0.1",
+		"d3-format": "^3.1.0",
+		"d3-interpolate": "^3.0.1",
+		"d3-scale": "^4.0.2",
+		"d3-selection": "^3.0.0",
+		"html2canvas": "^1.4.1",
+		"postcss-cli": "^11.0.0",
+		"postcss-discard-comments": "^6.0.2",
+		"svelte-floating-ui": "^1.5.8",
+		"svelte-select": "^5.8.3",
+		"@ldn-viz/utils": "*"
+	}
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,84 +1,85 @@
 {
-	"name": "@ldn-viz/ui",
-	"version": "11.0.0",
-	"scripts": {
-		"dev": "vite dev --port 3005 --open",
-		"build:sveltekit": "vite build && npm run package",
-		"build:tailwind": "postcss src/app.postcss -o dist/ldn-viz-ui.css",
-		"build": "npm run build:sveltekit && npm run build:tailwind",
-		"preview": "vite preview",
-		"package": "svelte-kit sync && svelte-package && publint",
-		"prepublishOnly": "npm run package",
-		"test": "playwright test",
-		"test:unit": "vitest run",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . && eslint src",
-		"format": "prettier --write ."
-	},
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
-		}
-	},
-	"files": [
-		"dist",
-		"!dist/**/*.test.*",
-		"!dist/**/*.spec.*"
-	],
-	"peerDependencies": {
-		"@sveltejs/kit": "^2.3.3",
-		"svelte": "^4.2.12"
-	},
-	"devDependencies": {
-		"@playwright/test": "^1.42.1",
-		"@sveltejs/adapter-static": "^3.0.1",
-		"@sveltejs/package": "^2.3.0",
-		"@sveltejs/vite-plugin-svelte": "^3.0.2",
-		"@types/d3": "^7.4.3",
-		"@typescript-eslint/eslint-plugin": "^7.2.0",
-		"@typescript-eslint/parser": "^7.2.0",
-		"autoprefixer": "^10.4.18",
-		"eslint": "^8.57.0",
-		"eslint-config-prettier": "^9.1.0",
-		"eslint-plugin-svelte": "^2.35.1",
-		"postcss": "^8.4.35",
-		"postcss-load-config": "^5.0.3",
-		"prettier": "^3.2.5",
-		"prettier-plugin-svelte": "^3.2.2",
-		"publint": "^0.2.7",
-		"svelte": "^4.2.12",
-		"svelte-check": "^3.6.7",
-		"svelte-preprocess": "^5.1.3",
-		"tailwindcss": "^3.4.1",
-		"tslib": "^2.6.2",
-		"typescript": "^5.4.2",
-		"vite": "^5.1.6",
-		"vitest": "^1.3.1",
-		"@ldn-viz/docs": "*"
-	},
-	"svelte": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"main": "./dist/index.js",
-	"type": "module",
-	"dependencies": {
-		"@melt-ui/svelte": "^0.76.0",
-		"@steeze-ui/heroicons": "^2.3.0",
-		"@steeze-ui/svelte-icon": "^1.5.0",
-		"@storybook/addon-svelte-csf": "^4.1.2",
-		"@types/d3-dsv": "^3.0.7",
-		"d3-array": "^3.2.4",
-		"d3-axis": "^3.0.0",
-		"d3-dsv": "^3.0.1",
-		"d3-format": "^3.1.0",
-		"d3-interpolate": "^3.0.1",
-		"d3-scale": "^4.0.2",
-		"d3-selection": "^3.0.0",
-		"html2canvas": "^1.4.1",
-		"postcss-cli": "^11.0.0",
-		"postcss-discard-comments": "^6.0.2",
-		"svelte-floating-ui": "^1.5.8",
-		"svelte-select": "^5.8.3"
-	}
+  "name": "@ldn-viz/ui",
+  "version": "11.0.0",
+  "scripts": {
+    "dev": "vite dev --port 3005 --open",
+    "build:sveltekit": "vite build && npm run package",
+    "build:tailwind": "postcss src/app.postcss -o dist/ldn-viz-ui.css",
+    "build": "npm run build:sveltekit && npm run build:tailwind",
+    "preview": "vite preview",
+    "package": "svelte-kit sync && svelte-package && publint",
+    "prepublishOnly": "npm run package",
+    "test": "playwright test",
+    "test:unit": "vitest run",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "lint": "prettier --check . && eslint src",
+    "format": "prettier --write ."
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.spec.*"
+  ],
+  "peerDependencies": {
+    "@sveltejs/kit": "^2.3.3",
+    "svelte": "^4.2.12"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.42.1",
+    "@sveltejs/adapter-static": "^3.0.1",
+    "@sveltejs/package": "^2.3.0",
+    "@sveltejs/vite-plugin-svelte": "^3.0.2",
+    "@types/d3": "^7.4.3",
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "@typescript-eslint/parser": "^7.2.0",
+    "autoprefixer": "^10.4.18",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-svelte": "^2.35.1",
+    "postcss": "^8.4.35",
+    "postcss-load-config": "^5.0.3",
+    "prettier": "^3.2.5",
+    "prettier-plugin-svelte": "^3.2.2",
+    "publint": "^0.2.7",
+    "svelte": "^4.2.12",
+    "svelte-check": "^3.6.7",
+    "svelte-preprocess": "^5.1.3",
+    "tailwindcss": "^3.4.1",
+    "tslib": "^2.6.2",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.6",
+    "vitest": "^1.3.1",
+    "@ldn-viz/docs": "*",
+    "@ldn-viz/utils": "*"
+  },
+  "svelte": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.js",
+  "type": "module",
+  "dependencies": {
+    "@melt-ui/svelte": "^0.76.0",
+    "@steeze-ui/heroicons": "^2.3.0",
+    "@steeze-ui/svelte-icon": "^1.5.0",
+    "@storybook/addon-svelte-csf": "^4.1.2",
+    "@types/d3-dsv": "^3.0.7",
+    "d3-array": "^3.2.4",
+    "d3-axis": "^3.0.0",
+    "d3-dsv": "^3.0.1",
+    "d3-format": "^3.1.0",
+    "d3-interpolate": "^3.0.1",
+    "d3-scale": "^4.0.2",
+    "d3-selection": "^3.0.0",
+    "html2canvas": "^1.4.1",
+    "postcss-cli": "^11.0.0",
+    "postcss-discard-comments": "^6.0.2",
+    "svelte-floating-ui": "^1.5.8",
+    "svelte-select": "^5.8.3"
+  }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -56,8 +56,7 @@
     "typescript": "^5.4.2",
     "vite": "^5.1.6",
     "vitest": "^1.3.1",
-    "@ldn-viz/docs": "*",
-    "@ldn-viz/utils": "*"
+    "@ldn-viz/docs": "*"
   },
   "svelte": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -80,6 +79,7 @@
     "postcss-cli": "^11.0.0",
     "postcss-discard-comments": "^6.0.2",
     "svelte-floating-ui": "^1.5.8",
-    "svelte-select": "^5.8.3"
+    "svelte-select": "^5.8.3",
+    "@ldn-viz/utils": "*"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,68 +1,38 @@
 {
 	"name": "@ldn-viz/ui",
 	"version": "11.0.0",
-	"scripts": {
-		"dev": "vite dev --port 3005 --open",
-		"build:sveltekit": "vite build && npm run package",
-		"build:tailwind": "postcss src/app.postcss -o dist/ldn-viz-ui.css",
-		"build": "npm run build:sveltekit && npm run build:tailwind",
-		"preview": "vite preview",
-		"package": "svelte-kit sync && svelte-package && publint",
-		"prepublishOnly": "npm run package",
-		"test": "playwright test",
-		"test:unit": "vitest run",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . && eslint src",
-		"format": "prettier --write ."
-	},
+	"type": "module",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
 	},
+	"main": "./dist/index.js",
+	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
 	"files": [
 		"dist",
 		"!dist/**/*.test.*",
 		"!dist/**/*.spec.*"
 	],
-	"peerDependencies": {
-		"@sveltejs/kit": "^2.3.3",
-		"svelte": "^4.2.12"
+	"scripts": {
+		"build": "npm run build:sveltekit && npm run build:tailwind",
+		"build:sveltekit": "vite build && npm run package",
+		"build:tailwind": "postcss src/app.postcss -o dist/ldn-viz-ui.css",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"dev": "vite dev --port 3005 --open",
+		"format": "prettier --write .",
+		"lint": "prettier --check . && eslint src",
+		"package": "svelte-kit sync && svelte-package && publint",
+		"prepublishOnly": "npm run package",
+		"preview": "vite preview",
+		"test": "playwright test",
+		"test:unit": "vitest run"
 	},
-	"devDependencies": {
-		"@playwright/test": "^1.42.1",
-		"@sveltejs/adapter-static": "^3.0.1",
-		"@sveltejs/package": "^2.3.0",
-		"@sveltejs/vite-plugin-svelte": "^3.0.2",
-		"@types/d3": "^7.4.3",
-		"@typescript-eslint/eslint-plugin": "^7.2.0",
-		"@typescript-eslint/parser": "^7.2.0",
-		"autoprefixer": "^10.4.18",
-		"eslint": "^8.57.0",
-		"eslint-config-prettier": "^9.1.0",
-		"eslint-plugin-svelte": "^2.35.1",
-		"postcss": "^8.4.35",
-		"postcss-load-config": "^5.0.3",
-		"prettier": "^3.2.5",
-		"prettier-plugin-svelte": "^3.2.2",
-		"publint": "^0.2.7",
-		"svelte": "^4.2.12",
-		"svelte-check": "^3.6.7",
-		"svelte-preprocess": "^5.1.3",
-		"tailwindcss": "^3.4.1",
-		"tslib": "^2.6.2",
-		"typescript": "^5.4.2",
-		"vite": "^5.1.6",
-		"vitest": "^1.3.1",
-		"@ldn-viz/docs": "*"
-	},
-	"svelte": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"main": "./dist/index.js",
-	"type": "module",
 	"dependencies": {
+		"@ldn-viz/utils": "*",
 		"@melt-ui/svelte": "^0.76.0",
 		"@steeze-ui/heroicons": "^2.3.0",
 		"@steeze-ui/svelte-icon": "^1.5.0",
@@ -79,7 +49,38 @@
 		"postcss-cli": "^11.0.0",
 		"postcss-discard-comments": "^6.0.2",
 		"svelte-floating-ui": "^1.5.8",
-		"svelte-select": "^5.8.3",
-		"@ldn-viz/utils": "*"
+		"svelte-select": "^5.8.3"
+	},
+	"devDependencies": {
+		"@ldn-viz/docs": "*",
+		"@playwright/test": "^1.42.1",
+		"@sveltejs/adapter-static": "^3.0.1",
+		"@sveltejs/package": "^2.3.0",
+		"@sveltejs/vite-plugin-svelte": "^3.0.2",
+		"@types/d3": "^7.4.3",
+		"@typescript-eslint/eslint-plugin": "^7.2.0",
+		"@typescript-eslint/parser": "^7.2.0",
+		"autoprefixer": "^10.4.18",
+		"eslint": "^8.57.0",
+		"eslint-config-prettier": "^9.1.0",
+		"eslint-plugin-svelte": "^2.35.1",
+		"postcss": "^8.4.35",
+		"postcss-load-config": "^5.0.3",
+		"prettier": "^3.2.5",
+		"prettier-plugin-packagejson": "^2.5.1",
+		"prettier-plugin-svelte": "^3.2.2",
+		"publint": "^0.2.7",
+		"svelte": "^4.2.12",
+		"svelte-check": "^3.6.7",
+		"svelte-preprocess": "^5.1.3",
+		"tailwindcss": "^3.4.1",
+		"tslib": "^2.6.2",
+		"typescript": "^5.4.2",
+		"vite": "^5.1.6",
+		"vitest": "^1.3.1"
+	},
+	"peerDependencies": {
+		"@sveltejs/kit": "^2.3.3",
+		"svelte": "^4.2.12"
 	}
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,23 +2,29 @@
   "name": "@ldn-viz/utils",
   "version": "0.2.0",
   "type": "module",
-  "files": [
-    "dist"
-  ],
-  "main": "./dist/ldn-viz-utils.umd.cjs",
-  "module": "./dist/ldn-viz-utils.js",
   "exports": {
     ".": {
       "import": "./dist/ldn-viz-utils.js",
       "require": "./dist/ldn-viz-utils.umd.cjs"
     }
   },
+  "main": "./dist/ldn-viz-utils.umd.cjs",
+  "module": "./dist/ldn-viz-utils.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "vite build",
-    "lint": "prettier --check . && eslint src",
     "format": "prettier --check . --write",
+    "lint": "prettier --check . && eslint src",
     "test": "echo no tests",
     "test:unit": "echo no tests"
+  },
+  "dependencies": {
+    "chroma-js": "^2.4.2",
+    "d3-array": "^3.2.4",
+    "d3-format": "^3.1.0",
+    "vite": "^5.1.6"
   },
   "devDependencies": {
     "@types/d3-array": "^3.2.1",
@@ -26,11 +32,5 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.2.5"
-  },
-  "dependencies": {
-    "chroma-js": "^2.4.2",
-    "d3-array": "^3.2.4",
-    "d3-format": "^3.1.0",
-    "vite": "^5.1.6"
   }
 }

--- a/packages/utils/src/colors/scales.ts
+++ b/packages/utils/src/colors/scales.ts
@@ -243,4 +243,4 @@ export const getThresholdBreaksColorsLabels = ({
   return thresholdObj;
 };
 
-console.log(getColorRamp());
+//console.log(getColorRamp());


### PR DESCRIPTION
**What does this change?**

1. Adds `@ldn-viz/util` as a dependency for `@ldn-viz/ui`, `@ldn-viz/maps`, and `@ldn-viz/charts`
2. Adds `package.json` formatting via Prettier.

**Why?**

It broke.

**Related issues**:

Addresses: #503 

**How is it tested?**

**It's not.** I don't know how to test it inside the repo. Unsure if the dependency can be placed in `devDependencies` or not.

**Is it complete?**

- [x] Have you included changeset file?
