### PR TITLE
Fix cookie settings components

### DIFF
--- a/.changeset/cookie-control.md
+++ b/.changeset/cookie-control.md
@@ -1,0 +1,6 @@
+---
+'@ldn-viz/ui': patch
+---
+
+FIXED: updated `AnalyticsAndCookieConsent` and `CookieControlSettings` components to avoid errors if they are rendered
+before `ldnVizCivic` is initialized

--- a/packages/ui/src/lib/analytics/AnalyticsAndCookieConsent.svelte
+++ b/packages/ui/src/lib/analytics/AnalyticsAndCookieConsent.svelte
@@ -54,6 +54,7 @@
 		var ldnVizCivic = {
 			appName: window.ldnVizCivicAppName || 'Embedded app',
 			intervalId: null,
+			initialIntervalId: null,
 			config: {
 				apiKey: window.ldnVizCivicApiKey,
 				product: 'PRO_MULTISITE',
@@ -209,6 +210,12 @@
 		};
 
 		ldnVizCivic.init = function () {
+			if (CookieControl) {
+				clearInterval(ldnVizCivic.initialIntervalId);
+			} else {
+				return;
+			}
+
 			if (!ldnVizCivic.isCookieControlManagedByParent()) {
 				CookieControl.load(ldnVizCivic.config);
 				return;
@@ -220,7 +227,7 @@
 			}
 		};
 
-		ldnVizCivic.init();
+		ldnVizCivic.initialIntervalId = setInterval(ldnVizCivic.init, 500);
 	</script>
 
 	<script>

--- a/packages/ui/src/lib/analytics/CookieControlSettings.stories.svelte
+++ b/packages/ui/src/lib/analytics/CookieControlSettings.stories.svelte
@@ -8,13 +8,11 @@
 
 <script>
 	import { Story, Template } from '@storybook/addon-svelte-csf';
-	import { writable } from 'svelte/store';
-
-	// hack to make the "View cookie settings" link appear
-	window.CookieControl = writable(true);
+	import AnalyticsAndCookieConsent from './AnalyticsAndCookieConsent.svelte';
 </script>
 
 <Template let:args>
+	<AnalyticsAndCookieConsent />
 	<CookieControlSettings {...args} />
 </Template>
 

--- a/packages/ui/src/lib/analytics/CookieControlSettings.svelte
+++ b/packages/ui/src/lib/analytics/CookieControlSettings.svelte
@@ -37,6 +37,8 @@
 			cookieControlStore.set(window.CookieControl);
 		}
 	});
+
+	$: cookieControlStore.set(window.CookieControl);
 </script>
 
 {#if $cookieControlStore}


### PR DESCRIPTION
This applies the fix that I applied directly to the HSDS Hub site. It avoids the error due to the cookie related Svelte components rendering before the `window.CookieControl` object is initialized.