### PR TITLE
Rewrite map control group & fix its types

### DIFF
--- a/.changeset/map-control-group.md
+++ b/.changeset/map-control-group.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': major
+---
+
+CHANGED: rewrite `MapControlGroup` interface and types.

--- a/packages/maps/src/lib/index.js
+++ b/packages/maps/src/lib/index.js
@@ -6,6 +6,7 @@ export { default as MapApp } from './map/MapApp.svelte';
 // Controls
 export { default as MapControlFullscreen } from './mapControlFullscreen/MapControlFullscreen.svelte';
 export { default as MapControlGroup } from './mapControlGroup/MapControlGroup.svelte';
+export * from './mapControlGroup/MapControlGroup.svelte';
 export { default as MapControlPan } from './mapControlPan/MapControlPan.svelte';
 export { default as MapControlRefresh } from './mapControlRefresh/MapControlRefresh.svelte';
 export { default as MapControlZoom } from './mapControlZoom/MapControlZoom.svelte';

--- a/packages/maps/src/lib/mapControlBorough/MapControlBorough.stories.svelte
+++ b/packages/maps/src/lib/mapControlBorough/MapControlBorough.stories.svelte
@@ -40,7 +40,7 @@
 			}}
 			bind:mapStore
 		>
-			<MapControlGroup position="TopLeft">
+			<MapControlGroup>
 				<MapControlBorough map={$mapStore} />
 			</MapControlGroup>
 

--- a/packages/maps/src/lib/mapControlFullscreen/MapControlFullscreen.stories.svelte
+++ b/packages/maps/src/lib/mapControlFullscreen/MapControlFullscreen.stories.svelte
@@ -47,7 +47,7 @@
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>
-			<MapControlGroup position="BottomLeft">
+			<MapControlGroup y="bottom">
 				<MapControlFullscreen {map} />
 			</MapControlGroup>
 		</Map>

--- a/packages/maps/src/lib/mapControlGroup/MapControlGroup.stories.svelte
+++ b/packages/maps/src/lib/mapControlGroup/MapControlGroup.stories.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
 
 	import Map, { appendOSKeyToUrl } from '../map/Map.svelte';
@@ -11,9 +11,27 @@
 	import MapControlPan from '../mapControlPan/MapControlPan.svelte';
 	import MapControlRefresh from '../mapControlRefresh/MapControlRefresh.svelte';
 	import MapControlZoom from '../mapControlZoom/MapControlZoom.svelte';
-	import MapControlGroup, { MapControlGroupPositions } from './MapControlGroup.svelte';
+	import MapControlGroup from './MapControlGroup.svelte';
+	import type {
+		MapControlGroupPositionX,
+		MapControlGroupPositionY
+	} from './MapControlGroup.svelte';
+
+	import { Button } from '@ldn-viz/ui';
 
 	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
+
+	const xPositions: MapControlGroupPositionX[] = ['left', 'center', 'right'];
+	const yPositions: MapControlGroupPositionY[] = ['top', 'center', 'bottom'];
+
+	const newSelectedStringArg = (options, defaultValue = '') => ({
+		control: { type: 'select' },
+		options: options,
+		table: {
+			defaultValue: { summary: defaultValue },
+			type: { summary: 'string' }
+		}
+	});
 </script>
 
 <Meta
@@ -22,46 +40,73 @@
 	parameters={{
 		layout: 'fullscreen'
 	}}
+	argTypes={{
+		x: newSelectedStringArg(['left', 'center', 'right'], 'left'),
+		y: newSelectedStringArg(['top', 'center', 'bottom'], 'top'),
+		xOffset: newSelectedStringArg(['md', 'lg'], 'md'),
+		yOffset: newSelectedStringArg(['md', 'lg'], 'md')
+	}}
 />
 
 <Template let:args>
-	<MapControlGroup {...args} />
+	<div class="w-[100dvw] h-[100dvh] bg-color-bg-primary relative">
+		<MapControlGroup {...args}>
+			<Button variant="square" emphasis="secondary" class="pointer-events-auto">🗺️</Button>
+		</MapControlGroup>
+	</div>
 </Template>
 
-<Story name="Positioning labels">
-	<MapApp>
-		<Map
-			options={{
-				style: os_light_vts,
-				transformRequest: appendOSKeyToUrl(OS_KEY)
-			}}
-		>
-			{#each Object.keys(MapControlGroupPositions) as position}
-				<MapControlGroup {position}>
-					<p class="bg-color-container-level-1 text-color-text-primary p-2">
-						{position}
+<Story name="Default" source />
+
+<Story name="Positions">
+	<div class="w-[100dvw] h-[100dvh] bg-color-bg-primary relative">
+		{#each yPositions as yPos (yPos)}
+			{#each xPositions as xPos (xPos)}
+				<MapControlGroup y={yPos} x={xPos}>
+					<p class="bg-color-container-level-1 text-color-text-primary p-2 capitalize">
+						{yPos}
+						{xPos}
 					</p>
 				</MapControlGroup>
 			{/each}
-
-			<div
-				class="max-w-sm absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2 transform z-10 bg-color-container-level-1 text-color-text-primary text-center p-4 space-y-4"
-			>
-				<p>
-					Group and position map controls using
-					<code>{'<MapControlGroup position="...">'}</code>.
-				</p>
-
-				<p>
-					The named layout positions are shown around the edges of this map. If using typescript you
-					can import the <code>MapControlGroupPositions</code> enum.
-				</p>
-			</div>
-		</Map>
-	</MapApp>
+		{/each}
+	</div>
 </Story>
 
-<Story name="Positioning controls">
+<Story name="Offsets">
+	<div class="w-[100dvw] h-[100dvh] bg-color-bg-primary relative">
+		<Button variant="square" emphasis="secondary" class="pointer-events-auto absolute top-0 left-0">
+			❌
+		</Button>
+		<MapControlGroup xOffset="lg">
+			<p class="bg-color-container-level-1 text-color-text-primary p-2">Offset X (lg)</p>
+		</MapControlGroup>
+
+		<Button
+			variant="square"
+			emphasis="secondary"
+			class="pointer-events-auto absolute top-0 right-0"
+		>
+			❌
+		</Button>
+		<MapControlGroup x="right" yOffset="lg">
+			<p class="bg-color-container-level-1 text-color-text-primary p-2">Offset Y (lg)</p>
+		</MapControlGroup>
+
+		<Button
+			variant="square"
+			emphasis="secondary"
+			class="pointer-events-auto absolute bottom-0 left-0"
+		>
+			❌
+		</Button>
+		<MapControlGroup y="bottom">
+			<p class="bg-color-container-level-1 text-color-text-primary p-2">Default (md)</p>
+		</MapControlGroup>
+	</div>
+</Story>
+
+<Story name="Content alignment">
 	<MapApp>
 		<Map
 			options={{
@@ -69,9 +114,9 @@
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>
-			{#each Object.keys(MapControlGroupPositions) as position}
-				{#if position != 'TopRightOffset'}
-					<MapControlGroup {position}>
+			{#each yPositions as yPos (yPos)}
+				{#each xPositions as xPos (xPos)}
+					<MapControlGroup y={yPos} x={xPos}>
 						<MapControlLocationSearch
 							adapter={new MapGeocoderAdapterMapBox(
 								'pk.eyJ1IjoiZ2xhLWdpcyIsImEiOiJjanBvNGh1bncwOTkzNDNueWt5MGU1ZGtiIn0.XFxLdq2dXttcXSXTiREPTA'
@@ -79,21 +124,13 @@
 						/>
 						<MapControlZoom />
 					</MapControlGroup>
-				{/if}
+				{/each}
 			{/each}
-
-			<div
-				class="max-w-sm absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2 transform z-10 bg-color-container-level-1 text-color-text-primary text-center p-4 space-y-4"
-			>
-				<p>
-					The alignment of elements within a <code>MapControlGroup</code> depends on its position.
-				</p>
-			</div>
 		</Map>
 	</MapApp>
 </Story>
 
-<Story name="Standard Layout">
+<Story name="Standard layout">
 	<MapApp>
 		<Map
 			options={{
@@ -109,7 +146,7 @@
 				<p class="text-center">On small devices most controls will hide themselves.</p>
 			</div>
 
-			<MapControlGroup position="TopLeft">
+			<MapControlGroup>
 				<MapControlLocationSearch
 					adapter={new MapGeocoderAdapterMapBox(
 						'pk.eyJ1IjoiZ2xhLWdpcyIsImEiOiJjanBvNGh1bncwOTkzNDNueWt5MGU1ZGtiIn0.XFxLdq2dXttcXSXTiREPTA'
@@ -118,12 +155,12 @@
 				<MapControlZoom />
 			</MapControlGroup>
 
-			<MapControlGroup position="BottomLeft">
+			<MapControlGroup y="bottom">
 				<MapControlFullscreen />
 				<MapControlRefresh />
 			</MapControlGroup>
 
-			<MapControlGroup position="TopRight">
+			<MapControlGroup x="right">
 				<p
 					class="bg-color-container-level-1 text-color-text-primary p-2 text-center pointer-events-auto"
 				>
@@ -131,7 +168,7 @@
 				</p>
 			</MapControlGroup>
 
-			<MapControlGroup position="BottomRight">
+			<MapControlGroup y="bottom" x="right">
 				<MapControlPan />
 			</MapControlGroup>
 		</Map>

--- a/packages/maps/src/lib/mapControlGroup/MapControlGroup.svelte
+++ b/packages/maps/src/lib/mapControlGroup/MapControlGroup.svelte
@@ -1,30 +1,48 @@
 <script lang="ts" context="module">
-	export enum MapControlGroupPositions {
-		TopLeft = 'TopLeft',
-		TopCenter = 'TopCenter',
-		TopRight = 'TopRight',
-		TopRightOffset = 'TopRightOffset',
-		CenterRight = 'CenterRight',
-		BottomRight = 'BottomRight',
-		BottomCenter = 'BottomCenter',
-		BottomLeft = 'BottomLeft',
-		CenterLeft = 'CenterLeft'
-	}
+	export type MapControlGroupPositionX = 'left' | 'center' | 'right';
+	export type MapControlGroupPositionY = 'top' | 'center' | 'bottom';
+	export type MapControlGroupOffset = 'md' | 'lg';
 
-	type PositionClass = {
-		[key in keyof typeof MapControlGroupPositions]: string;
+	const xPositions = {
+		left: {
+			md: 'left-6',
+			lg: 'left-16'
+		},
+		center: {
+			md: 'left-1/2',
+			lg: 'left-1/2'
+		},
+		right: {
+			md: 'right-6',
+			lg: 'right-16'
+		}
 	};
 
-	const positionClasses: PositionClass = {
-		TopLeft: 'top-6 left-6',
-		TopCenter: 'top-6 left-1/2 -translate-x-1/2 transform items-center',
-		TopRight: 'top-6 right-6 items-end',
-		TopRightOffset: 'top-16 right-6 items-end',
-		CenterRight: 'top-1/2 -translate-y-1/2 right-6 transform items-end',
-		BottomRight: 'bottom-6 right-6 items-end',
-		BottomCenter: 'bottom-6 left-1/2 -translate-x-1/2 transform items-center',
-		BottomLeft: 'bottom-6 left-6',
-		CenterLeft: 'top-1/2 -translate-y-1/2 left-6 transform'
+	const xAlignments = {
+		left: '',
+		center: '-translate-x-1/2 transform items-center',
+		right: 'items-end'
+	};
+
+	const yPositions = {
+		top: {
+			md: 'top-6',
+			lg: 'top-16'
+		},
+		center: {
+			md: 'top-1/2',
+			lg: 'top-1/2'
+		},
+		bottom: {
+			md: 'bottom-6',
+			lg: 'bottom-16'
+		}
+	};
+
+	const yAlignments = {
+		top: '',
+		center: '-translate-y-1/2 transform',
+		bottom: ''
 	};
 </script>
 
@@ -36,19 +54,48 @@
 	 */
 
 	/**
-	 * Position of the group over the map. Avialable positions defined by
-	 * `MapControlGroupPositions` enum type.
+	 * Horizontal position.
 	 */
-	export let position: keyof typeof MapControlGroupPositions = MapControlGroupPositions.TopLeft;
+	export let x: MapControlGroupPositionX = 'left';
 
 	/**
-	 * Additional classes applied to the group's container element.
+	 * Horizontal offset from screen edge. Used to avoid overlap with overflow
+	 * elements from `<AppShell>` and `<Sidebar>`.
 	 */
-	export let classes = '';
+	export let xOffset: MapControlGroupOffset = 'md';
 
-	const positionClass = positionClasses[position];
+	/**
+	 * Vertical position.
+	 */
+	export let y: MapControlGroupPositionY = 'top';
+
+	/**
+	 * Vertical offset from screen edge. Used to avoid overlap with overflow
+	 * elements from `<AppShell>` and `<Sidebar>`.
+	 */
+	export let yOffset: MapControlGroupOffset = 'md';
+
+	$: classes = [
+		'absolute',
+		xPositions[x][xOffset],
+		xAlignments[x],
+		yPositions[y][yOffset],
+		yAlignments[y],
+		'z-10',
+		'flex',
+		'flex-col',
+		'space-y-2',
+		'pointer-events-none',
+		$$restProps.class || ''
+	]
+		.join(' ')
+		.trim();
+
+	const removeClassRestProp = () => delete $$restProps.class;
+	$: classes, removeClassRestProp();
 </script>
 
-<div class="absolute {positionClass} z-10 flex flex-col space-y-2 pointer-events-none {classes}">
+<div class={classes} {...$$restProps}>
+	<!-- Group content, usually map control buttons. -->
 	<slot />
 </div>

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
@@ -44,7 +44,7 @@
 				transformRequest
 			}}
 		>
-			<MapControlGroup position="TopLeft">
+			<MapControlGroup>
 				<MapControlLocationSearch {adapter} {onSearchError} />
 			</MapControlGroup>
 		</Map>
@@ -59,7 +59,7 @@
 				transformRequest
 			}}
 		>
-			<MapControlGroup position="TopLeft">
+			<MapControlGroup>
 				<MapControlLocationSearch {adapter} {onSearchError} hideGeolocator />
 			</MapControlGroup>
 		</Map>

--- a/packages/maps/src/lib/mapControlPan/MapControlPan.stories.svelte
+++ b/packages/maps/src/lib/mapControlPan/MapControlPan.stories.svelte
@@ -50,7 +50,7 @@
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>
-			<MapControlGroup position="BottomRight">
+			<MapControlGroup y="bottom" x="right">
 				<MapControlPan />
 			</MapControlGroup>
 		</Map>

--- a/packages/maps/src/lib/mapControlRefresh/MapControlRefresh.stories.svelte
+++ b/packages/maps/src/lib/mapControlRefresh/MapControlRefresh.stories.svelte
@@ -38,7 +38,7 @@
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>
-			<MapControlGroup position="BottomLeft">
+			<MapControlGroup y="bottom">
 				<MapControlRefresh />
 			</MapControlGroup>
 		</Map>

--- a/packages/maps/src/lib/mapControlZoom/MapControlZoom.stories.svelte
+++ b/packages/maps/src/lib/mapControlZoom/MapControlZoom.stories.svelte
@@ -50,7 +50,7 @@
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
 		>
-			<MapControlGroup position="TopLeft">
+			<MapControlGroup>
 				<MapControlZoom />
 			</MapControlGroup>
 		</Map>


### PR DESCRIPTION
**What does this change?**

Rewrites `MapControlGroup` interface to allow finer grained control over positioning.

**Why?**

As the number of artifacts on the page grows the positioning of additional map controls was becoming difficult, e.g. map theme switcher.

**How is it tested?**

Storybook.

**How is it documented?**

Storybook.

**Are light and dark themes considered?**

No.

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
