### PR TITLE
Change sidebarAlways open object to use Booleans

### DIFF
--- a/.changeset/sidebar-always-open.md
+++ b/.changeset/sidebar-always-open.md
@@ -1,0 +1,7 @@
+---
+'@ldn-viz/ui': patch
+---
+
+CHANGED: the definition of when the sidebar is always open can now use Booleans (`true`/`false`) rather than strings (`'true'`/`'false'`)
+
+

--- a/packages/ui/src/lib/appShell/AppShell.stories.svelte
+++ b/packages/ui/src/lib/appShell/AppShell.stories.svelte
@@ -524,7 +524,7 @@
 </Story>
 
 <Story name="Always Open Responsive changes">
-	<AppShell sidebarAlwaysOpen={{ initial: 'false', md: 'true' }}>
+	<AppShell sidebarAlwaysOpen={{ initial: false, md: true }}>
 		<Sidebar slot="sidebar">
 			<SidebarHeader title="Main sidebar title" slot="header">
 				<svelte:fragment slot="subTitle">

--- a/packages/ui/src/lib/appShell/AppShell.svelte
+++ b/packages/ui/src/lib/appShell/AppShell.svelte
@@ -78,7 +78,7 @@
 	$: bpProp = getSetting(sidebarPlacement, innerWidth);
 	$: aoProp = sidebarAlwaysOpen ? getSetting(sidebarAlwaysOpen, innerWidth) : undefined;
 
-	$: $isAlwaysOpen = (aoProp === 'true' || aoProp === true);
+	$: $isAlwaysOpen = aoProp === 'true' || aoProp === true;
 	$: $sidebarPlacementStore = bpProp;
 
 	$: $isOpen = $isAlwaysOpen === true;

--- a/packages/ui/src/lib/appShell/AppShell.svelte
+++ b/packages/ui/src/lib/appShell/AppShell.svelte
@@ -8,6 +8,7 @@
 
 	import { setContext } from 'svelte';
 	import { writable } from 'svelte/store';
+	import type { Writable } from 'svelte/store';
 	import { fade, slide } from 'svelte/transition';
 	import { heightLookup, transitionAxis, widthLookup } from '../sidebar/sidebarUtils';
 	import { sidebarWidthStore } from '../sidebar/stores';
@@ -52,7 +53,7 @@
 	/**
 	 * Store recording/controlling whether the sidebar is set to be `alwaysOpen` at the current window size.
 	 */
-	export const isAlwaysOpen = writable(false);
+	export const isAlwaysOpen: Writable<boolean | string> = writable(false);
 
 	/**
 	 * Store recording/controlling the sidebar's current position.
@@ -72,15 +73,25 @@
 		Below are settings for Breakpoint Prop and Always Open Prop.
 		This is the secret sauce that allows us to pass an object containing different props per breakpoint.
 		The breakpoints are configurable if required, but use defaults: Demo to follow.
-		See also appShell/utils/getSettingByScreenWidth 
+		See also appShell/utils/getSettingByScreenWidth
 	*/
 	// bpProp = breakpoint prop - better name?
 	$: bpProp = getSetting(sidebarPlacement, innerWidth);
 
-	$: $isAlwaysOpen = aoProp === 'true' || aoProp === true;
-	$: $sidebarPlacementStore = bpProp;
+	$isOpen = startOpen;
 
-	$: $isOpen = $isAlwaysOpen === true;
+	const respondToWidthChange = (innerWidth) => {
+		$isAlwaysOpen = sidebarAlwaysOpen ? getSetting(sidebarAlwaysOpen, innerWidth) : undefined;
+
+		// if "alwaysOpen" at this size, then we are open at this size
+		if ($isAlwaysOpen === true || $isAlwaysOpen === 'true') {
+			$isOpen = true;
+		}
+	};
+
+	$: respondToWidthChange(innerWidth);
+
+	$: $sidebarPlacementStore = bpProp;
 
 	setContext('sidebarAlwaysOpen', isAlwaysOpen);
 	setContext('sidebarIsOpen', isOpen);

--- a/packages/ui/src/lib/appShell/AppShell.svelte
+++ b/packages/ui/src/lib/appShell/AppShell.svelte
@@ -121,7 +121,7 @@
 	{/if}
 
 	<!-- This div exists to push content to the side of the sidebar	when sidebarPush is set to true-->
-	{#if ($isAlwaysOpen === 'true' || (sidebarPush && $isOpen)) && $sidebarWidthStore}
+	{#if ($isAlwaysOpen === 'true' || $isAlwaysOpen === true || (sidebarPush && $isOpen)) && $sidebarWidthStore}
 		<div
 			class={classNames('flex', sidebarHeightClasses)}
 			transition:slide={{ duration: 300, axis: transitionAxis[bpProp] }}

--- a/packages/ui/src/lib/appShell/AppShell.svelte
+++ b/packages/ui/src/lib/appShell/AppShell.svelte
@@ -45,14 +45,14 @@
 	export let isOpen = writable(startOpen);
 
 	/**
-	 * A tailwind class or classes used to set or overide the height of the Appshell wrapper.
+	 * A tailwind class or classes used to set or override the height of the `AppShell` wrapper.
 	 */
 	export let heightClass = 'min-h-dvh';
 
 	/**
 	 * Store recording/controlling whether the sidebar is set to be `alwaysOpen` at the current window size.
 	 */
-	export const isAlwaysOpen = writable('false');
+	export const isAlwaysOpen = writable(false);
 
 	/**
 	 * Store recording/controlling the sidebar's current position.
@@ -78,10 +78,10 @@
 	$: bpProp = getSetting(sidebarPlacement, innerWidth);
 	$: aoProp = sidebarAlwaysOpen ? getSetting(sidebarAlwaysOpen, innerWidth) : undefined;
 
-	$: $isAlwaysOpen = aoProp;
+	$: $isAlwaysOpen = (aoProp === 'true' || aoProp === true);
 	$: $sidebarPlacementStore = bpProp;
 
-	$: $isOpen = $isAlwaysOpen === 'true';
+	$: $isOpen = $isAlwaysOpen === true;
 
 	setContext('sidebarAlwaysOpen', isAlwaysOpen);
 	setContext('sidebarIsOpen', isOpen);


### PR DESCRIPTION
It would be better to switch to *requiring* the use of Booleans rather than strings, but that is a breaking change that can be deferred for now.