### PR TITLE
fixed hintLabel so it's optional

### DIFF
--- a/.changeset/little-paws-greet.md
+++ b/.changeset/little-paws-greet.md
@@ -1,5 +1,5 @@
 ---
-"@ldn-viz/ui": minor
+"@ldn-viz/ui": patch
 ---
 
 FIXED hintLabel prop is now optional

--- a/.changeset/little-paws-greet.md
+++ b/.changeset/little-paws-greet.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/ui": minor
+---
+
+FIXED hintLabel prop is now optional

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
@@ -35,7 +35,7 @@
 		color?: string;
 		disabled?: boolean;
 		hint?: string;
-		hintLabel: string;
+		hintLabel?: string;
 	}[] = [];
 
 	/**


### PR DESCRIPTION
**What does this change?**
`hintLabel` is now an optional prop in `RadioButtonGroup`, to match intended functionality.

**Is it complete?**

- [x] Have you included changeset file?
