### PR TITLE
Map dark mode

### DIFF
--- a/.changeset/map-dark-mode.md
+++ b/.changeset/map-dark-mode.md
@@ -1,0 +1,7 @@
+---
+'@ldn-viz/maps': major
+---
+
+CHANGED: refactored `Map` by splitting out core MapLibre stuff to `MapLibre` internal component.
+CHANGED: updated `Map` to accept light and dark base map styles and toggle them based on theme mode.
+CHANGED: removed `classes` property from `map`, pass classes as `class` attribute instead. 

--- a/packages/maps/src/lib/index.js
+++ b/packages/maps/src/lib/index.js
@@ -2,6 +2,8 @@
 export * from './map/Map.svelte';
 export { default as Map } from './map/Map.svelte';
 export { default as MapApp } from './map/MapApp.svelte';
+export * from './map/types';
+export * from './map/util';
 
 // Controls
 export { default as MapControlFullscreen } from './mapControlFullscreen/MapControlFullscreen.svelte';

--- a/packages/maps/src/lib/map/Map.stories.svelte
+++ b/packages/maps/src/lib/map/Map.stories.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 
 	import * as darkStyle from '../themes/os_dark.json';
@@ -7,10 +7,17 @@
 	import * as os_light_vts from '../themes/os_light_vts.json';
 
 	import loadTestLayers from '../loadTestLayers';
-	import Map, { appendOSKeyToUrl } from './Map.svelte';
+	import Map from './Map.svelte';
+	import { appendOSKeyToUrl } from './util';
+	import type { MapLibreStyle } from './types';
+
 	import PropertiesStory from './PropertiesStory.svelte';
 
 	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
+
+	const castAsMapLibreStyle = (style: unknown): MapLibreStyle => {
+		return style as MapLibreStyle;
+	};
 </script>
 
 <Meta
@@ -24,7 +31,16 @@
 			table: {
 				type: {
 					summary: 'function',
-					detail: '(osKey: string) => string'
+					detail: '(osKey: string) => maplibre_gl.TransformRequestFunction'
+				}
+			}
+		},
+		options: {
+			control: 'none',
+			table: {
+				type: {
+					summary: 'object',
+					detail: 'MapLibreOptions'
 				}
 			}
 		},
@@ -33,7 +49,7 @@
 			table: {
 				type: {
 					summary: 'Svelte store',
-					detail: 'writable<null | maplibre_gl.Map>'
+					detail: 'writable<null | MapLibre>'
 				}
 			}
 		},
@@ -42,7 +58,7 @@
 			table: {
 				type: {
 					summary: 'Svelte store',
-					detail: 'writable<null | MapCursor>'
+					detail: 'writable<null | MapCursorType>'
 				}
 			}
 		},
@@ -51,7 +67,7 @@
 			table: {
 				type: {
 					summary: 'function',
-					detail: '(map: maplibre_gl.Map) => void'
+					detail: '(map: MapLibre) => void'
 				}
 			}
 		},
@@ -60,9 +76,32 @@
 			table: {
 				type: {
 					summary: 'function',
-					detail: '(map: maplibre_gl.Map) => void'
+					detail: '(map: MapLibre) => void'
 				}
 			}
+		},
+		lightStyle: {
+			control: 'none',
+			table: {
+				type: {
+					summary: 'object',
+					detail: 'MapLibreStyle'
+				}
+			}
+		},
+		darkStyle: {
+			control: 'none',
+			table: {
+				type: {
+					summary: 'object',
+					detail: 'MapLibreStyle'
+				}
+			}
+		}
+	}}
+	args={{
+		options: {
+			transformRequest: appendOSKeyToUrl(OS_KEY)
 		}
 	}}
 />
@@ -73,6 +112,8 @@
 	</div>
 </Template>
 
+<Story name="Responsive to theme" source />
+
 <!--
 This is our default light basemap.
 It uses the Ordnance Survey's [OS_VTS_3857_Light.json](https://github.com/OrdnanceSurvey/OS-Vector-Tile-API-Stylesheets) stylesheet.
@@ -81,8 +122,9 @@ It uses the Ordnance Survey's [OS_VTS_3857_Light.json](https://github.com/Ordnan
 	<div class="w-[100dvw] h-[100dvh]">
 		<Map
 			whenMapLoads={loadTestLayers}
+			lightStyle={castAsMapLibreStyle(os_light_vts)}
+			darkStyle={null}
 			options={{
-				style: os_light_vts,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		/>
@@ -97,8 +139,9 @@ It is very similar to the Ordnance Survey's [OS_VTS_3857_Greyscale.json](https:/
 	<div class="w-[100dvw] h-[100dvh]">
 		<Map
 			whenMapLoads={loadTestLayers}
+			lightStyle={castAsMapLibreStyle(greyStyle)}
+			darkStyle={null}
 			options={{
-				style: greyStyle,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		/>
@@ -110,8 +153,9 @@ It is very similar to the Ordnance Survey's [OS_VTS_3857_Greyscale.json](https:/
 	<div class="w-[100dvw] h-[100dvh]">
 		<Map
 			whenMapLoads={loadTestLayers}
+			lightStyle={null}
+			darkStyle={castAsMapLibreStyle(darkGreyMutedStyle)}
 			options={{
-				style: darkGreyMutedStyle,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		/>
@@ -126,8 +170,9 @@ It uses the Ordnance Survey's [OS_VTS_3857_Dark.json](https://github.com/Ordnanc
 	<div class="w-[100dvw] h-[100dvh]">
 		<Map
 			whenMapLoads={loadTestLayers}
+			lightStyle={null}
+			darkStyle={castAsMapLibreStyle(darkStyle)}
 			options={{
-				style: darkStyle,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		/>

--- a/packages/maps/src/lib/map/Map.svelte
+++ b/packages/maps/src/lib/map/Map.svelte
@@ -1,49 +1,12 @@
-<script context="module" lang="ts">
-	import maplibre_gl from 'maplibre-gl';
-	import 'maplibre-gl/dist/maplibre-gl.css';
-	import { onMount, setContext } from 'svelte';
-	import { writable, type Writable } from 'svelte/store';
-
-	import {
-		GREATER_LONDON_BOUNDS,
-		GREATER_LONDON_BOUNDS_MAX,
-		theme_os_light_vts
-	} from '@ldn-viz/maps';
-	import MapCursor from './mapCursor/MapCursor';
-	import type { MapCursorStore } from './mapCursor/types';
-
-	export type MapLibre = maplibre_gl.Map;
-	export type MapStore = Writable<null | maplibre_gl.Map>;
-	export type WhenMapLoads = (map: maplibre_gl.Map) => void;
-
-	/**
-	 * Applied as the MapLibre `transformRequest` option to append the OS key
-	 * to outgoing OS API requests.
-	 */
-	export const appendOSKeyToUrl = (osKey: string) => {
-		return (url: string) => {
-			const urlObj = new URL(url);
-
-			if (urlObj.hostname !== 'api.os.uk') {
-				return { url: urlObj.href };
-			}
-
-			const WEB_MERCATOR_EPSG = '3857';
-			urlObj.searchParams.set('srs', WEB_MERCATOR_EPSG);
-			urlObj.searchParams.set('key', osKey);
-
-			return { url: urlObj.href };
-		};
-	};
-</script>
-
 <script lang="ts">
 	/**
-	 * The `<Map>` component wraps a MapLibre `Map` to provide:
-	 * - access to the `Map` and `MapCursor` objects via context;
-	 * - notification of both map initialisation and destruction events;
-	 * - default map options suitable for mapping in London;
-	 * - default styling to HTML elements rendered by the map.
+	 * The `<Map>` component wraps a MapLibre map and manages the style (based
+	 * on the current theme mode) and cursor event handling for quicker and
+	 * easier map creation and management.
+	 *
+	 * It also:
+	 * - provides stores for `Map` and `MapCursor` instances;
+	 * - sets context for `Map` and `MapCursor` instances;
 	 *
 	 * The map's container has a relative CSS position so slotted content can
 	 * position itself accordingly. Map controls and other overlay components
@@ -53,26 +16,42 @@
 	 * @component
 	 */
 
-	/**
-	 * Store containing the MapLibre instance.
-	 */
-	export const mapStore: MapStore = writable(null);
+	import { setContext } from 'svelte';
+	import { writable } from 'svelte/store';
+	import maplibre_gl from 'maplibre-gl';
 
-	/**
-	 * Store containing the MapCursor instance.
-	 */
-	export const mapCursorStore: MapCursorStore = writable(null);
+	import { currentThemeMode } from '@ldn-viz/ui';
+	import { theme_os_light_vts, theme_os_dark } from '@ldn-viz/maps';
+
+	import MapCursor from './mapCursor/MapCursor';
+	import type { MapCursorType, MapCursorTypeStore } from './mapCursor/types';
+
+	import MapLibre from './MapLibre.svelte';
+	import type { MapLibreOptions, MapLibreStyle, MapStore, WhenMapLoads } from './types';
 
 	/**
 	 * Disables initialisation of the map on mount. This is most often used
-	 * to speed up development on non-map components.
+	 * to avoid uneeded map rendering during development of non-map application
+	 * elements.
 	 */
 	export let disabled = false;
 
 	/**
-	 * Custom MapLibre options (see [MapOptions](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/MapOptions/)).
+	 * Custom ([MapLibre `MapOptions`](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/MapOptions/)).
 	 */
-	export let options = {};
+	export let options: MapLibreOptions = {};
+
+	/**
+	 * Store containing the MapLibre instance.
+	 */
+	export const mapStore: MapStore = writable(null);
+	setContext('mapStore', mapStore);
+
+	/**
+	 * Store containing the MapCursor instance.
+	 */
+	export const mapCursorStore: MapCursorTypeStore = writable(null);
+	setContext('mapCursorStore', mapCursorStore);
 
 	/**
 	 * Called when the map is finished loading and ready for use.
@@ -80,97 +59,81 @@
 	export let whenMapLoads: null | WhenMapLoads = null;
 
 	/**
-	 * Called when the map component is destroyed. Required when external resources need to be cleaned up.
+	 * Called when the map component is destroyed. Required when external
+	 * resources need to be cleaned up.
 	 */
 	export let whenMapUnloads: null | WhenMapLoads = null;
 
 	/**
-	 * Additional classes applied to the map's container element.
+	 * Light style base map. Defaults to `theme_os_light_vts`. Pass `null`
+	 * to disable light mode.
 	 */
-	export let classes = '';
+	export let lightStyle: null | MapLibreStyle = theme_os_light_vts as MapLibreStyle;
 
-	setContext('mapStore', mapStore);
-	setContext('mapCursorStore', mapCursorStore);
+	/**
+	 * Dark style base map. Defaults to `theme_os_dark`. Pass `null`
+	 * to disable dark mode.
+	 */
+	export let darkStyle: null | MapLibreStyle = theme_os_dark as MapLibreStyle;
 
-	const defaultOptions = {
-		style: theme_os_light_vts,
-		bounds: GREATER_LONDON_BOUNDS,
-		maxBounds: GREATER_LONDON_BOUNDS_MAX,
-		attributionControl: true,
-		clickTolerance: 6
-	};
-
-	let container: null | HTMLElement;
-
-	onMount(() => {
-		if (disabled) {
-			return;
-		}
-
-		const maplibre: maplibre_gl.Map = new maplibre_gl.Map({
-			...defaultOptions,
-			...options,
-			container: container as HTMLElement
-		} as maplibre_gl.MapOptions);
-
+	const whenMapCreated: WhenMapLoads = (maplibre) => {
 		maplibre.once('load', () => {
 			mapStore.set(maplibre);
-			mapCursorStore.set(new MapCursor(maplibre));
+
+			const mapCursor = MapCursor(maplibre) as MapCursorType;
+			mapCursorStore.set(mapCursor);
 
 			if (whenMapLoads) {
 				whenMapLoads(maplibre);
 			}
-
-			// When embedded the map has a tendency to not spread itself across its
-			// entire canvas. This might be a MapLibre issue but it is resolved by
-			// forcing a resize.
-			maplibre.resize();
 		});
+	};
 
-		return () => {
-			if (whenMapUnloads) {
-				whenMapUnloads(maplibre);
-			}
+	const whenMapDestroyed: WhenMapLoads = (maplibre) => {
+		if (whenMapUnloads) {
+			whenMapUnloads(maplibre);
+		}
 
-			$mapCursorStore?.destroy();
+		$mapCursorStore?.destroy();
 
-			mapStore.set(null);
-			mapCursorStore.set(null);
+		mapStore.set(null);
+		mapCursorStore.set(null);
+	};
+
+	const updateMapOptions = () => {
+		mapOptions = {
+			...options,
+			style: identifyStyle()
 		};
-	});
+	};
 
-	// client width and height because on:resize won't always trigger refresh.
-	let clientWidth = 0;
-	let clientHeight = 0;
-	$: clientWidth && clientHeight && $mapStore?.resize();
+	const identifyStyle = (): MapLibreStyle => {
+		if (!lightStyle && !darkStyle) {
+			return theme_os_light_vts as MapLibreStyle;
+		}
+
+		if (lightStyle && !darkStyle) {
+			return lightStyle as MapLibreStyle;
+		}
+
+		if (!lightStyle && darkStyle) {
+			return darkStyle as MapLibreStyle;
+		}
+
+		const style = $currentThemeMode === 'dark' ? darkStyle : lightStyle;
+		return style as MapLibreStyle;
+	};
+
+	let mapOptions: Omit<maplibre_gl.MapOptions, 'container'> = {
+		...options,
+		style: identifyStyle()
+	};
+
+	$: $currentThemeMode, darkStyle, lightStyle, updateMapOptions();
 </script>
 
-<section
-	bind:this={container}
-	bind:clientWidth
-	bind:clientHeight
-	class="w-full h-full relative overflow-hidden dark {classes}"
-	{...$$restProps}
->
-	<slot />
-</section>
-
-<style global>
-	/*
-		Override top level MapLibre & MapBox styling with ldn-viz styling so we
-		don't have to do it separately within each map sub-component, e.g.
-		map controls, popups, etc.
-	*/
-	.mapboxgl-map,
-	.maplibregl-map {
-		font-size: inherit;
-		font-family: inherit;
-		font-style: inherit;
-		line-height: inherit;
-	}
-
-	.maplibregl-ctrl-attrib-inner,
-	.mapboxgl-ctrl-attrib-inner {
-		@apply text-sm;
-	}
-</style>
+{#key mapOptions}
+	<MapLibre {disabled} options={mapOptions} {whenMapCreated} {whenMapDestroyed} {...$$restProps}>
+		<slot />
+	</MapLibre>
+{/key}

--- a/packages/maps/src/lib/map/MapLibre.svelte
+++ b/packages/maps/src/lib/map/MapLibre.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+	/**
+	 * The `<MapLibre>` component wraps a MapLibre `Map` ensuring it sizes
+	 * correctly and exposing map creation and destruction functions. It is not
+	 * designed for external use. Use the `<Map>` component instead.
+	 *
+	 * (see [MapLibre Map](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/)).
+	 * @component
+	 */
+
+	import { onMount, onDestroy } from 'svelte';
+	import maplibre_gl from 'maplibre-gl';
+	import 'maplibre-gl/dist/maplibre-gl.css';
+
+	import {
+		GREATER_LONDON_BOUNDS,
+		GREATER_LONDON_BOUNDS_MAX,
+		theme_os_light_vts
+	} from '@ldn-viz/maps';
+
+	import type { MapLibre, MapLibreStyle, WhenMapLoads, MapLibreBounds } from './types';
+
+	type MapLibreOptions = Omit<maplibre_gl.MapOptions, 'container'>;
+
+	const defaultOptions: MapLibreOptions = {
+		style: theme_os_light_vts as MapLibreStyle,
+		bounds: GREATER_LONDON_BOUNDS as MapLibreBounds,
+		maxBounds: GREATER_LONDON_BOUNDS_MAX as MapLibreBounds,
+		clickTolerance: 6
+	};
+
+	/**
+	 * Disables initialisation of the map on mount. This is most often used
+	 * to avoid uneeded map rendering during development of non-map application
+	 * elements.
+	 */
+	export let disabled = false;
+
+	/**
+	 * Custom MapLibre options (see [MapOptions](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/MapOptions/)).
+	 */
+	export let options: MapLibreOptions = defaultOptions;
+
+	/**
+	 * Called during component mounting after the map has been created but
+	 * before it has loaded.
+	 *
+	 * This allows custom `load` functions to be added to the map instance
+	 * before loading occurs.
+	 */
+	export let whenMapCreated: null | WhenMapLoads = null;
+
+	/**
+	 * Called during component unmounting just before the map and component are
+	 * destroyed.
+	 */
+	export let whenMapDestroyed: null | WhenMapLoads = null;
+
+	let container: null | HTMLElement;
+	let maplibre: null | MapLibre;
+
+	onMount(() => {
+		if (disabled) {
+			return;
+		}
+
+		maplibre = new maplibre_gl.Map({
+			...defaultOptions,
+			...options,
+			container: container as HTMLElement
+		} as maplibre_gl.MapOptions);
+
+		maplibre.once('load', () => {
+			// When embedded the map has a tendency to not spread itself across its
+			// entire canvas. This might be a MapLibre issue but it is resolved by
+			// forcing a resize.
+			maplibre!.resize();
+		});
+
+		if (whenMapCreated) {
+			whenMapCreated(maplibre!);
+		}
+	});
+
+	onDestroy(() => {
+		return () => {
+			if (whenMapDestroyed) {
+				whenMapDestroyed(maplibre!);
+			}
+
+			maplibre = null;
+		};
+	});
+
+	// client width and height because on:resize won't always trigger refresh.
+	let clientWidth = 0;
+	let clientHeight = 0;
+	$: clientWidth && clientHeight && maplibre?.resize();
+</script>
+
+<section
+	bind:this={container}
+	bind:clientWidth
+	bind:clientHeight
+	class:w-full={true}
+	class:h-full={true}
+	class:relative={true}
+	class:overflow-hidden={true}
+	{...$$restProps}
+>
+	<slot />
+</section>
+
+<style global>
+	/*
+		Override top level MapLibre & MapBox styling with ldn-viz styling so we
+		don't have to do it separately within each map sub-component, e.g.
+		map controls, popups, etc.
+	*/
+
+	.mapboxgl-map,
+	.maplibregl-map {
+		font-size: inherit;
+		font-family: inherit;
+		font-style: inherit;
+		line-height: inherit;
+	}
+
+	.maplibregl-ctrl-attrib-inner,
+	.mapboxgl-ctrl-attrib-inner {
+		@apply text-sm;
+	}
+</style>

--- a/packages/maps/src/lib/map/PropertiesStory.svelte
+++ b/packages/maps/src/lib/map/PropertiesStory.svelte
@@ -1,29 +1,37 @@
-<script>
-	import * as os_light_vts from '../themes/os_light_vts.json';
-	import Map, { appendOSKeyToUrl } from './Map.svelte';
+<script lang="ts">
+	import Map from './Map.svelte';
+	import { appendOSKeyToUrl } from './util';
+	import type { MapLibre, MapLibrePoint, MapLibreMouseLikeEvent } from './types';
 
-	let clickedLayerIDs = ['Click a point on the map to list the vector layer IDs'];
-	let map = null;
+	const initialLayerIds = ['Click a point on the map to list the vector layer IDs'];
 
-	const updateClickedLayers = (event) => {
+	let clickedLayerIDs: string[] = initialLayerIds;
+	let map: null | MapLibre = null;
+
+	const updateClickedLayers = (event: MapLibreMouseLikeEvent) => {
 		if (map) {
-			clickedLayerIDs = removeDuplicates(queryVectorLayerIDs(event.point));
+			const ids = queryVectorLayerIDs(event.point);
+			clickedLayerIDs = removeDuplicateIds(ids);
 		}
 	};
 
-	const queryVectorLayerIDs = (point) => {
+	const queryVectorLayerIDs = (point: MapLibrePoint): string[] => {
+		if (!map) {
+			return initialLayerIds;
+		}
+
 		return map.queryRenderedFeatures(point).map((f) => f.layer.id);
 	};
 
-	const removeDuplicates = (array) => [...new Set(array)];
+	const removeDuplicateIds = (array: string[]): string[] => [...new Set(array)];
 
-	const registerClickHandler = (newMap) => {
+	const registerClickHandler = (newMap: MapLibre) => {
 		map = newMap;
 		newMap.getCanvas().style.cursor = 'pointer';
 		newMap.on('click', updateClickedLayers);
 	};
 
-	const unregisterClickHandler = (oldMap) => {
+	const unregisterClickHandler = (oldMap: MapLibre) => {
 		oldMap.off('click', updateClickedLayers);
 		map = null;
 	};
@@ -34,7 +42,6 @@
 		whenMapLoads={registerClickHandler}
 		whenMapUnloads={unregisterClickHandler}
 		options={{
-			style: os_light_vts,
 			transformRequest: appendOSKeyToUrl('vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP')
 		}}
 	>

--- a/packages/maps/src/lib/map/mapCursor/types.ts
+++ b/packages/maps/src/lib/map/mapCursor/types.ts
@@ -1,10 +1,29 @@
 import type { Writable } from 'svelte/store';
-import MapCursor from './MapCursor.js';
+import type { MapLibreMouseLikeEvent } from '../types';
 
-export type MapCursorStore = Writable<null | MapCursor>;
+type Handler = (
+	event: MapLibreMouseLikeEvent,
+	details: {
+		feature: null | object;
+		features: object[];
+		isTouchEvent: boolean;
+	}
+) => void;
+
+// TODO: Needs further refinement of feature object types
+export type MapCursorType = {
+	activeFeatures: () => object[];
+	topFeature: () => null | object;
+	on: (eventType: string, layerId: string, handler: Handler) => void;
+	off: (eventType: string, layerId: string, handler: Handler) => void;
+	offLayer: (layerId: string) => void;
+	destroy: () => void;
+};
+
+export type MapCursorTypeStore = Writable<null | MapCursorType>;
 
 export type MapCursorFeatureHandler = (
-	event: MouseEvent | TouchEvent,
+	event: MapLibreMouseLikeEvent,
 	details: {
 		feature: null | object;
 		features: object[];

--- a/packages/maps/src/lib/map/types.ts
+++ b/packages/maps/src/lib/map/types.ts
@@ -1,0 +1,57 @@
+import maplibre_gl from 'maplibre-gl';
+import type { StyleSpecification } from 'maplibre-gl';
+import { type Writable } from 'svelte/store';
+
+/**
+ * Alias for MapLibre map options type.
+ */
+export type MapLibreOptions = Omit<maplibre_gl.MapOptions, 'container' | 'style'>;
+
+/**
+ * Alias for MapLibre style specification type.
+ */
+export type MapLibreStyle = StyleSpecification;
+
+/**
+ * Alias for a MapLibre Map instance type.
+ */
+export type MapLibre = maplibre_gl.Map;
+
+/**
+ * Store type for a MapLibre Map instance.
+ */
+export type MapLibreStore = Writable<null | MapLibre>;
+
+/**
+ * Store type for a MapLibre Map instance.
+ *
+ * @deprecated Use MapLibreStore.
+ */
+export type MapStore = MapLibreStore;
+
+/**
+ * Called when the map is created, destroyed, loaded or unloaded.
+ */
+export type WhenMapLoads = (map: MapLibre) => void;
+
+/**
+ * Alias for a MapLibre point type or point like type.
+ */
+export type MapLibrePoint = maplibre_gl.PointLike;
+
+/**
+ * Alias for a MapLibre bounds or bounds like.
+ */
+export type MapLibreBounds = maplibre_gl.LngLatBoundsLike;
+
+/**
+ * Alias for MapLibre for mouse, touch, pen, and other pointer like events.
+ */
+export type MapLibreMouseLikeEvent = maplibre_gl.MapMouseEvent | maplibre_gl.MapTouchEvent;
+
+/**
+ * Alias for MapLibre for mouse, touch, pen, and other pointer like layer events.
+ */
+export type MapLibreLayerMouseLikeEvent =
+	| maplibre_gl.MapLayerMouseEvent
+	| maplibre_gl.MapLayerTouchEvent;

--- a/packages/maps/src/lib/map/util.ts
+++ b/packages/maps/src/lib/map/util.ts
@@ -1,0 +1,21 @@
+import type { RequestTransformFunction } from 'maplibre-gl';
+
+/**
+ * Applied as the MapLibre `transformRequest` option to append the OS key
+ * to outgoing OS API requests.
+ */
+export const appendOSKeyToUrl: (osKey: string) => RequestTransformFunction = (osKey) => {
+	return (url: string) => {
+		const urlObj = new URL(url);
+
+		if (urlObj.hostname !== 'api.os.uk') {
+			return { url: urlObj.href };
+		}
+
+		const WEB_MERCATOR_EPSG = '3857';
+		urlObj.searchParams.set('srs', WEB_MERCATOR_EPSG);
+		urlObj.searchParams.set('key', osKey);
+
+		return { url: urlObj.href };
+	};
+};

--- a/packages/maps/src/lib/mapContextLayers/boroughsContextLayer/BoroughsContextLayer.stories.svelte
+++ b/packages/maps/src/lib/mapContextLayers/boroughsContextLayer/BoroughsContextLayer.stories.svelte
@@ -48,7 +48,8 @@
 
 <script>
 	import { Story, Template } from '@storybook/addon-svelte-csf';
-	import Map, { appendOSKeyToUrl } from '../../map/Map.svelte';
+	import Map from '../../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../../map/util';
 
 	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
 </script>

--- a/packages/maps/src/lib/mapControlBorough/MapControlBorough.stories.svelte
+++ b/packages/maps/src/lib/mapControlBorough/MapControlBorough.stories.svelte
@@ -13,18 +13,19 @@
 <script lang="ts">
 	import { Template, Story } from '@storybook/addon-svelte-csf';
 
-	import * as os_light_vts from '../themes/os_light_vts.json';
 	import MapApp from '../map/MapApp.svelte';
-	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
+	import type { MapLibreStore } from '../map/types';
 
 	import MapControlGroup from '../mapControlGroup/MapControlGroup.svelte';
-	import { type Writable, writable } from 'svelte/store';
-	import type { Map as MaplibreglMap } from 'maplibre-gl';
+	import { writable } from 'svelte/store';
 	import BoroughsContextLayer from '../mapContextLayers/boroughsContextLayer/BoroughsContextLayer.svelte';
 
 	const transformRequest = appendOSKeyToUrl('vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP');
 
-	let mapStore: Writable<MaplibreglMap> = writable();
+	let mapStore: MapLibreStore = writable();
 </script>
 
 <Template let:args>
@@ -35,7 +36,6 @@
 	<MapApp>
 		<Map
 			options={{
-				style: os_light_vts,
 				transformRequest
 			}}
 			bind:mapStore

--- a/packages/maps/src/lib/mapControlFullscreen/MapControlFullscreen.stories.svelte
+++ b/packages/maps/src/lib/mapControlFullscreen/MapControlFullscreen.stories.svelte
@@ -1,9 +1,9 @@
 <script>
 	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
 	import MapApp from '../map/MapApp.svelte';
-	import * as os_light_vts from '../themes/os_light_vts.json';
 
 	import MapControlFullscreen from '../mapControlFullscreen/MapControlFullscreen.svelte';
 	import MapControlGroup from '../mapControlGroup/MapControlGroup.svelte';
@@ -43,7 +43,6 @@
 		<Map
 			whenMapLoads={(m) => (map = m)}
 			options={{
-				style: os_light_vts,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>

--- a/packages/maps/src/lib/mapControlGroup/MapControlGroup.stories.svelte
+++ b/packages/maps/src/lib/mapControlGroup/MapControlGroup.stories.svelte
@@ -1,9 +1,9 @@
 <script>
 	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
 	import MapApp from '../map/MapApp.svelte';
-	import * as os_light_vts from '../themes/os_light_vts.json';
 
 	import MapControlFullscreen from '../mapControlFullscreen/MapControlFullscreen.svelte';
 	import MapControlLocationSearch from '../mapControlLocationSearch/MapControlLocationSearch.svelte';
@@ -32,7 +32,6 @@
 	<MapApp>
 		<Map
 			options={{
-				style: os_light_vts,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>
@@ -65,7 +64,6 @@
 	<MapApp>
 		<Map
 			options={{
-				style: os_light_vts,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>
@@ -97,7 +95,6 @@
 	<MapApp>
 		<Map
 			options={{
-				style: os_light_vts,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
@@ -13,9 +13,9 @@
 <script lang="ts">
 	import { Template, Story } from '@storybook/addon-svelte-csf';
 
-	import * as os_light_vts from '../themes/os_light_vts.json';
 	import MapApp from '../map/MapApp.svelte';
-	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
 
 	import MapControlGroup from '../mapControlGroup/MapControlGroup.svelte';
 
@@ -40,7 +40,6 @@
 	<MapApp>
 		<Map
 			options={{
-				style: os_light_vts,
 				transformRequest
 			}}
 		>
@@ -55,7 +54,6 @@
 	<MapApp>
 		<Map
 			options={{
-				style: os_light_vts,
 				transformRequest
 			}}
 		>

--- a/packages/maps/src/lib/mapControlPan/MapControlPan.stories.svelte
+++ b/packages/maps/src/lib/mapControlPan/MapControlPan.stories.svelte
@@ -1,9 +1,9 @@
 <script>
 	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
 	import MapApp from '../map/MapApp.svelte';
-	import * as os_light_vts from '../themes/os_light_vts.json';
 
 	import MapControlGroup from '../mapControlGroup/MapControlGroup.svelte';
 	import MapControlPan from '../mapControlPan/MapControlPan.svelte';
@@ -46,7 +46,6 @@
 
 		<Map
 			options={{
-				style: os_light_vts,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>

--- a/packages/maps/src/lib/mapControlRefresh/MapControlRefresh.stories.svelte
+++ b/packages/maps/src/lib/mapControlRefresh/MapControlRefresh.stories.svelte
@@ -1,9 +1,9 @@
 <script>
 	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
 	import MapApp from '../map/MapApp.svelte';
-	import * as os_light_vts from '../themes/os_light_vts.json';
 
 	import MapControlGroup from '../mapControlGroup/MapControlGroup.svelte';
 	import MapControlRefresh from '../mapControlRefresh/MapControlRefresh.svelte';
@@ -34,7 +34,6 @@
 
 		<Map
 			options={{
-				style: os_light_vts,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>

--- a/packages/maps/src/lib/mapControlZoom/MapControlZoom.stories.svelte
+++ b/packages/maps/src/lib/mapControlZoom/MapControlZoom.stories.svelte
@@ -1,9 +1,9 @@
 <script>
 	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
 	import MapApp from '../map/MapApp.svelte';
-	import * as os_light_vts from '../themes/os_light_vts.json';
 
 	import MapControlGroup from '../mapControlGroup/MapControlGroup.svelte';
 	import MapControlZoom from '../mapControlZoom/MapControlZoom.svelte';
@@ -46,7 +46,6 @@
 
 		<Map
 			options={{
-				style: os_light_vts,
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>

--- a/packages/maps/src/lib/mapCursorEvent/MapCursorEvent.stories.svelte
+++ b/packages/maps/src/lib/mapCursorEvent/MapCursorEvent.stories.svelte
@@ -55,7 +55,9 @@
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 
 	import loadTestLayers from '../loadTestLayers';
-	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
+
 	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
 
 	let init = false;

--- a/packages/maps/src/lib/mapLayerSource/MapLayerSource.stories.svelte
+++ b/packages/maps/src/lib/mapLayerSource/MapLayerSource.stories.svelte
@@ -46,7 +46,8 @@
 <script lang="ts">
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
 	import MapLayerView from '../mapLayerView/MapLayerView.svelte';
 	import testData from '../testData.json';
 

--- a/packages/maps/src/lib/mapLayerSource/adaptations/geojsonMapLayerSource/GeoJSONMapLayerSource.stories.svelte
+++ b/packages/maps/src/lib/mapLayerSource/adaptations/geojsonMapLayerSource/GeoJSONMapLayerSource.stories.svelte
@@ -95,7 +95,8 @@
 	import colors from '@ldn-viz/themes/colors.json';
 	import { Button } from '@ldn-viz/ui';
 
-	import Map, { appendOSKeyToUrl } from '../../../map/Map.svelte';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
 	import MapLayerView from '../../../mapLayerView/MapLayerView.svelte';
 	import testData from '../../../testData.json';
 

--- a/packages/maps/src/lib/mapLayerSource/adaptations/geojsonMapLayerSource/GeoJSONMapLayerSource.stories.svelte
+++ b/packages/maps/src/lib/mapLayerSource/adaptations/geojsonMapLayerSource/GeoJSONMapLayerSource.stories.svelte
@@ -95,8 +95,8 @@
 	import colors from '@ldn-viz/themes/colors.json';
 	import { Button } from '@ldn-viz/ui';
 
-	import Map from '../map/Map.svelte';
-	import { appendOSKeyToUrl } from '../map/util';
+	import Map from '../../../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../../../map/util';
 	import MapLayerView from '../../../mapLayerView/MapLayerView.svelte';
 	import testData from '../../../testData.json';
 

--- a/packages/maps/src/lib/mapLayerView/MapLayerView.stories.svelte
+++ b/packages/maps/src/lib/mapLayerView/MapLayerView.stories.svelte
@@ -67,7 +67,8 @@
 <script lang="ts">
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
 	import MapLayerSource from '../mapLayerSource/MapLayerSource.svelte';
 	import testData from '../testData.json';
 

--- a/packages/maps/src/lib/mapMarker/MapMarker.stories.svelte
+++ b/packages/maps/src/lib/mapMarker/MapMarker.stories.svelte
@@ -35,7 +35,8 @@
 <script>
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
 	import loadTestLayers from '../loadTestLayers';
 	import TestTooltip from './TestTooltip.svelte';
 	import TestPopup from './TestPopup.svelte';

--- a/packages/maps/src/lib/mapMarker/elements/mapMarkerContainer/MapMarkerContainer.stories.svelte
+++ b/packages/maps/src/lib/mapMarker/elements/mapMarkerContainer/MapMarkerContainer.stories.svelte
@@ -34,7 +34,9 @@
 	import { writable } from 'svelte/store';
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../../../map/Map.svelte';
+	import Map from '../../../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../../../map/util';
+
 	import loadTestLayers from '../../../loadTestLayers';
 	import MapMarker from '../../MapMarker.svelte';
 	import TestTooltip from './TestTooltip.svelte';

--- a/packages/maps/src/lib/mapMarker/elements/mapMarkerFlyToFeature/MapMarkerFlyToFeature.stories.svelte
+++ b/packages/maps/src/lib/mapMarker/elements/mapMarkerFlyToFeature/MapMarkerFlyToFeature.stories.svelte
@@ -20,7 +20,9 @@
 	import { setContext } from 'svelte';
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../../../map/Map.svelte';
+	import Map from '../../../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../../../map/util';
+
 	import loadTestLayers from '../../../loadTestLayers';
 	import MapMarker from '../../MapMarker.svelte';
 

--- a/packages/maps/src/lib/mapMarker/elements/mapMarkerPlacement/MapMarkerPlacement.stories.svelte
+++ b/packages/maps/src/lib/mapMarker/elements/mapMarkerPlacement/MapMarkerPlacement.stories.svelte
@@ -22,7 +22,9 @@
 	import { writable } from 'svelte/store';
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../../../map/Map.svelte';
+	import Map from '../../../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../../../map/util';
+
 	import loadTestLayers from '../../../loadTestLayers';
 	import MapMarker from '../../MapMarker.svelte';
 	import TestTooltipCenterAboveFeature from './TestTooltipCenterAboveFeature.svelte';

--- a/packages/maps/src/lib/mapMarker/elements/mapMarkerStyledContainer/MapMarkerStyledContainer.stories.svelte
+++ b/packages/maps/src/lib/mapMarker/elements/mapMarkerStyledContainer/MapMarkerStyledContainer.stories.svelte
@@ -25,7 +25,9 @@
 	import { writable } from 'svelte/store';
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 
-	import Map, { appendOSKeyToUrl } from '../../../map/Map.svelte';
+	import Map from '../../../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../../../map/util';
+
 	import loadTestLayers from '../../../loadTestLayers';
 	import MapMarker from '../../MapMarker.svelte';
 	import TestTooltip from './TestTooltip.svelte';


### PR DESCRIPTION
**What does this change?**

Adds dark mode to `Map` component including new properties to set light and dark map styles.

**How?**

A `style` value must no longer be provided to the `options` prop.

Adds props:
- `lightStyle`: light map style to use or null to disable light mode.
- `darkStyle`: dark map style to use or null to disable dark mode.

**How is it tested?**

Storybook.

**How is it documented?**

Storybook.

**Are light and dark themes considered?**

Yes.

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
