### PR TITLE
Default theme set to system

### DIFF
--- a/.changeset/unlucky-walls-enjoy.md
+++ b/.changeset/unlucky-walls-enjoy.md
@@ -2,4 +2,4 @@
 "@ldn-viz/themes": patch
 ---
 
-set default theme selection to system
+CHANGED: set default theme selection to system

--- a/.changeset/unlucky-walls-enjoy.md
+++ b/.changeset/unlucky-walls-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/themes": patch
+---
+
+set default theme selection to system

--- a/package-lock.json
+++ b/package-lock.json
@@ -20677,7 +20677,7 @@
     },
     "packages/charts": {
       "name": "@ldn-viz/charts",
-      "version": "1.5.0",
+      "version": "2.0.1",
       "dependencies": {
         "@ldn-viz/ui": "*",
         "@observablehq/plot": "^0.6.14",
@@ -20752,7 +20752,7 @@
     },
     "packages/maps": {
       "name": "@ldn-viz/maps",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "dependencies": {
         "@deck.gl/core": "^8.9.35",
         "@deck.gl/layers": "^8.9.35",
@@ -20818,7 +20818,7 @@
     },
     "packages/tables": {
       "name": "@ldn-viz/tables",
-      "version": "0.3.0",
+      "version": "1.0.0",
       "dependencies": {
         "@ldn-viz/charts": "*",
         "@ldn-viz/themes": "*",
@@ -20880,10 +20880,11 @@
     },
     "packages/themes": {
       "name": "@ldn-viz/themes",
-      "version": "1.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.10",
+        "esm-env": "^1.0.0",
         "mini-svg-data-uri": "^1.4.4"
       },
       "devDependencies": {
@@ -20898,7 +20899,7 @@
     },
     "packages/ui": {
       "name": "@ldn-viz/ui",
-      "version": "10.0.0",
+      "version": "11.0.0",
       "dependencies": {
         "@melt-ui/svelte": "^0.76.0",
         "@steeze-ui/heroicons": "^2.3.0",
@@ -20977,7 +20978,7 @@
     },
     "packages/utils": {
       "name": "@ldn-viz/utils",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "chroma-js": "^2.4.2",
         "d3-array": "^3.2.4",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -15,13 +15,14 @@
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.2.5",
     "publint": "^0.2.7",
-    "tailwindcss": "^3.4.1",
     "style-dictionary": "^3.9.2",
-    "style-dictionary-utils": "^2.4.1"
+    "style-dictionary-utils": "^2.4.1",
+    "tailwindcss": "^3.4.1"
   },
   "dependencies": {
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.10",
+    "esm-env": "^1.0.0",
     "mini-svg-data-uri": "^1.4.4"
   }
 }

--- a/packages/themes/themeStore.ts
+++ b/packages/themes/themeStore.ts
@@ -1,10 +1,10 @@
-import { browser } from '$app/environment';
 import { prefersDarkMode } from '@ldn-viz/utils';
+import { BROWSER } from 'esm-env';
 import { derived, writable, type Readable } from 'svelte/store';
 
 const getLocalStorage = () => {
-  if (browser) {
-    return globalThis.localStorage?.getItem('theme') || 'light';
+  if (BROWSER) {
+    return globalThis.localStorage?.getItem('theme') || 'system';
   }
   return 'light';
 };


### PR DESCRIPTION
**What does this change?**
defaults the user theme selection to system. And update the browser import to esm-env

**Why?**
before the default was light - using 'system' better honours user preference.
bowser import should be none svelte specific

**How?**
change config and change import to module

**Related issues**:
#512 

**Does this introduce new dependencies?**
no

**How is it tested?**
n/a

**How is it documented?**
confluence

**Are light and dark themes considered?**
yes

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
