### PR TITLE
Allow custom placeholder text in geocoder

### DIFF
--- a/.changeset/geocoder-placeholder.md
+++ b/.changeset/geocoder-placeholder.md
@@ -1,0 +1,6 @@
+---
+"@ldn-viz/ui": minor
+"@ldn-viz/maps": minor
+---
+
+CHANGED: allow custom placeholder text in `Geocoder`, `MapControlGeocoder` and `MapControlLocationSearch` components

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlGeocoder.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlGeocoder.svelte
@@ -51,6 +51,11 @@
 	 */
 	export let inputClasses = '';
 
+	/**
+	 * Placeholder text to be dislayed in the input element.
+	 */
+	export let placeholder = 'Location search';
+
 	const mapStore: MapStore = getContext('mapStore');
 
 	const zoomLevel = 16;
@@ -81,6 +86,7 @@
 	onLocationSelected={onLocationSelectedGeocoder}
 	{classes}
 	{inputClasses}
+	{placeholder}
 	bind:showClearButton
 	bind:selected
 	let:onSuggestionEvent

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
@@ -51,6 +51,25 @@
 	</MapApp>
 </Story>
 
+<Story name="Location Search - custom placeholder">
+	<MapApp>
+		<Map
+			options={{
+				style: os_light_vts,
+				transformRequest
+			}}
+		>
+			<MapControlGroup position="TopLeft">
+				<MapControlLocationSearch
+					{adapter}
+					{onSearchError}
+					placeholder="Type here to search for a place"
+				/>
+			</MapControlGroup>
+		</Map>
+	</MapApp>
+</Story>
+
 <Story name="Hidden Geolocator">
 	<MapApp>
 		<Map

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.svelte
@@ -51,6 +51,11 @@
 	 */
 	export let hideGeolocator = false;
 
+	/**
+	 * Placeholder text to be dislayed in the input element.
+	 */
+	export let placeholder = 'Location search';
+
 	let limitWidthClass = '';
 
 	if (hideGeolocator) {
@@ -71,6 +76,7 @@
 		{onSearchError}
 		{maxSuggestions}
 		inputClasses="w-72 {limitWidthClass}"
+		{placeholder}
 	/>
 	{#if !hideGeolocator}
 		<MapControlGeolocator {onLocationFound} {onSearchError} />

--- a/packages/ui/src/lib/geolocation/Geocoder.stories.svelte
+++ b/packages/ui/src/lib/geolocation/Geocoder.stories.svelte
@@ -210,3 +210,42 @@
 		</pre>
 	</div>
 </Story>
+
+<Story name="Custom placeholder">
+	<div class="m-6 space-y-6">
+		<p class="dark:text-white">
+			A simple geocoder with dropdown suggestions. A simple hardcoded list adapter is used here so
+			results are limited.
+		</p>
+		<p class="dark:text-white">
+			At least three characters are required before any suggestions are provided. This avoids
+			spamming the underlying Web APIs with excessively vague requests.
+		</p>
+		<p class="dark:text-white">
+			Try entering 'brick' or 'london' if you're having trouble finding any places.
+		</p>
+		<Geocoder
+			let:onSuggestionEvent
+			let:attribution
+			let:suggestions
+			adapter={listAdapter}
+			{onLocationSelected}
+			{onSearchError}
+			classes="w-72"
+			placeholder="Type here to search for a place "
+		>
+			{#if suggestions?.length > 0}
+				<GeocoderSuggestionList
+					{onSuggestionEvent}
+					{attribution}
+					{suggestions}
+					{selected}
+					maxSuggestions={5}
+				/>
+			{/if}
+		</Geocoder>
+		<pre class="dark:text-white whitespace-pre-wrap">
+			{selected ? formatResult(selected) : formatResult({})}
+		</pre>
+	</div>
+</Story>

--- a/packages/ui/src/lib/geolocation/Geocoder.svelte
+++ b/packages/ui/src/lib/geolocation/Geocoder.svelte
@@ -82,6 +82,11 @@
 	 */
 	export let showClearButton = false;
 
+	/**
+	 * Placeholder text to be dislayed in the input element.
+	 */
+	export let placeholder = 'Location search';
+
 	let container: HTMLElement;
 	let input: HTMLInputElement;
 	let query = '';
@@ -292,7 +297,7 @@
 	<input
 		bind:this={input}
 		type="search"
-		placeholder="Location search"
+		{placeholder}
 		class="form-input min-w-0 w-64 max-w-[100%] pl-10 grow shrink bg-color-input-background border border-color-input-border placeholder-color-input-placeholder h-full text-color-valuetext {inputClasses}"
 		class:pr-8={showClearButton}
 		bind:value={query}


### PR DESCRIPTION
**What does this change?**
Ths allows custom placeholder text in `Geocoder`, `MapControlGeocoder` and `MapControlLocationSearch` components. 

**Why?**
This will be useful in the new Small Sites map, where selecting a location sorts the list of sites by proximity to it.
