### PR TITLE
Package import path

### DIFF
--- a/.changeset/popular-carrots-punch.md
+++ b/.changeset/popular-carrots-punch.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/charts": patch
+---
+
+update import path to theme package

--- a/.changeset/popular-carrots-punch.md
+++ b/.changeset/popular-carrots-punch.md
@@ -2,4 +2,4 @@
 "@ldn-viz/charts": patch
 ---
 
-update import path to theme package
+FIXED: update path used to import theme package

--- a/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
+++ b/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
@@ -1,5 +1,5 @@
+import tokens from '@ldn-viz/themes/styles/js/theme-tokens';
 import type { AxisOptions } from '@observablehq/plot';
-import tokens from '../../../../../packages/themes/styles/js/theme-tokens';
 
 export const fontStack = "'Inter', system-ui, sans-serif"; // TODO: swap for inter
 


### PR DESCRIPTION
**What does this change?**
updates the import path to themes package inside observable plot fragments

**Why?**
it was set to a relative path

**How?**
set it to correct package path

**Related issues**:
#508 

**Does this introduce new dependencies?**
no

**How is it tested?**
n/a

**How is it documented?**
n/a

**Are light and dark themes considered?**
n/a

**Is it complete?**

- [ x] Have you included changeset file?
- [ x] If this adds a new component, is it exported via `index.js`?
