### PR TITLE
Dev

### DIFF
--- a/.changeset/odd-jars-love.md
+++ b/.changeset/odd-jars-love.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/charts": minor
+---
+
+Adjust reponisve layout of export buttons

--- a/package-lock.json
+++ b/package-lock.json
@@ -20822,7 +20822,7 @@
     },
     "packages/charts": {
       "name": "@ldn-viz/charts",
-      "version": "3.1.0",
+      "version": "3.3.0",
       "dependencies": {
         "@ldn-viz/ui": "*",
         "@ldn-viz/utils": "*",
@@ -20899,7 +20899,7 @@
     },
     "packages/maps": {
       "name": "@ldn-viz/maps",
-      "version": "5.0.0",
+      "version": "5.2.0",
       "dependencies": {
         "@deck.gl/core": "^8.9.35",
         "@deck.gl/layers": "^8.9.35",
@@ -20967,7 +20967,7 @@
     },
     "packages/tables": {
       "name": "@ldn-viz/tables",
-      "version": "1.2.0",
+      "version": "2.2.0",
       "dependencies": {
         "@ldn-viz/charts": "*",
         "@ldn-viz/themes": "*",
@@ -21049,7 +21049,7 @@
     },
     "packages/ui": {
       "name": "@ldn-viz/ui",
-      "version": "14.0.0",
+      "version": "14.3.0",
       "dependencies": {
         "@ldn-viz/utils": "*",
         "@melt-ui/svelte": "^0.76.0",

--- a/packages/charts/src/lib/chartContainer/ExportBtns.svelte
+++ b/packages/charts/src/lib/chartContainer/ExportBtns.svelte
@@ -14,38 +14,39 @@
 	export let columnMapping: undefined | { [oldName: string]: string } = undefined;
 </script>
 
-<!-- class="flex flex-col sm:flex-row shrink-0 sm:ml-auto sm:self-end sm:space-x-2 capture-ignore" -->
-<div
-	class="flex flex-col space-y-2 mt-2 shrink-0 sm:flex-row sm:space-y-0 sm:space-x-2 sm:mt-0 sm:items-end sm:ml-auto"
-	data-html2canvas-ignore
->
+<div class="flex flex-wrap mt-2 space-y-2 items-end" data-html2canvas-ignore>
 	{#if dataDownloadButton && dataForDownload}
-		<DataDownloadButton
-			data={dataForDownload}
-			{columnMapping}
-			filename="download"
-			formats={dataDownloadButton === true ? ['CSV', 'JSON'] : dataDownloadButton}
-			variant="outline"
-			emphasis="secondary"
-			size="sm"
-		>
-			<svelte:fragment slot="afterLabel">
-				<Icon src={ArrowDownTray} theme="mini" class="w-5 h-5 ml-2" aria-hidden="true" />
-			</svelte:fragment>
-		</DataDownloadButton>
+		<div class="mr-2 shrink-0">
+			<DataDownloadButton
+				data={dataForDownload}
+				{columnMapping}
+				filename="download"
+				formats={dataDownloadButton === true ? ['CSV', 'JSON'] : dataDownloadButton}
+				variant="outline"
+				emphasis="secondary"
+				size="sm"
+			>
+				<svelte:fragment slot="afterLabel">
+					<Icon src={ArrowDownTray} theme="mini" class="w-5 h-5 ml-2" aria-hidden="true" />
+				</svelte:fragment>
+			</DataDownloadButton>
+		</div>
 	{/if}
 
 	{#if imageDownloadButton}
-		<ImageDownloadButton
-			formats={imageDownloadButton === true ? ['PNG', 'SVG'] : imageDownloadButton}
-			htmlNode={chartToCapture}
-			variant="outline"
-			emphasis="secondary"
-			size="sm"
-		>
-			<svelte:fragment slot="afterLabel">
-				<Icon src={Camera} theme="mini" class="w-5 h-5 ml-2" aria-hidden="true" />
-			</svelte:fragment>
-		</ImageDownloadButton>
+		<div class="shrink-0">
+			<ImageDownloadButton
+				formats={imageDownloadButton === true ? ['PNG', 'SVG'] : imageDownloadButton}
+				htmlNode={chartToCapture}
+				variant="outline"
+				emphasis="secondary"
+				size="sm"
+				class="shrink-0"
+			>
+				<svelte:fragment slot="afterLabel">
+					<Icon src={Camera} theme="mini" class="w-5 h-5 ml-2" aria-hidden="true" />
+				</svelte:fragment>
+			</ImageDownloadButton>
+		</div>
 	{/if}
 </div>

--- a/packages/charts/src/lib/chartContainer/Footer.svelte
+++ b/packages/charts/src/lib/chartContainer/Footer.svelte
@@ -4,9 +4,9 @@
 	export let note = '';
 </script>
 
-<div class="w-full flex flex-col sm:flex-row justify-between mt-1">
+<div class="w-full flex flex-wrap justify-between mt-1 space-y-2">
 	{#if byline || source || note}
-		<ul class="flex flex-col space-y-0.5 text-color-text-secondary text-xs max-w-xl mr-4">
+		<ul class="flex flex-col space-y-0.5 text-color-text-secondary text-xs min-w-80 max-w-xl mr-4">
 			{#if byline}<li>{byline}</li>{/if}
 			{#if source}<li><span class="font-bold mr-1">Source:</span>{source}</li>{/if}
 			{#if note}<li><span class="font-bold mr-1">Note:</span>{note}</li>{/if}


### PR DESCRIPTION
**What does this change?**
Adjusts flow of export button in the cahrt footer (and therefore table footer)

**Why?**
when chart positioned 50/50 in grid buttons were not sensible positioned

**How?**
uses flexbox and flex wrap over defined breakpoints - so width/layot is controlled by width of parent rather than screen width

**Related issues**:
#632 

**Does this introduce new dependencies?**
no

**How is it tested?**
storybook

**How is it documented?**
na

**Are light and dark themes considered?**
na

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
