### PR TITLE
Radio group props

### DIFF
--- a/.changeset/silent-islands-brush.md
+++ b/.changeset/silent-islands-brush.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/ui": minor
+---
+
+CHANGED hintLabel prop to be optional; ADDED story for horizontal alignment of radio buttons in RadioButtonGroup

--- a/package-lock.json
+++ b/package-lock.json
@@ -20822,7 +20822,7 @@
     },
     "packages/charts": {
       "name": "@ldn-viz/charts",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "dependencies": {
         "@ldn-viz/ui": "*",
         "@ldn-viz/utils": "*",
@@ -20967,7 +20967,7 @@
     },
     "packages/tables": {
       "name": "@ldn-viz/tables",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@ldn-viz/charts": "*",
         "@ldn-viz/themes": "*",
@@ -21052,7 +21052,7 @@
     },
     "packages/ui": {
       "name": "@ldn-viz/ui",
-      "version": "14.5.0",
+      "version": "14.6.0",
       "dependencies": {
         "@ldn-viz/utils": "*",
         "@melt-ui/svelte": "^0.76.0",

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
@@ -40,3 +40,15 @@
 	<RadioButtonGroup options={optionsForGroup} name="station-type" bind:selectedId buttonsHidden />
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>
+
+<Story name="RadioGroup - aligned in row">
+	<RadioButtonGroup
+		options={optionsForGroup}
+		name="station-type"
+		bind:selectedId
+		flexDirection=""
+		marginX="space-x-4"
+		buttonsHidden
+	/>
+	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
+</Story>

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
@@ -39,19 +39,19 @@
 	}[] = [];
 
 	/**
-	 * Default `flex-direction` is `flex-col` but allows you to create horizontal radios
-	 * if you pass in an empty string (default `flex` behaviour is to display in row).
+	 * Direction of the flexbox. Default direction is column but passing in `flex-row` or an
+	 * empty string will allow you to display radios in a row.
 	 */
 	export let flexDirection = 'flex-col';
 
 	/**
-	 * Optional prop to change margin on the x-axis between elements.
+	 * Optional prop to change margin between elements on the x-axis.
 	 * For example `space-x-4`.
 	 */
 	export let marginX = '';
 
 	/**
-	 * Optional prop to change margin on the y-axis between elements.
+	 * Optional prop to change margin between elements on the y-axis.
 	 */
 	export let marginY = 'space-y-0.25';
 

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
@@ -52,12 +52,11 @@
 
 	/**
 	 * Optional prop to change margin on the y-axis between elements.
-	 * Default is `space-y-0.25`.
 	 */
 	export let marginY = 'space-y-0.25';
 
 	/**
-	 * if `true`, then then `Clear` button is not displayed.
+	 * if `true`, then the `Clear` button is not displayed.
 	 */
 	export let buttonsHidden = false;
 </script>

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
@@ -39,12 +39,30 @@
 	}[] = [];
 
 	/**
+	 * Default `flex-direction` is `flex-col` but allows you to create horizontal radios
+	 * if you pass in an empty string (default `flex` behaviour is to display in row).
+	 */
+	export let flexDirection = 'flex-col';
+
+	/**
+	 * Optional prop to change margin on the x-axis between elements.
+	 * For example `space-x-4`.
+	 */
+	export let marginX = '';
+
+	/**
+	 * Optional prop to change margin on the y-axis between elements.
+	 * Default is `space-y-0.25`.
+	 */
+	export let marginY = 'space-y-0.25';
+
+	/**
 	 * if `true`, then then `Clear` button is not displayed.
 	 */
 	export let buttonsHidden = false;
 </script>
 
-<div class="flex flex-col space-y-0.25">
+<div class="flex {flexDirection} {marginX} {marginY}">
 	{#if !buttonsHidden}
 		<Button variant="text" class="!px-0" on:click={() => (selectedId = '')}>Clear</Button>
 	{/if}

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
@@ -35,7 +35,7 @@
 		color?: string;
 		disabled?: boolean;
 		hint?: string;
-		hintLabel: string;
+		hintLabel?: string;
 	}[] = [];
 
 	/**


### PR DESCRIPTION
**What does this change?**
- RadioGroup options no longer expect `hintLabel` prop (which was the intended functionality)
- Added new `RadioButtonGroup` story to display radio buttons in a row, with new optional props: `flexDirection`, `marginX`, `marginY`
     - note, `marginX` and `marginY` are currently strings but could be numbers (I tried this, i.e. `space-x-{marginX}`, but it didn't work)
![image](https://github.com/user-attachments/assets/1a718382-97bd-4ca3-8e4d-cc78d558df8d)

**Related issues**: #663 

**Is it complete?**

- [x] Have you included changeset file?
