### PR TITLE
Map cursor event type fix

### DIFF
--- a/.changeset/polite-rings-help.md
+++ b/.changeset/polite-rings-help.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/maps": minor
+---
+
+FIXED: `GeoJSONFeature` to `GeoJSON.Feature` in `MapCursorEvent` for correct typing of `handlerArgTypes`

--- a/packages/maps/src/lib/mapCursorEvent/MapCursorEvent.stories.svelte
+++ b/packages/maps/src/lib/mapCursorEvent/MapCursorEvent.stories.svelte
@@ -8,7 +8,7 @@
 			type: {
 				summary: 'function',
 				detail:
-					'function(event: MouseEvent | TouchEvent, {\n  feature: GeoJSONFeature,\n  features: GeoJSONFeature[],\n  isTouchEvent: boolean\n}) => void'
+					'function(event: MouseEvent | TouchEvent, {\n  feature: GeoJSON.Feature,\n  features: GeoJSON.Feature[],\n  isTouchEvent: boolean\n}) => void'
 			}
 		}
 	};
@@ -20,7 +20,7 @@
 			type: {
 				summary: 'function',
 				detail:
-					'function(event: MouseEvent | TouchEvent, {\n  feature: null,\n  features: GeoJSONFeature[],\n  isTouchEvent: boolean\n}) => void'
+					'function(event: MouseEvent | TouchEvent, {\n  feature: null,\n  features: GeoJSON.Feature[],\n  isTouchEvent: boolean\n}) => void'
 			}
 		}
 	};


### PR DESCRIPTION
**What does this change?**
I corrected the `GeoJSON Feature` types of `handlerArgType` in `MapCursorEvent.stories.svelte`. They are now `GeoJSON.Feature` which matches the exported interface from the `@types/geojson` package (`GeoJSONFeature` causes type errors because it doesn't exist).

- [x] Have you included changeset file?
