### PR TITLE
respect startOpen prop in AppShell

### DIFF
--- a/.changeset/sidebar-start-open.md
+++ b/.changeset/sidebar-start-open.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+FIXED: fix bug that caused `AppShell` to always acts as if the `startOpen` prop was `false`

--- a/packages/ui/src/lib/appShell/AppShell.stories.svelte
+++ b/packages/ui/src/lib/appShell/AppShell.stories.svelte
@@ -508,6 +508,36 @@
 	</AppShell>
 </Story>
 
+<Story name="Start Open (default)">
+	<AppShell startOpen>
+		<Sidebar slot="sidebar">
+			<SidebarHeader title="Main sidebar title" slot="header">
+				<svelte:fragment slot="subTitle">
+					<p>
+						Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui, nec
+						venenatis sapien. Etiam venenatis felis.
+					</p>
+				</svelte:fragment>
+			</SidebarHeader>
+		</Sidebar>
+	</AppShell>
+</Story>
+
+<Story name="Start Closed">
+	<AppShell startOpen={false}>
+		<Sidebar slot="sidebar">
+			<SidebarHeader title="Main sidebar title" slot="header">
+				<svelte:fragment slot="subTitle">
+					<p>
+						Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui, nec
+						venenatis sapien. Etiam venenatis felis.
+					</p>
+				</svelte:fragment>
+			</SidebarHeader>
+		</Sidebar>
+	</AppShell>
+</Story>
+
 <Story name="Always Open">
 	<AppShell sidebarAlwaysOpen={{ initial: 'true' }}>
 		<Sidebar slot="sidebar">
@@ -523,6 +553,11 @@
 	</AppShell>
 </Story>
 
+<!--
+The sidebar is always open if the window is wider than the `md` breakpoint size.
+In the sidebar was closed when the browser window was small, then it will automatically open when
+the screen width increases past this threshold.
+ -->
 <Story name="Always Open Responsive changes">
 	<AppShell sidebarAlwaysOpen={{ initial: 'false', md: 'true' }}>
 		<Sidebar slot="sidebar">

--- a/packages/ui/src/lib/appShell/AppShell.svelte
+++ b/packages/ui/src/lib/appShell/AppShell.svelte
@@ -76,12 +76,21 @@
 	*/
 	// bpProp = breakpoint prop - better name?
 	$: bpProp = getSetting(sidebarPlacement, innerWidth);
-	$: aoProp = sidebarAlwaysOpen ? getSetting(sidebarAlwaysOpen, innerWidth) : undefined;
 
-	$: $isAlwaysOpen = aoProp;
+	$isOpen = startOpen;
+
+	const respondToWidthChange = (innerWidth) => {
+		$isAlwaysOpen = sidebarAlwaysOpen ? getSetting(sidebarAlwaysOpen, innerWidth) : undefined;
+
+		// if "alwaysOpen" at this size, then we are open at this size
+		if ($isAlwaysOpen === 'true') {
+			$isOpen = true;
+		}
+	};
+
+	$: respondToWidthChange(innerWidth);
+
 	$: $sidebarPlacementStore = bpProp;
-
-	$: $isOpen = $isAlwaysOpen === 'true';
 
 	setContext('sidebarAlwaysOpen', isAlwaysOpen);
 	setContext('sidebarIsOpen', isOpen);


### PR DESCRIPTION
Fix bug that caused `AppShell` to always acts as if the `startOpen` prop was `false`.

Fixes #673 