### PR TITLE
add page about datepickers

### DIFF
--- a/packages/ui/src/lib/datepicker.mdx
+++ b/packages/ui/src/lib/datepicker.mdx
@@ -1,0 +1,12 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Ui/Datepicker/Datepicker" />
+
+# Datepicker/Calendar
+
+We use the [@svelte-plugins/datepicker](https://svelte-plugins.github.io/datepicker/) component
+([GitHub repository](https://github.com/svelte-plugins/datepicker)) as a datepicker.
+
+We haven't yet implemented a wrapper around it, as different applications have tended to have quite specific requirements.
+
+For example, the HSDS-Hub implements a more complex widget for selecting a date range (and automatically identifying the immediately previous period or the same period in the previous year as a comparison period)

--- a/packages/ui/src/lib/datepicker.mdx
+++ b/packages/ui/src/lib/datepicker.mdx
@@ -9,4 +9,4 @@ We use the [@svelte-plugins/datepicker](https://svelte-plugins.github.io/datepic
 
 We haven't yet implemented a wrapper around it, as different applications have tended to have quite specific requirements.
 
-For example, the HSDS-Hub implements a more complex widget for selecting a date range (and automatically identifying the immediately previous period or the same period in the previous year as a comparison period)
+For example, the HSDS-Hub implements a more complex widget for selecting a date range (and automatically identifying the immediately previous period or the same period in the previous year as a comparison period).


### PR DESCRIPTION
Add a page linking to the datepicker component we use.

Preview: https://dev.ldn-gis.co.uk/storybook-document-datepicker/?path=/docs/ui-datepicker-datepicker--documentation