### PR TITLE
Increase z-index of popover controls in LayerControl component so that they do not open behind sidebars

### DIFF
--- a/.changeset/layer-control-z-index.md
+++ b/.changeset/layer-control-z-index.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: increase z-index of popover controls in `LayerControl` component so that they do not open behind sidebars

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -42,7 +42,7 @@
 		{...$content}
 		use:content
 		transition:fade={{ duration: 100 }}
-		class="z-10 w-64 bg-core-grey-50 p-4 shadow"
+		class="z-50 w-64 bg-core-grey-50 p-4 shadow"
 	>
 		<div {...$arrow} use:arrow />
 

--- a/packages/ui/src/lib/layerControl/OpacityControl.svelte
+++ b/packages/ui/src/lib/layerControl/OpacityControl.svelte
@@ -28,7 +28,7 @@
 		{...$content}
 		use:content
 		transition:fade={{ duration: 100 }}
-		class="z-10 w-64 bg-core-grey-50 p-4 shadow"
+		class="z-50 w-64 bg-core-grey-50 p-4 shadow"
 	>
 		<div {...$arrow} use:arrow />
 

--- a/packages/ui/src/lib/layerControl/ResizeControl.svelte
+++ b/packages/ui/src/lib/layerControl/ResizeControl.svelte
@@ -29,7 +29,7 @@
 		{...$content}
 		use:content
 		transition:fade={{ duration: 100 }}
-		class="z-10 w-64 bg-core-grey-50 p-4 shadow"
+		class="z-50 w-64 bg-core-grey-50 p-4 shadow"
 	>
 		<div {...$arrow} use:arrow />
 


### PR DESCRIPTION
**Related issues**:

This fixes #671 
