### PR TITLE
Refactor ObservablePlot to extract ObservablePlotInner and add controls slot

### DIFF
--- a/.changeset/slow-boxes-doubt.md
+++ b/.changeset/slow-boxes-doubt.md
@@ -2,4 +2,4 @@
 "@ldn-viz/charts": minor
 ---
 
-ADDED: `ObservablePlot` now wraps around `ChartContainer` and `ObservablePlotInner` components and accepts a `controls` slot
+ADDED: `ObservablePlot` now applies a `ChartContainer` wrapper around a separate `ObservablePlotInner` components and accepts a `controls` slot

--- a/.changeset/slow-boxes-doubt.md
+++ b/.changeset/slow-boxes-doubt.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/charts": minor
+---
+
+ADDED: `ObservablePlot` now wraps around `ChartContainer` and `ObservablePlotInner` components and accepts a `controls` slot

--- a/package-lock.json
+++ b/package-lock.json
@@ -20822,7 +20822,7 @@
     },
     "packages/charts": {
       "name": "@ldn-viz/charts",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "dependencies": {
         "@ldn-viz/ui": "*",
         "@ldn-viz/utils": "*",
@@ -21049,7 +21049,7 @@
     },
     "packages/ui": {
       "name": "@ldn-viz/ui",
-      "version": "14.3.0",
+      "version": "14.5.0",
       "dependencies": {
         "@ldn-viz/utils": "*",
         "@melt-ui/svelte": "^0.76.0",

--- a/packages/charts/src/lib/index.js
+++ b/packages/charts/src/lib/index.js
@@ -5,6 +5,8 @@ export { default as SubTitle } from './chartContainer/SubTitle.svelte';
 export { default as Title } from './chartContainer/Title.svelte';
 
 export { default as ObservablePlot } from './observablePlot/ObservablePlot.svelte';
-export * from './observablePlot/ObservablePlot.svelte';
+
+export { default as ObservablePlotInner } from './observablePlot/ObservablePlotInner.svelte';
+export * from './observablePlot/ObservablePlotInner.svelte';
 
 export * from './observablePlotFragments/observablePlotFragments';

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.stories.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.stories.svelte
@@ -42,7 +42,7 @@
 	} from '../../data/demoData';
 
 	import DemoTooltip from './DemoTooltip.svelte';
-	import { addEventHandler, registerTooltip } from './ObservablePlot.svelte';
+	import { addEventHandler, registerTooltip } from './ObservablePlotInner.svelte';
 	import type { Position } from './types';
 
 	$: ({

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.stories.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.stories.svelte
@@ -24,7 +24,7 @@
 	import * as Plot from '@observablehq/plot';
 	import { format } from 'd3-format';
 
-	import { currentThemeMode } from '@ldn-viz/ui';
+	import { currentThemeMode, Select } from '@ldn-viz/ui';
 	import {
 		getDefaultPlotStyles,
 		plotTheme,
@@ -34,8 +34,8 @@
 	import {
 		areaPlotData,
 		areaPlotPointsToLabel,
-		educationLabelOffsets,
 		education_data,
+		educationLabelOffsets,
 		lineChartData,
 		material_deprivation_data,
 		penguins
@@ -321,6 +321,16 @@
 		Selected point:
 		<pre>{JSON.stringify(clickedValue, null, 2)}</pre>
 	</div>
+</Story>
+
+<!-- Some charts have filters to update displayed information. In order to make the interaction clearer, you can slot in controls underneath the `title` and `subTitle` and above the actual chart. -->
+<Story name="With controls">
+	<ObservablePlot {spec} title="Penguin Culmens" subTitle="A scatterplot of depth against length">
+		<div slot="controls" class="flex gap-4 mb-4">
+			<Select label="An input affecting the chart" items={[]} />
+			<Select label="Another input" items={[]} />
+		</div>
+	</ObservablePlot>
 </Story>
 
 <!-- 

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
@@ -1,11 +1,10 @@
-<script context="module" lang="ts">
+<script lang="ts">
 	/**
 	 * The `ObservablePlot` component allows the rendering of visualisations using the [Observable Plot](https://observablehq.com/plot/) library, wrapping an `ObservablePlotInner` component in a [ChartContainer](./?path=/docs/charts-chartcontainer--documentation) wrapper.
-	 *  @component
+	 * If you do not require the extra chrome applied by the `ChartContainer`, or need to include several plots in the same container, then use the [ObservablePlotInner](./?path=/docs/charts-observableplotinner--documentation) component directly.
+	 * @component
 	 */
-</script>
 
-<script lang="ts">
 	import type { Position } from './types.ts';
 
 	import { writable } from 'svelte/store';

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
@@ -105,6 +105,9 @@
 		chartHeight={'h-fit'}
 		{chartWidth}
 	>
+		<!-- any controls to be displayed below the title and subTitle, but above the chart itself -->
+		<slot name="controls" />
+
 		<ObservablePlotInner {data} {domNode} {tooltipStore} {tooltipOffset} {spec} />
 	</ChartContainer>
 {/key}

--- a/packages/charts/src/lib/observablePlot/ObservablePlotInner.stories.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlotInner.stories.svelte
@@ -1,0 +1,180 @@
+<script context="module">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import ObservablePlotInner from './ObservablePlotInner.svelte';
+
+	export const meta = {
+		title: 'Charts/ObservablePlotInner',
+		component: ObservablePlotInner,
+
+		argTypes: {
+			// this is a module export, not a prop, so don't include it in table
+			addClick: {
+				table: {
+					disable: true
+				}
+			}
+		}
+	};
+</script>
+
+<script lang="ts">
+	import type { Writable } from 'svelte/store';
+	import { writable } from 'svelte/store';
+
+	import * as Plot from '@observablehq/plot';
+	import { format } from 'd3-format';
+
+	import { currentThemeMode, Select } from '@ldn-viz/ui';
+	import {
+		getDefaultPlotStyles,
+		plotTheme,
+		preprocessOptions
+	} from '../observablePlotFragments/observablePlotFragments';
+
+	import {
+		areaPlotData,
+		areaPlotPointsToLabel,
+		education_data,
+		educationLabelOffsets,
+		lineChartData,
+		material_deprivation_data,
+		penguins
+	} from '../../data/demoData';
+
+	import DemoTooltip from './DemoTooltip.svelte';
+	import { addEventHandler, registerTooltip } from './ObservablePlotInner.svelte';
+	import type { Position } from './types';
+
+	$: ({
+		defaultArea,
+		defaultColor,
+		defaultDot,
+		defaultGridX,
+		defaultGridY,
+		defaultSize,
+		defaultStyle,
+		defaultTip,
+		defaultLine,
+		defaultXAxis,
+		defaultXScale,
+		defaultYAxis,
+		defaultYScale,
+		defaultRule,
+		defaultAnnotationText
+	} = getDefaultPlotStyles($currentThemeMode));
+
+	$: spec = {
+		style: {
+			...defaultStyle
+		},
+
+		...defaultSize,
+
+		x: { ...defaultXScale },
+
+		y: { ...defaultYScale },
+
+		marks: [
+			Plot.gridX({ ...defaultGridX }),
+			Plot.gridY({ ...defaultGridY }),
+			Plot.ruleY([0], { ...defaultRule }),
+			Plot.ruleX([0], { ...defaultRule }),
+			Plot.dot(penguins, { ...defaultDot, x: 'culmen_length_mm', y: 'culmen_depth_mm' }), // instead of defaultPoint
+			Plot.axisX({ ...defaultXAxis }),
+			Plot.axisY({ ...defaultYAxis, label: 'culmen_depth_mm' }),
+			Plot.tip(
+				penguins,
+				Plot.pointerX({ ...defaultTip, x: 'culmen_length_mm', y: 'culmen_depth_mm' })
+			)
+		]
+	};
+
+	$: mbBarSpec = {
+		y: {
+			...defaultYScale,
+			label: ''
+		},
+
+		x: {
+			...defaultXScale,
+			domain: [0, 20],
+			insetLeft: 0 // adjusting to fit y axis labels of this chart
+		},
+
+		color: {
+			...defaultColor,
+			range: [
+				plotTheme($currentThemeMode).color.data.primary,
+				plotTheme($currentThemeMode).color.data.context
+			]
+		},
+
+		style: {
+			...defaultStyle
+		},
+
+		...defaultSize,
+		marginLeft: 200,
+		marginRight: 60,
+
+		marks: [
+			// grid marks
+			Plot.gridX({ ...defaultGridX, ticks: 5 }),
+
+			Plot.barX(material_deprivation_data, {
+				x: 'Pensioners',
+				y: 'Region',
+				fill: 'Area',
+				sort: { y: 'x', reverse: true }
+			}),
+
+			Plot.textX(material_deprivation_data, {
+				x: 'Pensioners',
+				y: 'Region',
+				fill: 'Area',
+				dx: 4,
+				textAnchor: 'start',
+				text: (d) => `${d.Pensioners}%`,
+				sort: { y: 'x', reverse: true }
+			}),
+
+			// // axis x
+			Plot.axisX({
+				...defaultXAxis,
+				label: 'Percentage of Pensioners',
+				tickFormat: (d) => `${d}%`,
+				ticks: 5
+			}),
+
+			// 0 baseline
+			Plot.ruleX([0], { ...defaultRule }), // Q: Should we always place a 0 baseline in the default chart (if range is not starting at 0, it won't be shown anyway)
+
+			// data tool tip - last to display
+			Plot.tip(
+				material_deprivation_data,
+				Plot.pointerY({
+					...defaultTip,
+					x: 'Pensioners',
+					y: 'Region',
+					title: (d) => [d.Region, `${d.Pensioners}%`].join('\n')
+				})
+			)
+		]
+	};
+
+	let clickedValue: any | undefined = undefined;
+	let clickedIndex: any | undefined = undefined;
+
+	const tooltipStore: Writable<Position> = writable();
+</script>
+
+<Template let:args>
+	<ObservablePlotInner
+		{...args}
+		{spec}
+		title="Penguin Culmens"
+		subTitle="A scatterplot of depth against length"
+	/>
+</Template>
+
+<Story name="Default" args={{ spec }} source />

--- a/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
@@ -1,0 +1,156 @@
+<script context="module" lang="ts">
+	/**
+	 * The `ObservablePlot` component allows the rendering of visualisations using the [Observable Plot](https://observablehq.com/plot/) library, wrapped in a [ChartContainer](./?path=/docs/charts-chartcontainer--documentation) wrapper.
+	 *  @component
+	 */
+
+	import type {
+		AddEventHandlerFunction,
+		AddEventHandlerInnerFunction,
+		Position,
+		RegisterTooltipFunction
+	} from './types.ts';
+
+	export const registerTooltip: RegisterTooltipFunction =
+		(posStore, markShape = 'circle') =>
+		(index, scales, values, dimensions, context, next) => {
+			const el = next && next(index, scales, values, dimensions, context);
+			const marks = el?.querySelectorAll(markShape) || [];
+
+			addEventHandlerInner(
+				'mouseenter',
+				(ev: MouseEvent, d: any) => {
+					posStore.set({
+						...d,
+						clientX: ev.clientX,
+						clientY: ev.clientY,
+						pageX: ev.pageX,
+						pageY: ev.pageY,
+						layerX: ev.layerX,
+						layerY: ev.layerY
+					}); // can't use the $store syntax here
+				},
+				marks,
+				values,
+				index
+			);
+
+			addEventHandlerInner(
+				'mouseleave',
+				() => {
+					posStore.set(undefined); // can't use the $store syntax here
+				},
+				marks,
+				values,
+				index
+			);
+
+			return el ?? null;
+		};
+
+	export const addEventHandler: AddEventHandlerFunction =
+		(eventName, eventHandler, markShape = 'circle') =>
+		(index, scales, values, dimensions, context, next) => {
+			const el = next && next(index, scales, values, dimensions, context);
+			const marks = el?.querySelectorAll(markShape) || [];
+
+			addEventHandlerInner(eventName, eventHandler, marks, values, index);
+
+			return el ?? null;
+		};
+
+	const addEventHandlerInner: AddEventHandlerInnerFunction = (
+		eventName,
+		eventHandler,
+		marks,
+		values,
+		index
+	) => {
+		for (let i = 0; i < marks.length; i++) {
+			const d = {
+				index: index[i],
+				x: values.channels.x.value[i],
+				y: values.channels.y.value[i]
+			};
+
+			marks[i].addEventListener(eventName, (ev: any) => eventHandler(ev, d));
+		}
+	};
+</script>
+
+<script lang="ts">
+	import * as Plot from '@observablehq/plot';
+
+	import { afterUpdate, onMount, setContext } from 'svelte';
+	import { derived, writable } from 'svelte/store';
+
+	/**
+	 * The Observable Plot specification for the visualization.
+	 */
+	export let spec;
+
+	/**
+	 * Data being visualized (as an array of objects), to be used by data download button.
+	 */
+	export let data: { [key: string]: any }[] = [];
+
+	/**
+	 * Provides a way to access the DOM node into which the visualization is rendered.
+	 */
+	export let domNode: any = undefined;
+
+	/**
+	 * A store that stores details of the moused-over point.
+	 * Used for custom tooltips.
+	 */
+	export let tooltipStore = writable<Position>();
+
+	/** A y-offset between data points and tooltips (pixels). */
+	export let tooltipOffset = -16;
+
+	const renderPlot = (node: HTMLDivElement) => {
+		node.appendChild(Plot.plot(spec));
+	};
+
+	let width: number;
+
+	onMount(() => {
+		updateDimensions();
+		window.addEventListener('resize', updateDimensions);
+		return () => {
+			window.removeEventListener('resize', updateDimensions);
+		};
+	});
+
+	afterUpdate(() => {
+		updateDimensions();
+	});
+
+	const updateDimensions = () => {
+		spec.width = width;
+	};
+
+	const tooltipData = derived(tooltipStore, ($tooltipStore) =>
+		$tooltipStore ? data[$tooltipStore.index] : undefined
+	);
+	setContext('tooltipData', tooltipData);
+</script>
+
+<div use:renderPlot {...$$restProps} bind:this={domNode} bind:clientWidth={width} />
+
+<!-- IMPORTANT TODO: data prop and exportData prop for buttons - align usage-->
+{#if $tooltipStore && $tooltipData}
+	<div
+		class="absolute max-w-[200px] text-sm p-2 bg-color-container-level-1 shadow z-50 -translate-x-1/2 -translate-y-full"
+		style:top={`${$tooltipStore.layerY + tooltipOffset}px`}
+		style:left={`${$tooltipStore.layerX}px`}
+	>
+		<slot name="tooltip">
+			<pre>{JSON.stringify(data[$tooltipStore.index], null, 2)}</pre>
+		</slot>
+
+		<div
+			class="absolute bg-color-container-level-1 rotate-45 w-4 h-4 -translate-x-1/2 inset-x-1/2"
+		/>
+	</div>
+{/if}

--- a/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
@@ -1,6 +1,6 @@
 <script context="module" lang="ts">
 	/**
-	 * The `ObservablePlot` component allows the rendering of visualisations using the [Observable Plot](https://observablehq.com/plot/) library, wrapped in a [ChartContainer](./?path=/docs/charts-chartcontainer--documentation) wrapper.
+	 * The `ObservablePlotInner` component allows the rendering of visualisations using the [Observable Plot](https://observablehq.com/plot/) library, wrapped in a [ChartContainer](./?path=/docs/charts-chartcontainer--documentation) wrapper.
 	 *  @component
 	 */
 

--- a/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
@@ -1,6 +1,8 @@
 <script context="module" lang="ts">
 	/**
-	 * The `ObservablePlotInner` component allows the rendering of visualisations using the [Observable Plot](https://observablehq.com/plot/) library, wrapped in a [ChartContainer](./?path=/docs/charts-chartcontainer--documentation) wrapper.
+	 * The `ObservablePlotInner` component allows the rendering of visualisations using the [Observable Plot](https://observablehq.com/plot/) library.
+	 * It does *not* apply the  [ChartContainer](./?path=/docs/charts-chartcontainer--documentation) as a wrapper:
+	 *  if you require this, use the [ObservablePlot](./?path=/docs/charts-observableplot--documentation) component instead.
 	 *  @component
 	 */
 

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -25,11 +25,11 @@ module.exports = {
   },
   rules: {
     '@typescript-eslint/no-explicit-any': ['warn'],
-    "@typescript-eslint/no-unused-vars": [
-      "warn",
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
       {
-        "argsIgnorePattern": "^_", // Ignore arguments prefixed with underscore
-        "varsIgnorePattern": "^_" // Ignore variables prefixed with underscore
+        argsIgnorePattern: '^_', // Ignore arguments prefixed with underscore
+        varsIgnorePattern: '^_' // Ignore variables prefixed with underscore
       }
     ]
   }


### PR DESCRIPTION
**What does this change?**
`ObservablePlot` wraps around `ChartContainer` and `ObservablePlotInner` components. `ObservablePlotInner` now contains the plot logic that used to live in `ObservablePlot`.

You can now also add a `controls` slot to keep `Select` or other inputs with the relevant charts.

**Why?**
Adding desired functionality and clarity to the structure of the `ObservablePlot` component.

**Is it complete?**

- [x] Have you included changeset file?
