### PR TITLE
allow axis renderers to be specified as strings

### DIFF
--- a/.changeset/tables-axis-renders.md
+++ b/.changeset/tables-axis-renders.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/tables": minor
+---
+
+CHANGED: allow axis renderers to be specified by name (as strings, rather than Svelte components) in table specifications

--- a/packages/tables/src/lib/core/lib/dataObj.ts
+++ b/packages/tables/src/lib/core/lib/dataObj.ts
@@ -8,7 +8,7 @@ import { scaleBand } from 'd3-scale';
 
 import { getContinuousColorScale, getCategoricalColorScale } from './scales';
 
-import { renderer } from '../renderers';
+import { axisRenderer, renderer } from '../renderers';
 
 // TODO: convert data types?
 
@@ -80,6 +80,9 @@ export class TableData {
 			}
 			if (col.group && typeof col.group.renderer === 'string') {
 				col.group.renderer = renderer[col.group.renderer];
+			}
+			if (col.cell && typeof col.cell.axisRenderer === 'string') {
+				col.cell.axisRenderer = axisRenderer[col.cell.axisRenderer];
 			}
 		}
 	}

--- a/packages/tables/src/lib/core/renderers.ts
+++ b/packages/tables/src/lib/core/renderers.ts
@@ -24,7 +24,6 @@ import Tick from './renderers/Tick.svelte';
 import BarDivergingAxis from '../core/renderers/BarDivergingAxis.svelte';
 import PairArrowAxis from '../core/renderers/PairArrowAxis.svelte';
 
-
 export const renderer = {
 	BarCell,
 	CategoricalTick,
@@ -51,8 +50,7 @@ export const renderer = {
 	ViolinPlot
 };
 
-
 export const axisRenderer = {
 	BarDivergingAxis,
-	PairArrowAxis,
-}
+	PairArrowAxis
+};

--- a/packages/tables/src/lib/core/renderers.ts
+++ b/packages/tables/src/lib/core/renderers.ts
@@ -7,18 +7,23 @@ import StackedBar from './aggregateRenderers/StackedBar.svelte';
 import Summary from './aggregateRenderers/Summary.svelte';
 import ViolinPlot from './aggregateRenderers/ViolinPlot.svelte';
 import BarCell from './renderers/BarCell.svelte';
+import BarDivergingCell from './renderers/BarDivergingCell.svelte';
 import CategoricalTick from './renderers/CategoricalTick.svelte';
 import ColorAndLabel from './renderers/ColorAndLabel.svelte';
 import ColoredCell from './renderers/ColoredCell.svelte';
 import DateCell from './renderers/DateCell.svelte';
 import Dot from './renderers/Dot.svelte';
-import BarDivergingCell from './renderers/BarDivergingCell.svelte';
 import GoodOrBad from './renderers/GoodOrBad.svelte';
 import Header from './renderers/Header.svelte';
 import PairArrow from './renderers/PairArrowCell.svelte';
 import ProportionalSymbol from './renderers/ProportionalSymbol.svelte';
 import TextCell from './renderers/TextCell.svelte';
 import Tick from './renderers/Tick.svelte';
+
+//
+import BarDivergingAxis from '../core/renderers/BarDivergingAxis.svelte';
+import PairArrowAxis from '../core/renderers/PairArrowAxis.svelte';
+
 
 export const renderer = {
 	BarCell,
@@ -45,3 +50,9 @@ export const renderer = {
 	Summary,
 	ViolinPlot
 };
+
+
+export const axisRenderer = {
+	BarDivergingAxis,
+	PairArrowAxis,
+}

--- a/packages/tables/src/lib/table/TableHSDS.stories.svelte
+++ b/packages/tables/src/lib/table/TableHSDS.stories.svelte
@@ -1,6 +1,4 @@
 <script context="module">
-	import BarDivergingAxis from '../core/renderers/BarDivergingAxis.svelte';
-	import PairArrowAxis from '../core/renderers/PairArrowAxis.svelte';
 	import Table from './Table.svelte';
 
 	export const meta = {
@@ -120,7 +118,7 @@
 					extent: [0, 250],
 					width: '200px',
 
-					axisRenderer: PairArrowAxis
+					axisRenderer: 'PairArrowAxis'
 				},
 
 				column: { renderer: 'TextCell', value: '' }
@@ -137,7 +135,7 @@
 					alignText: 'right',
 					extent: [-140, +140],
 
-					axisRenderer: BarDivergingAxis,
+					axisRenderer: 'BarDivergingAxis',
 					numTicks: 5
 				},
 


### PR DESCRIPTION
**What does this change?**

This allows axis renderers to be specified by name (as strings, rather than Svelte components) in table specifications.