### PR TITLE
Add prop to Button component to specify that link should be opened in new tab

### DIFF
--- a/.changeset/link-button.md
+++ b/.changeset/link-button.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+ADDED: `Button` now has a prop to specify link should be opened in a new tab

--- a/packages/ui/src/lib/button/Button.stories.svelte
+++ b/packages/ui/src/lib/button/Button.stories.svelte
@@ -138,6 +138,6 @@
 
 <Story name="With Link, opening in new tab">
 	<div class="space-y-2">
-		<Button href="http://google.com" openInBackground>Link</Button>
+		<Button href="http://google.com" openInNewTab>Link</Button>
 	</div>
 </Story>

--- a/packages/ui/src/lib/button/Button.stories.svelte
+++ b/packages/ui/src/lib/button/Button.stories.svelte
@@ -135,3 +135,9 @@
 		<Button disabled href="#">Link</Button>
 	</div>
 </Story>
+
+<Story name="With Link, opening in new tab">
+	<div class="space-y-2">
+		<Button href="http://google.com" openInBackground>Link</Button>
+	</div>
+</Story>

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -17,6 +17,7 @@
 		size: 'sm' | 'md' | 'lg';
 		disabled: boolean;
 		href: string;
+		openInBackground: boolean;
 		type: 'button' | 'submit';
 		title: string;
 	}
@@ -59,6 +60,11 @@
 	 * If this is set, the button is a link with the specified target.
 	 */
 	export let href: ButtonProps['href'] = '';
+
+	/**
+	 * If `true`, then clicking the button will open the link target in a new tab. Has no effect if `href` is not set.
+	 */
+	export let openInBackground = false;
 
 	/**
 	 * If `submit`, then this is a submit button for use with a form.
@@ -209,6 +215,8 @@
 	<svelte:element
 		this={href ? 'a' : 'button'}
 		type={href ? undefined : type}
+		target={href && openInBackground ? '_blank' : undefined}
+		rel={href && openInBackground ? 'noopener noreferrer' : undefined}
 		{href}
 		{disabled}
 		{title}

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -17,7 +17,7 @@
 		size: 'sm' | 'md' | 'lg';
 		disabled: boolean;
 		href: string;
-		openInBackground: boolean;
+		openInNewTab: boolean;
 		type: 'button' | 'submit';
 		title: string;
 	}
@@ -64,7 +64,7 @@
 	/**
 	 * If `true`, then clicking the button will open the link target in a new tab. Has no effect if `href` is not set.
 	 */
-	export let openInBackground = false;
+	export let openInNewTab = false;
 
 	/**
 	 * If `submit`, then this is a submit button for use with a form.
@@ -215,8 +215,8 @@
 	<svelte:element
 		this={href ? 'a' : 'button'}
 		type={href ? undefined : type}
-		target={href && openInBackground ? '_blank' : undefined}
-		rel={href && openInBackground ? 'noopener noreferrer' : undefined}
+		target={href && openInNewTab ? '_blank' : undefined}
+		rel={href && openInNewTab ? 'noopener noreferrer' : undefined}
 		{href}
 		{disabled}
 		{title}


### PR DESCRIPTION
This has uses including linking to pages on the datastore from the new small sites map.

Here's a preview link that lets you inspect the DOM that is created (but the links don't actually work, due to how the embedding of stories inside storybook is done): https://dev.ldn-gis.co.uk/storybook-link-button-new-tab/?path=/story/ui-button--with-link-opening-in-new-tab