### PR TITLE
Tables: allow rule above table header to be disabled

### DIFF
--- a/.changeset/table-optional-top-rule.md
+++ b/.changeset/table-optional-top-rule.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/tables': minor
+---
+
+CHANGED: in `Table` component, it is now possible to disable the horizontal rule above the header

--- a/packages/tables/src/lib/table/Table.svelte
+++ b/packages/tables/src/lib/table/Table.svelte
@@ -14,6 +14,7 @@
 	import NumRowsControls from './rows/NumRowsControls.svelte';
 	import PaginationControls from './rows/PaginationControls.svelte';
 	import RowRenderer from './rows/RowRenderer.svelte';
+	import { classNames } from '@ldn-viz/ui';
 
 	/**
 	 * The data to be displayed in the table. An array of objects: one object per row, and one field per columns.
@@ -150,6 +151,8 @@
 		// TODO: may need to add some of the values from table.widths to account for chrome added when rows grouped
 		...table.columnSpec.map((c) => c.cell.width ?? table.widths.defaultCell)
 	]);
+
+	$: topRuleClass = tableSpec.showHeaderTopRule === false ? '' : 'border-t';
 </script>
 
 {#if table && table.extents}
@@ -166,7 +169,10 @@
 
 	<TableContainer {data} {title} {subTitle} {exportBtns} exportData={data} {columnMapping}>
 		<div class="table-auto text-sm w-full text-color-text-primary" slot="table">
-			<div class="border-t border-b border-color-ui-border-primary" style:width={tableWidth}>
+			<div
+				class={classNames(topRuleClass, 'border-b border-color-ui-border-primary')}
+				style:width={tableWidth}
+			>
 				{#if tableSpec.colGroups}
 					<ColumnGroupHeadingRow {table} />
 				{/if}

--- a/packages/tables/src/lib/table/TableHSDS.stories.svelte
+++ b/packages/tables/src/lib/table/TableHSDS.stories.svelte
@@ -67,6 +67,7 @@
 	}));
 
 	const footfallTableSpec = {
+		showHeaderTopRule: false,
 		columns: [
 			{
 				short_label: 'metric',


### PR DESCRIPTION
This allows the horizontal rule above the header of a table to be disabled, to match the design in the Figma mockups for the HSDS hub.