### PR TITLE
Header and Modal theme colors

### DIFF
--- a/.changeset/quiet-apricots-happen.md
+++ b/.changeset/quiet-apricots-happen.md
@@ -3,4 +3,4 @@
 "@ldn-viz/docs": patch
 ---
 
-Header and Modal Header themed dark as default
+CHANGED: Header and Modal Header are now themed dark as default, but this can be overridden with a prop

--- a/.changeset/quiet-apricots-happen.md
+++ b/.changeset/quiet-apricots-happen.md
@@ -1,0 +1,6 @@
+---
+"@ldn-viz/ui": minor
+"@ldn-viz/docs": patch
+---
+
+Header and Modal Header themed dark as default

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-turbo": "^1.12.5",
         "prettier": "^3.2.5",
+        "prettier-plugin-packagejson": "^2.5.1",
         "prettier-plugin-svelte": "^3.2.2",
         "turbo": "^1.12.5"
       }
@@ -3500,6 +3501,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@playwright/test": {
@@ -10614,6 +10627,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-4.0.1.tgz",
+      "integrity": "sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/detect-package-manager": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-package-manager/-/detect-package-manager-2.0.1.tgz",
@@ -12590,6 +12615,15 @@
       },
       "bin": {
         "giget": "dist/cli.mjs"
+      }
+    },
+    "node_modules/git-hooks-list": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-3.1.0.tgz",
+      "integrity": "sha512-LF8VeHeR7v+wAbXqfgRlTSX/1BJR9Q1vEMR8JAz1cEg6GX07+zyj3sAdDvYjj/xnlIfVuGgj4qBei1K3hKH+PA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
       }
     },
     "node_modules/github-slugger": {
@@ -16225,6 +16259,24 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-packagejson": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.2.tgz",
+      "integrity": "sha512-w+TmoLv2pIa+siplW1cCj2ujEXQQS6z7wmWLOiLQK/2QVl7Wy6xh/ZUpqQw8tbKMXDodmSW4GONxlA33xpdNOg==",
+      "dev": true,
+      "dependencies": {
+        "sort-package-json": "2.10.1",
+        "synckit": "0.9.1"
+      },
+      "peerDependencies": {
+        "prettier": ">= 1.16.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prettier-plugin-svelte": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.2.2.tgz",
@@ -17575,6 +17627,83 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sort-object-keys": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+      "integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
+      "dev": true
+    },
+    "node_modules/sort-package-json": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.10.1.tgz",
+      "integrity": "sha512-d76wfhgUuGypKqY72Unm5LFnMpACbdxXsLPcL27pOsSrmVqH3PztFp1uq+Z22suk15h7vXmTesuh2aEjdCqb5w==",
+      "dev": true,
+      "dependencies": {
+        "detect-indent": "^7.0.1",
+        "detect-newline": "^4.0.0",
+        "get-stdin": "^9.0.0",
+        "git-hooks-list": "^3.0.0",
+        "globby": "^13.1.2",
+        "is-plain-obj": "^4.1.0",
+        "semver": "^7.6.0",
+        "sort-object-keys": "^1.1.3"
+      },
+      "bin": {
+        "sort-package-json": "cli.js"
+      }
+    },
+    "node_modules/sort-package-json/node_modules/detect-indent": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.1.tgz",
+      "integrity": "sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/sort-package-json/node_modules/globby": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sort-package-json/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sort-package-json/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -18738,6 +18867,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
+      "integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/tabbable": {
@@ -20677,9 +20822,10 @@
     },
     "packages/charts": {
       "name": "@ldn-viz/charts",
-      "version": "2.0.1",
+      "version": "3.1.0",
       "dependencies": {
         "@ldn-viz/ui": "*",
+        "@ldn-viz/utils": "*",
         "@observablehq/plot": "^0.6.14",
         "layercake": "^8.1.1"
       },
@@ -20697,6 +20843,7 @@
         "postcss": "^8.4.35",
         "postcss-load-config": "^5.0.3",
         "prettier": "^3.2.5",
+        "prettier-plugin-packagejson": "^2.5.1",
         "prettier-plugin-svelte": "^3.2.2",
         "publint": "^0.2.7",
         "svelte": "^4.2.12",
@@ -20752,11 +20899,12 @@
     },
     "packages/maps": {
       "name": "@ldn-viz/maps",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dependencies": {
         "@deck.gl/core": "^8.9.35",
         "@deck.gl/layers": "^8.9.35",
         "@deck.gl/mapbox": "^8.9.35",
+        "@ldn-viz/utils": "*",
         "@turf/turf": "6.5.0",
         "maplibre-gl": "^4.1.0",
         "svelte-maplibre": "^0.8.2"
@@ -20775,6 +20923,7 @@
         "postcss": "^8.4.35",
         "postcss-load-config": "^5.0.3",
         "prettier": "^3.2.5",
+        "prettier-plugin-packagejson": "^2.5.1",
         "prettier-plugin-svelte": "^3.2.2",
         "publint": "^0.2.7",
         "svelte": "^4.2.12",
@@ -20818,7 +20967,7 @@
     },
     "packages/tables": {
       "name": "@ldn-viz/tables",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "@ldn-viz/charts": "*",
         "@ldn-viz/themes": "*",
@@ -20846,6 +20995,7 @@
         "postcss": "^8.4.35",
         "postcss-load-config": "^5.0.3",
         "prettier": "^3.2.5",
+        "prettier-plugin-packagejson": "^2.5.1",
         "prettier-plugin-svelte": "^3.2.2",
         "publint": "^0.2.7",
         "svelte": "^4.2.12",
@@ -20880,7 +21030,7 @@
     },
     "packages/themes": {
       "name": "@ldn-viz/themes",
-      "version": "2.0.1",
+      "version": "4.0.0",
       "dependencies": {
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.10",
@@ -20899,8 +21049,9 @@
     },
     "packages/ui": {
       "name": "@ldn-viz/ui",
-      "version": "11.0.0",
+      "version": "14.0.0",
       "dependencies": {
+        "@ldn-viz/utils": "*",
         "@melt-ui/svelte": "^0.76.0",
         "@steeze-ui/heroicons": "^2.3.0",
         "@steeze-ui/svelte-icon": "^1.5.0",
@@ -20935,6 +21086,7 @@
         "postcss": "^8.4.35",
         "postcss-load-config": "^5.0.3",
         "prettier": "^3.2.5",
+        "prettier-plugin-packagejson": "^2.5.1",
         "prettier-plugin-svelte": "^3.2.2",
         "publint": "^0.2.7",
         "svelte": "^4.2.12",
@@ -20978,7 +21130,7 @@
     },
     "packages/utils": {
       "name": "@ldn-viz/utils",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "dependencies": {
         "chroma-js": "^2.4.2",
         "d3-array": "^3.2.4",

--- a/packages/ui/src/lib/header/Header.stories.svelte
+++ b/packages/ui/src/lib/header/Header.stories.svelte
@@ -65,3 +65,15 @@
 		</HeaderRight>
 	</Header>
 </Story>
+
+<Story name="Light Theme (Experimental)">
+	<Header theme="light">
+		<HeaderTitle>EV Charger Dashboard</HeaderTitle>
+
+		<NavLinks>
+			<NavLink target="map">Map</NavLink>
+
+			<NavLink target="trends">Trends</NavLink>
+		</NavLinks>
+	</Header>
+</Story>

--- a/packages/ui/src/lib/header/Header.svelte
+++ b/packages/ui/src/lib/header/Header.svelte
@@ -7,9 +7,16 @@
 	 */
 </script>
 
-<nav
-	class="w-screen flex items-center px-4 py-[.5rem] bg-color-background-container-level-0 text-color-text-primary text-left h-[50px] border-l-[5px] border-color-static-brand"
+<script lang="ts">
+	/**
+	 * Colour scheme to use, either `light` or `dark`.
+	 */
+	export let theme: 'light' | 'dark' = 'dark';
+</script>
+
+<header
+	class={`w-screen flex items-center px-4 py-[.5rem] bg-color-container-level-0 text-color-text-primary text-left h-[50px] border-l-[5px] border-color-static-brand ${theme}`}
 >
 	<!-- Contents of the header (typically a combination of `<HeaderTitle>`, `<HeaderRight>`, `<NavLinks>`, and `<HeaderItem>` components) -->
 	<slot />
-</nav>
+</header>

--- a/packages/ui/src/lib/header/NavLinks.svelte
+++ b/packages/ui/src/lib/header/NavLinks.svelte
@@ -3,7 +3,7 @@ A container for `<NavLink>` components.
 @component
 -->
 
-<div class="flex items-center">
+<nav class="flex items-center">
 	<!-- one or more `<NavLink>` components -->
 	<slot />
-</div>
+</nav>

--- a/packages/ui/src/lib/modal/Modal.stories.svelte
+++ b/packages/ui/src/lib/modal/Modal.stories.svelte
@@ -116,3 +116,24 @@
 		<Button variant="solid" emphasis="secondary" on:click={() => ($isOpen = false)}>Cancel</Button>
 	</Modal>
 </Story>
+
+<Story name="Light Theme (Experimantal)">
+	<Button on:click={() => ($isOpen = true)}>Open modal!</Button>
+
+	<Modal
+		bind:isOpen
+		title="A modal with a light header!"
+		description="This modal has a description..."
+		headerTheme="light"
+	>
+		<div class="pt-2">
+			...and contents!
+			<p>A list</p>
+			<ul class="list-disc list-inside">
+				<li>One</li>
+				<li>Two</li>
+				<li>Three</li>
+			</ul>
+		</div>
+	</Modal>
+</Story>

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -36,6 +36,11 @@
 	export let description: string = '';
 
 	/**
+	 * Colour scheme to apply to the header, either `light` or `dark`. The modal will respect global theme settings.
+	 */
+	export let headerTheme: 'light' | 'dark' = 'dark';
+
+	/**
 	 * width of the modal
 	 */
 	export let width:
@@ -82,7 +87,7 @@
 		<div class="fixed inset-8 flex items-center justify-center pointer-events-none z-50">
 			<div {...$content} use:$content.action class={modalClass}>
 				<div
-					class="bg-color-container-level-1 text-color-text-primary p-2 pl-3 relative flex items-center justify-between border-l-[5px] border-color-static-brand"
+					class={`bg-color-container-level-1 text-color-text-primary p-2 pl-3 relative flex items-center justify-between border-l-[5px] border-color-static-brand ${headerTheme}`}
 				>
 					<div class="text-lg font-medium" {...$meltTitle} use:$meltTitle.action>{title}</div>
 					<div {...$close} use:$close.action>


### PR DESCRIPTION
**What does this change?**
adds props to the Global Header and to the Modal Header components that allows them to be either light or dark themed individually - defaults to dark

**Why?**
Default - even in light mode, is for these elements to be themed dark

**How?**
accepts props with defaults. This allows for overriding to light theme colors if ever required. This is the same behaviour as the sidebar.

**Related issues**:
#562 

**Does this introduce new dependencies?**
no

**How is it tested?**
storybook

**How is it documented?**
storybook

**Are light and dark themes considered?**
yes

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
