### PR TITLE
use em instead of rem for width and height of radios/ checkboxes

### DIFF
--- a/.changeset/radio-checkbox-spacing.md
+++ b/.changeset/radio-checkbox-spacing.md
@@ -1,0 +1,5 @@
+---
+"@ldn-viz/ui": patch
+---
+
+FIXED: fix spacing between `RadioButton`s and `Checkbox`es when inside a `SidebarSection`

--- a/packages/themes/ldn-theme.js
+++ b/packages/themes/ldn-theme.js
@@ -46,8 +46,8 @@ const config = {
         },
         '.form-checkbox, .form-radio': {
           'border-width': '2px',
-          width: '1.25rem',
-          height: '1.25rem',
+          width: '1.25em',
+          height: '1.25em',
           color: ldnColors['color-input-background-active'],
           '&:hover': {
             'border-color': ldnColors['color-input-border-hover']


### PR DESCRIPTION
**What does this change?**
Switches css width and height of form-checkbox and form-radio class from rem to em

**Why?**
Using rem meant that inside a text-sm context the elements, when grouped were too close.

**How?**
Change to ldn-viz theme global css

**Related issues**:
no

**Does this introduce new dependencies?**
no

**How is it tested?**
storybook

**How is it documented?**
na

**Are light and dark themes considered?**
na

**Is it complete?**
y

- [ ] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
