### PR TITLE
Allow sub-components of side-by-side ChartContainers to be aligned

### DIFF
--- a/.changeset/align-chart-components.md
+++ b/.changeset/align-chart-components.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/charts': minor
+---
+
+CHANGED: add ability to align the sub-components of two or more `ChartContainers` placed side-by-side

--- a/packages/charts/src/lib/chartContainer/ChartContainer.stories.svelte
+++ b/packages/charts/src/lib/chartContainer/ChartContainer.stories.svelte
@@ -76,3 +76,36 @@
 		imageDownloadButton={['PNG']}
 	/>
 </Story>
+
+<!--
+This story show how you can place two (or more) sites side-by-side, and ensure that the titles/chart body/download buttons remain aligned as the window is shrunk.
+-->
+<Story name="Aligning 2 charts">
+	<div class="grid grid-flow-col grid-cols-2 gap-x-12" style="grid-template-rows: auto auto auto;">
+		<ChartContainer
+			overrideClass="bg-color-palette-red-500"
+			title="This is the Chart Title"
+			subTitle="Subtitle provides extra context"
+			source="The source of this chart data"
+			byline="A byline for the chart"
+			note="Be aware that you can provide a note if required"
+			dataDownloadButton={['JSON', 'CSV']}
+			data={[]}
+			imageDownloadButton={['PNG']}
+			alignMultiple
+		/>
+
+		<ChartContainer
+			overrideClass="bg-color-palette-red-500"
+			title="This is the Chart Title"
+			subTitle="Subtitle provides extra context. This one is much longer than for the other chart, so wil wrap earlier."
+			source="The source of this chart data"
+			byline="A byline for the chart"
+			note="Be aware that you can provide a note if required. This one is much longer than for the other chart, so wil wrap earlier. It's really unnecessarilt ong."
+			dataDownloadButton={['JSON', 'CSV']}
+			data={[]}
+			imageDownloadButton={['PNG']}
+			alignMultiple
+		/>
+	</div>
+</Story>

--- a/packages/charts/src/lib/chartContainer/ChartContainer.stories.svelte
+++ b/packages/charts/src/lib/chartContainer/ChartContainer.stories.svelte
@@ -101,7 +101,7 @@ This story show how you can place two (or more) sites side-by-side, and ensure t
 			subTitle="Subtitle provides extra context. This one is much longer than for the other chart, so wil wrap earlier."
 			source="The source of this chart data"
 			byline="A byline for the chart"
-			note="Be aware that you can provide a note if required. This one is much longer than for the other chart, so wil wrap earlier. It's really unnecessarilt ong."
+			note="Be aware that you can provide a note if required. This one is much longer than for the other chart, so wil wrap earlier. It's really excessively long."
 			dataDownloadButton={['JSON', 'CSV']}
 			data={[]}
 			imageDownloadButton={['PNG']}

--- a/packages/charts/src/lib/chartContainer/ChartContainer.svelte
+++ b/packages/charts/src/lib/chartContainer/ChartContainer.svelte
@@ -77,18 +77,31 @@
 	export let chartHeight = 'h-60';
 
 	export let overrideClass = '';
-	let chartClass = classNames('relative', chartHeight, overrideClass);
 
 	/**
 	 * Tailwind class to set overall chart width
 	 */
 	export let chartWidth = 'w-full';
 
+	/**
+	 * If set to `true`, set `display: contents` on the top-level `ChartContainer` div, so that a grid layout can be
+	 * be applied to align parts of charts across two columns
+	 */
+	export let alignMultiple = false;
+
 	// For save as image
 	let chartToCapture: HTMLDivElement;
+
+	let chartClass = classNames(
+		'relative',
+		chartHeight,
+		overrideClass,
+		alignMultiple ? 'min-w-0' : ''
+	);
+	$: classes = classNames(chartWidth, alignMultiple ? 'contents' : 'flex flex-col');
 </script>
 
-<div class={`chart-container ${chartWidth}`} bind:this={chartToCapture} id="captureElement">
+<div class={classes} bind:this={chartToCapture} id="captureElement">
 	{#if title || subTitle}
 		<div class="mb-4">
 			{#if title}
@@ -106,6 +119,9 @@
 
 	<!-- any controls to be displayed below the title and subTitle, but above the chart itself -->
 	<slot name="controls" />
+
+	<!-- separate slot for legend, so that main chart can be aligned if legends wrap over different number of lines-->
+	<slot name="legend" />
 
 	<!-- Visualisation goes here -->
 	<div class={chartClass}>
@@ -126,9 +142,3 @@
 		</Footer>
 	{/if}
 </div>
-
-<style lang="postcss">
-	.chart-container {
-		@apply flex flex-col;
-	}
-</style>


### PR DESCRIPTION
add ability to align the sub-components of two or more `ChartContainers` placed side-by-side

Preview: https://dev.ldn-gis.co.uk/storybook-align-chart-components/?path=/story/charts-chartcontainer--aligning-2-charts