### PR TITLE
Png download padding

### DIFF
--- a/.changeset/silly-cherries-wave.md
+++ b/.changeset/silly-cherries-wave.md
@@ -3,4 +3,4 @@
 "@ldn-viz/tables": minor
 ---
 
-add padding to images downloaded by download png buttons
+FIXED: add padding to images of charts or tables downloaded in png format using ImageDownloadButton

--- a/.changeset/silly-cherries-wave.md
+++ b/.changeset/silly-cherries-wave.md
@@ -1,0 +1,6 @@
+---
+"@ldn-viz/charts": minor
+"@ldn-viz/tables": minor
+---
+
+add padding to images downloaded by download png buttons

--- a/packages/charts/src/lib/chartContainer/ChartContainer.svelte
+++ b/packages/charts/src/lib/chartContainer/ChartContainer.svelte
@@ -111,6 +111,7 @@
 		<Footer {source} {byline} {note}>
 			<ExportBtns
 				{chartToCapture}
+				idToPad="captureElement"
 				dataForDownload={data}
 				{dataDownloadButton}
 				{imageDownloadButton}

--- a/packages/charts/src/lib/chartContainer/ExportBtns.svelte
+++ b/packages/charts/src/lib/chartContainer/ExportBtns.svelte
@@ -4,6 +4,7 @@
 	import { Icon } from '@steeze-ui/svelte-icon';
 
 	export let chartToCapture: HTMLDivElement;
+	export let idToPad = '';
 	export let dataForDownload: { [key: string]: any }[] | undefined;
 	export let dataDownloadButton: true | false | ('CSV' | 'JSON')[];
 	export let imageDownloadButton: true | false | ('PNG' | 'SVG')[];
@@ -41,6 +42,7 @@
 				variant="outline"
 				emphasis="secondary"
 				size="sm"
+				{idToPad}
 			>
 				<svelte:fragment slot="afterLabel">
 					<Icon src={Camera} theme="mini" class="w-5 h-5 ml-2" aria-hidden="true" />

--- a/packages/tables/src/lib/table/TableContainer.svelte
+++ b/packages/tables/src/lib/table/TableContainer.svelte
@@ -118,6 +118,7 @@
 			<ExportBtns
 				chartToCapture={tableToCapture}
 				{columnMapping}
+				idToPad="captureElement"
 				dataForDownload={data}
 				{dataDownloadButton}
 				{imageDownloadButton}


### PR DESCRIPTION
**What does this change?**
adds default padding to images downloaded via "download as Png" button

**Why?**
padding wasn't being added

**How?**

**Related issues**:

**Does this introduce new dependencies?**
n

**How is it tested?**
storybook

**How is it documented?**

**Are light and dark themes considered?**

**Is it complete?**

- [x] Have you included changeset file?

