### PR TITLE
Add function to generate simple diverging colors

### DIFF
--- a/.changeset/get-simple-diverging.md
+++ b/.changeset/get-simple-diverging.md
@@ -2,4 +2,4 @@
 '@ldn-viz/utils': minor
 ---
 
-ADDED: `getSimpleDiverging()` simple function to generate diverging color range
+ADDED: `getSimpleDiverging()` simple function to generate diverging color range from two color arrays

--- a/.changeset/get-simple-diverging.md
+++ b/.changeset/get-simple-diverging.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/utils': minor
+---
+
+ADDED: `getSimpleDiverging()` simple function to generate diverging color range

--- a/package-lock.json
+++ b/package-lock.json
@@ -20822,7 +20822,7 @@
     },
     "packages/charts": {
       "name": "@ldn-viz/charts",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dependencies": {
         "@ldn-viz/ui": "*",
         "@ldn-viz/utils": "*",
@@ -21049,7 +21049,7 @@
     },
     "packages/ui": {
       "name": "@ldn-viz/ui",
-      "version": "14.0.0",
+      "version": "14.1.0",
       "dependencies": {
         "@ldn-viz/utils": "*",
         "@melt-ui/svelte": "^0.76.0",

--- a/packages/utils/src/colors/scales.ts
+++ b/packages/utils/src/colors/scales.ts
@@ -1,6 +1,6 @@
 import chroma from 'chroma-js';
 
-import { bin, extent, min, max } from 'd3-array';
+import { bin, extent, max, min } from 'd3-array';
 import { format } from 'd3-format';
 
 import ldnColors from '@ldn-viz/themes/colors.json';
@@ -31,6 +31,28 @@ export const getColorRamp = ({
   }
 
   return colorArray;
+};
+
+// A simple function wrapping around getColorRamp that calls
+// getColorRamp twice and concatenates the resulting arrays
+export const getSimpleDiverging = (
+  count: number,
+  lowColors: string[],
+  highColors: string[],
+  even: boolean
+) => {
+  const halfCount = Math.floor(count / 2);
+  const neutral = count % 2 !== 0 ? ldnColors.core.grey[100] : null;
+  return neutral
+    ? [
+        ...getColorRamp({ colors: lowColors, even, count: halfCount }),
+        neutral,
+        ...getColorRamp({ colors: highColors, even, count: halfCount })
+      ]
+    : [
+        ...getColorRamp({ colors: lowColors, even, count: halfCount }),
+        ...getColorRamp({ colors: highColors, even, count: halfCount })
+      ];
 };
 
 export const getThresholdBreaksColorsLabels = ({


### PR DESCRIPTION
`getThresholdBreaksColorsLabels()` has a bug that makes it difficult to get the right count of colors with `extent` and `breakCount`, and is rigid in the structure of the arguments which limits its use for simpler color ramps.

I wrote this function for simple use cases where users want to pass in two arrays of colors to get a diverging color ramp at a specific count. It calls `getColorRamp` twice and concatenates the resulting arrays, inserting a neutral middle color if the count is an odd number.

**How is it tested?**
Pass in a count, arrays of colors and boolean to the function. It should return an array with a length equal to count.

You can see it in practice [here](https://github.com/Greater-London-Authority/app-friday-effect-svelte/tree/new-refactor-data-loading). Relevant functions are saved in `src/lib/utils/utils.ts`.

You can change the colors in `darkPinkOrange` and this will update the bar charts:
```ts
export const darkPinkOrange = () => {
	const lowColors = [
		ldnColors.core.darkPink[800],
		ldnColors.core.darkPink[500],
		ldnColors.core.darkPink[200]
	];
	const highColors = [
		ldnColors.core.orange[200],
		ldnColors.core.orange[500],
		ldnColors.core.orange[800]
	];

	return getSimpleDivergingColors(8, lowColors, highColors, true);
};
```
<img width="717" alt="image" src="https://github.com/user-attachments/assets/d7898644-85ea-4a6a-a415-43fe44a3a00d">

- [x] Have you included changeset file?
