### PR TITLE
update to use the new Image/Data download buttons in ExportBtns component

### DIFF
--- a/.changeset/export-buttons-columnmapping.md
+++ b/.changeset/export-buttons-columnmapping.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/charts": minor
+---
+
+ADDED: added `columnMapping` prop to `ExportBtns` component, to allow columns to be renamed before data download

--- a/.changeset/table-columnmapping.md
+++ b/.changeset/table-columnmapping.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/tables": minor
+---
+
+ADDED: added `columnMapping` prop to `Table` component, to allow columns to be renamed before data download

--- a/packages/charts/src/lib/chartContainer/ExportBtns.svelte
+++ b/packages/charts/src/lib/chartContainer/ExportBtns.svelte
@@ -5,24 +5,36 @@
 
 	export let chartToCapture: HTMLDivElement;
 	export let data: any;
-
-	/**
-	 * An optional object defining a mapping from the names of attributes in the `data` prop to the names of columns in the generated file.
-	 */
-	export let columnMapping: undefined | { [oldName: string]: string } = undefined;
 </script>
 
 <div
-	class="flex flex-col sm:flex-row shrink-0 sm:ml-auto sm:self-end capture-ignore gap-2"
+	class="flex flex-col sm:flex-row shrink-0 sm:ml-auto sm:self-end capture-ignore"
 	data-html2canvas-ignore
 >
 	<DataDownloadButton
 		{data}
-		{columnMapping}
-		filename="download"
-		formats={["CSV", "JSON"]}
+		filename="download.csv"
+		format="CSV"
+		variant="text"
+		emphasis="secondary"
+		size="sm"
 	>
-		Download <Icon
+		Download as CSV <Icon
+			src={ArrowDownTray}
+			theme="mini"
+			class="w-5 h-5 ml-2"
+			aria-hidden="true"
+		/>
+	</DataDownloadButton>
+	<DataDownloadButton
+		{data}
+		filename="download.json"
+		format="JSON"
+		variant="text"
+		emphasis="secondary"
+		size="sm"
+	>
+		Download as JSON<Icon
 			src={ArrowDownTray}
 			theme="mini"
 			class="w-5 h-5 ml-2"
@@ -31,8 +43,11 @@
 	</DataDownloadButton>
 
 	<ImageDownloadButton
-		formats={["PNG"]}
+		format="PNG"
 		htmlNode={chartToCapture}
+		variant="text"
+		emphasis="secondary"
+		size="sm"
 	>
 		Save as image<Icon src={Camera} theme="mini" class="w-5 h-5 ml-2" aria-hidden="true" />
 	</ImageDownloadButton>

--- a/packages/charts/src/lib/chartContainer/ExportBtns.svelte
+++ b/packages/charts/src/lib/chartContainer/ExportBtns.svelte
@@ -7,6 +7,11 @@
 	export let dataForDownload: { [key: string]: any }[] | undefined;
 	export let dataDownloadButton: true | false | ('CSV' | 'JSON')[];
 	export let imageDownloadButton: true | false | ('PNG' | 'SVG')[];
+
+	/**
+	 * An optional object defining a mapping from the names of attributes in the `data` prop to the names of columns in the generated file.
+	 */
+	export let columnMapping: undefined | { [oldName: string]: string } = undefined;
 </script>
 
 <!-- class="flex flex-col sm:flex-row shrink-0 sm:ml-auto sm:self-end sm:space-x-2 capture-ignore" -->
@@ -17,6 +22,7 @@
 	{#if dataDownloadButton && dataForDownload}
 		<DataDownloadButton
 			data={dataForDownload}
+			{columnMapping}
 			filename="download"
 			formats={dataDownloadButton === true ? ['CSV', 'JSON'] : dataDownloadButton}
 			variant="outline"

--- a/packages/charts/src/lib/chartContainer/ExportBtns.svelte
+++ b/packages/charts/src/lib/chartContainer/ExportBtns.svelte
@@ -5,36 +5,24 @@
 
 	export let chartToCapture: HTMLDivElement;
 	export let data: any;
+
+	/**
+	 * An optional object defining a mapping from the names of attributes in the `data` prop to the names of columns in the generated file.
+	 */
+	export let columnMapping: undefined | { [oldName: string]: string } = undefined;
 </script>
 
 <div
-	class="flex flex-col sm:flex-row shrink-0 sm:ml-auto sm:self-end capture-ignore"
+	class="flex flex-col sm:flex-row shrink-0 sm:ml-auto sm:self-end capture-ignore gap-2"
 	data-html2canvas-ignore
 >
 	<DataDownloadButton
 		{data}
-		filename="download.csv"
-		format="CSV"
-		variant="text"
-		emphasis="secondary"
-		size="sm"
+		{columnMapping}
+		filename="download"
+		formats={["CSV", "JSON"]}
 	>
-		Download as CSV <Icon
-			src={ArrowDownTray}
-			theme="mini"
-			class="w-5 h-5 ml-2"
-			aria-hidden="true"
-		/>
-	</DataDownloadButton>
-	<DataDownloadButton
-		{data}
-		filename="download.json"
-		format="JSON"
-		variant="text"
-		emphasis="secondary"
-		size="sm"
-	>
-		Download as JSON<Icon
+		Download <Icon
 			src={ArrowDownTray}
 			theme="mini"
 			class="w-5 h-5 ml-2"
@@ -43,11 +31,8 @@
 	</DataDownloadButton>
 
 	<ImageDownloadButton
-		format="PNG"
+		formats={["PNG"]}
 		htmlNode={chartToCapture}
-		variant="text"
-		emphasis="secondary"
-		size="sm"
 	>
 		Save as image<Icon src={Camera} theme="mini" class="w-5 h-5 ml-2" aria-hidden="true" />
 	</ImageDownloadButton>

--- a/packages/tables/src/lib/table/Table.stories.svelte
+++ b/packages/tables/src/lib/table/Table.stories.svelte
@@ -119,6 +119,15 @@
 	<Table {data} {tableSpec} exportBtns />
 </Story>
 
+<Story name="Export buttons - relabel columns" source>
+	<Table
+		{data}
+		{tableSpec}
+		exportBtns
+		columnMapping={{ first_name: 'First Name', last_name: 'Last Name', pet: 'Pet' }}
+	/>
+</Story>
+
 <Story name="Row Grouping" source>
 	<Table {data} {tableSpec} allowRowGrouping />
 </Story>

--- a/packages/tables/src/lib/table/Table.svelte
+++ b/packages/tables/src/lib/table/Table.svelte
@@ -89,6 +89,11 @@
 	 */
 	export let allowSorting = false;
 
+	/**
+	 * An optional object defining a mapping from the names of attributes in the `data` prop to the names of columns in the downloaded file.
+	 */
+	export let columnMapping: undefined | { [oldName: string]: string } = undefined;
+
 	const onRowsChange = () => {
 		table = table; // eslint-disable-line no-self-assign
 	};
@@ -157,7 +162,7 @@
 		{/if}
 	</div>
 
-	<TableContainer {data} {title} {subTitle} {exportBtns} exportData={data}>
+	<TableContainer {data} {title} {subTitle} {exportBtns} exportData={data} {columnMapping}>
 		<div class="table-auto text-sm w-full text-color-text-primary" slot="table">
 			<div class="border-t border-b border-color-ui-border-primary" style:width={tableWidth}>
 				{#if tableSpec.colGroups}

--- a/packages/tables/src/lib/table/TableContainer.svelte
+++ b/packages/tables/src/lib/table/TableContainer.svelte
@@ -17,6 +17,11 @@
 	// export props for table
 	export let data;
 
+	/**
+	 * An optional object defining a mapping from the names of attributes in the `data` prop to the names of columns in the generated file.
+	 */
+	export let columnMapping: undefined | { [oldName: string]: string } = undefined;
+
 	// For save as image
 	let tableToCapture: HTMLDivElement;
 </script>
@@ -51,7 +56,7 @@
 	<slot name="paginationControls" />
 
 	{#if exportBtns === true}
-		<ExportBtns chartToCapture={tableToCapture} {data} />
+		<ExportBtns chartToCapture={tableToCapture} {data} {columnMapping} />
 	{/if}
 </div>
 


### PR DESCRIPTION
- update to use the new Image/Data download buttons in ExportBtns component
- add a `columnMapping` prop to the `ExportBtns` component, to allow data columns to be renamed before download