### PR TITLE
Image download

### DIFF
--- a/apps/docs/.storybook/preview-head.html
+++ b/apps/docs/.storybook/preview-head.html
@@ -4,4 +4,5 @@
 <link
 	href="https://fonts.googleapis.com/css2?family=EB+Garamond&family=Inter:wght@100..900&family=Roboto:wght@100;400;500;700&display=swap"
 	rel="stylesheet"
+	crossorigin="anonymous"
 />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@changesets/cli": "^2.27.1",
-        "html2canvas": "^1.4.1"
+        "@changesets/cli": "^2.27.1"
       },
       "devDependencies": {
         "@ldn-viz/eslint-config-custom": "*",
@@ -7820,14 +7819,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/better-opn": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
@@ -8319,14 +8310,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -9014,6 +8997,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dom-to-svg": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/dom-to-svg/-/dom-to-svg-0.12.2.tgz",
+      "integrity": "sha512-zVlswIYMj3669dUfErBszLcYOy+NzPEFhMezdzLVaqFcaj7VQecS0o8r9bqzBSczDtex2X/4HMZktFoj4EDqOA==",
+      "dependencies": {
+        "gradient-parser": "^1.0.2",
+        "postcss": "^8.2.9",
+        "postcss-value-parser": "^4.1.0"
       }
     },
     "node_modules/domelementtype": {
@@ -10436,6 +10429,14 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
+    "node_modules/gradient-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.0.2.tgz",
+      "integrity": "sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -10524,17 +10525,10 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "node_modules/htmlparser2-svelte": {
       "version": "4.1.0",
@@ -14272,14 +14266,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -14804,14 +14790,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
-      }
     },
     "node_modules/uuid": {
       "version": "9.0.1",
@@ -15620,7 +15598,6 @@
         "d3-scale": "^4.0.2",
         "d3-shape": "^3.2.0",
         "d3-time-format": "^4.1.0",
-        "html2canvas": "^1.4.1",
         "svelte-virtual-scroll-list": "^1.3.0"
       },
       "devDependencies": {
@@ -15756,7 +15733,8 @@
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-selection": "^3.0.0",
-        "html2canvas": "^1.4.1",
+        "dom-to-svg": "^0.12.2",
+        "html-to-image": "^1.11.11",
         "postcss-cli": "^11.0.0",
         "postcss-discard-comments": "^6.0.2",
         "svelte-floating-ui": "^1.5.8",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "test:unit": "turbo run test:unit"
   },
   "dependencies": {
-    "@changesets/cli": "^2.27.1",
-    "html2canvas": "^1.4.1"
+    "@changesets/cli": "^2.27.1"
   },
   "devDependencies": {
     "@ldn-viz/eslint-config-custom": "*",
@@ -28,8 +27,8 @@
     "turbo": "^1.12.5",
     "vitest": "^2.1.8"
   },
-  	"overrides": {
-		"esbuild": "0.24.0"
-	},
-  "packageManager": "npm@9.5.0"
+  "packageManager": "npm@9.5.0",
+  "overrides": {
+    "esbuild": "0.24.0"
+  }
 }

--- a/packages/charts/src/lib/chartContainer/ExportBtns.svelte
+++ b/packages/charts/src/lib/chartContainer/ExportBtns.svelte
@@ -52,7 +52,7 @@
 	export let columnMapping: undefined | { [oldName: string]: string } = undefined;
 </script>
 
-<div class="flex flex-wrap mt-2 space-y-2 items-end" data-html2canvas-ignore>
+<div class="flex flex-wrap mt-2 space-y-2 items-end" data-capture-ignore>
 	{#if dataDownloadButton && dataForDownload}
 		<div class="mr-2 shrink-0">
 			<DataDownloadButton
@@ -76,7 +76,7 @@
 			<ImageDownloadButton
 				{filename}
 				formats={imageDownloadButton === true ? ['PNG', 'SVG'] : imageDownloadButton}
-				htmlNode={chartToCapture}
+				node={chartToCapture}
 				variant="outline"
 				emphasis="secondary"
 				size="sm"

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -43,7 +43,6 @@
 		"d3-scale": "^4.0.2",
 		"d3-shape": "^3.2.0",
 		"d3-time-format": "^4.1.0",
-		"html2canvas": "^1.4.1",
 		"svelte-virtual-scroll-list": "^1.3.0"
 	},
 	"devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -46,7 +46,7 @@
 		"d3-interpolate": "^3.0.1",
 		"d3-scale": "^4.0.2",
 		"d3-selection": "^3.0.0",
-		"html2canvas": "^1.4.1",
+		"html-to-image": "^1.11.11",
 		"postcss-cli": "^11.0.0",
 		"postcss-discard-comments": "^6.0.2",
 		"svelte-floating-ui": "^1.5.8",

--- a/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.stories.svelte
+++ b/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.stories.svelte
@@ -1,5 +1,4 @@
 <script context="module" lang="ts">
-	import { Story, Template } from '@storybook/addon-svelte-csf';
 	import ImageDownloadButton from './ImageDownloadButton.svelte';
 
 	export const meta = {
@@ -21,167 +20,44 @@
 <script lang="ts">
 	import { Camera } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
+	import { Story, Template } from '@storybook/addon-svelte-csf';
 	import LogoByCiu from '../logos/LogoByCIU.svelte';
 
-	let svgRef;
-	let svgRef2;
-	let svgRef3;
-	let htmlRef: HTMLElement;
+	// let svgRef;
+	// let svgRef2;
+	// let svgRef3;
+	// let htmlRef: HTMLElement;
+
+	let htmlNode: HTMLElement;
 </script>
 
-<Template let:args>
-	<svg bind:this={svgRef} width="100" height="100">
-		<rect x="0" y="0" width="100" height="100" fill="red" />
-		<circle cx="10" cy="10" r="10" fill="blue" />
-	</svg>
+<div
+	bind:this={htmlNode}
+	class="flex flex-col gap-2 w-fit pb-8 text-color-text-primary bg-color-container-level-0"
+>
+	<h2 class="font-bold text-lg">A title</h2>
+	<p class="text-color-text-secondary" data-capture-ignore>A paragraph of text...</p>
+	<LogoByCiu class="w-80" />
+</div>
 
-	<ImageDownloadButton {...args} svgNode={svgRef}>
+<Template let:args>
+	<ImageDownloadButton {...args} {htmlNode}>
 		<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
 	</ImageDownloadButton>
 </Template>
 
 <Story name="Default" source />
 
-<Story name="Default - with image">
-	<svg bind:this={svgRef} width="100" height="100">
-		<rect x="0" y="0" width="100" height="100" fill="red" />
-		<circle cx="10" cy="10" r="10" fill="blue" />
-	</svg>
-
-	<ImageDownloadButton svgNode={svgRef}>
-		<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
-	</ImageDownloadButton>
-</Story>
-
-<Story name="Button types">
-	<svg bind:this={svgRef} width="100" height="100">
-		<rect x="0" y="0" width="100" height="100" fill="red" />
-		<circle cx="10" cy="10" r="10" fill="blue" />
-	</svg>
-
-	<div class="space-y-2">
-		<ImageDownloadButton svgNode={svgRef} filename="download" emphasis="primary">
-			<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
-		</ImageDownloadButton>
-		<ImageDownloadButton svgNode={svgRef} filename="download" emphasis="secondary">
-			<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
-		</ImageDownloadButton>
-		<ImageDownloadButton svgNode={svgRef} filename="download" variant="outline" size="sm">
-			<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
-		</ImageDownloadButton>
-	</div>
-</Story>
-
-<Story name="Disabled">
-	<svg bind:this={svgRef} width="100" height="100">
-		<rect x="0" y="0" width="100" height="100" fill="red" />
-		<circle cx="10" cy="10" r="10" fill="blue" />
-	</svg>
-
-	<ImageDownloadButton svgNode={svgRef} disabled={true}>
-		<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
-	</ImageDownloadButton>
-</Story>
-
-<Story name="Image with no explicit size">
-	<svg bind:this={svgRef2} width="100" height="100">
-		<rect x="0" y="0" width="100" height="100" fill="red" />
-		<circle cx="10" cy="10" r="10" fill="blue" />
-	</svg>
-
-	<ImageDownloadButton svgNode={svgRef2}>
-		<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
-	</ImageDownloadButton>
-</Story>
+<Story name="Disabled" source args={{ disabled: true }} />
 
 <Story name="Download as an SVG - no option">
-	<svg bind:this={svgRef3} width="100" height="100">
-		<rect x="0" y="0" width="100" height="100" fill="red" />
-		<circle cx="10" cy="10" r="10" fill="blue" />
-	</svg>
-
-	<ImageDownloadButton svgNode={svgRef3} formats={['SVG']}>
+	<ImageDownloadButton {htmlNode} formats={['SVG']}>
 		<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
 	</ImageDownloadButton>
 </Story>
 
 <Story name="Download as an PNG - no option">
-	<svg bind:this={svgRef3} width="100" height="100">
-		<rect x="0" y="0" width="100" height="100" fill="red" />
-		<circle cx="10" cy="10" r="10" fill="blue" />
-	</svg>
-
-	<ImageDownloadButton svgNode={svgRef3} formats={['PNG']}>
+	<ImageDownloadButton {htmlNode} formats={['PNG']}>
 		<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
 	</ImageDownloadButton>
 </Story>
-
-<Story name="Download HTML">
-	<div bind:this={htmlRef} class="flex flex-col gap-2 w-fit pb-8 text-color-text-primary">
-		<h2 class="font-bold text-lg">A title</h2>
-		<p class="text-color-text-secondary">A paragraph of text...</p>
-		<LogoByCiu class="w-80" />
-	</div>
-
-	<ImageDownloadButton htmlNode={htmlRef}>
-		<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
-	</ImageDownloadButton>
-</Story>
-
-<Story name="Download HTML with default padding">
-	<div
-		bind:this={htmlRef}
-		id="divToSave"
-		class="flex flex-col gap-2 w-fit pb-8 text-color-text-primary"
-	>
-		<h2 class="font-bold text-lg">A title</h2>
-		<p class="text-color-text-secondary">A paragraph of text...</p>
-		<LogoByCiu class="w-80" />
-	</div>
-
-	<ImageDownloadButton htmlNode={htmlRef} idToPad="divToSave">
-		<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
-	</ImageDownloadButton>
-</Story>
-
-<Story name="Download HTML with custom padding">
-	<div
-		bind:this={htmlRef}
-		id="divToSave"
-		class="flex flex-col gap-2 w-fit pb-8 text-color-text-primary"
-	>
-		<h2 class="font-bold text-lg">A title</h2>
-		<p class="text-color-text-secondary">A paragraph of text...</p>
-		<LogoByCiu class="w-80" />
-	</div>
-
-	<ImageDownloadButton htmlNode={htmlRef} idToPad="divToSave" padding="100px">
-		<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
-	</ImageDownloadButton>
-</Story>
-
-<Story name="With no icon">
-	<svg bind:this={svgRef} width="100" height="100">
-		<rect x="0" y="0" width="100" height="100" fill="red" />
-		<circle cx="10" cy="10" r="10" fill="blue" />
-	</svg>
-
-	<ImageDownloadButton svgNode={svgRef} />
-</Story>
-
-<Story name="With icon before label">
-	<svg bind:this={svgRef} width="100" height="100">
-		<rect x="0" y="0" width="100" height="100" fill="red" />
-		<circle cx="10" cy="10" r="10" fill="blue" />
-	</svg>
-
-	<ImageDownloadButton svgNode={svgRef}
-		><Icon src={Camera} theme="mini" class="mr-2 w-5 h-5" aria-hidden="true" slot="beforeLabel" />
-	</ImageDownloadButton>
-</Story>
-
-<style>
-	svg {
-		margin-bottom: 2em;
-	}
-</style>

--- a/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.svelte
+++ b/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.svelte
@@ -1,37 +1,27 @@
 <script lang="ts">
-	/**
-	 * The `<ImageDownloadButton>` component renders a button which, when clicked on, downloads an image file showing either an `HTML` or `SVG` element and its children.
+	/* The `<ImageDownloadButton>` component renders a button which, when clicked on, downloads an image file showing either an `HTML` or `SVG` element and its children.
+	 *
+	 * **Note**: This will not convert a non svg element into an svg, but will download an existing svg element as an svg file.
+	 *
+	 * To ignore elements apply a data attribute "data-capture-ignore" and they will not be included in the download
 	 * @component
 	 */
 
-	import html2canvas from 'html2canvas';
+	import { toPng, toSvg } from 'html-to-image';
 	import type { Option } from '../multipleActionButton/MultipleActionButton.svelte';
 	import MultipleActionButton from '../multipleActionButton/MultipleActionButton.svelte';
 
 	/**
-	 * A `SVGElement` node to be converted.
+	 * An `Element` node to be converted. When 'SVG' format is selected the largest child svg element will be targeted.
+	 * This is primarily for use with charts where the chart element needs to be compatible with Figma/ illustrator.
+	 * If this does not yeild the desired results you may need to adjust your markup.
 	 */
-	export let svgNode: SVGElement | undefined = undefined;
+	export let htmlNode: HTMLElement;
 
 	/**
-	 * An `HTMLElement` node to be converted.
+	 * The available file formats for the downloaded image.
 	 */
-	export let htmlNode: HTMLElement | undefined = undefined;
-
-	/**
-	 * `id` of element to add padding to
-	 */
-	export let idToPad = '';
-
-	/**
-	 * Amount of padding to add, as a string including units.
-	 */
-	export let padding = '30px';
-
-	/**
-	 * If converting an SVG to PNG, the resolution of the PNG will be `scaleFactor` times the size at which the SVG was displayed at.
-	 */
-	export let scaleFactor = 2;
+	export let formats: ('PNG' | 'SVG')[] = ['PNG', 'SVG'];
 
 	/**
 	 * The name the downloaded file will be saved with.
@@ -39,19 +29,18 @@
 	export let filename = '';
 
 	/**
+	 * Amount of padding to add, as a string including units.
+	 */
+	export let padding = '30px';
+
+	/**
 	 * If `true`, the user will not be able to interact with the button to download data.
 	 */
 	export let disabled = false;
 
-	/**
-	 * The available file formats for the downloaded image.
-	 */
-	export let formats: ('PNG' | 'SVG')[] = ['PNG', 'SVG'];
-	let format = 'PNG';
-
 	const downloadFromURL = (url: string) => {
 		if (!filename) {
-			filename = format === 'SVG' ? 'Image.svg' : 'Image.png';
+			filename = format === 'SVG' ? 'image.svg' : 'image.png';
 		}
 
 		const link = document.createElement('a');
@@ -62,107 +51,49 @@
 		link.remove();
 	};
 
-	const createHTMLImageFromURL = async (url: string) => {
-		let img: HTMLImageElement | undefined;
+	const findNearestChildSvg = (htmlNode: HTMLElement) => {
+		if (!(htmlNode instanceof HTMLElement)) {
+			throw new Error('htmlNode must be an HTMLElement');
+		}
 
-		await new Promise((resolve) => {
-			img = new Image();
-			img.onload = resolve;
-			img.src = url;
+		const svgElements = htmlNode.querySelectorAll('svg');
+
+		let largestSVG = null;
+		let largestArea = 0;
+
+		svgElements.forEach((element) => {
+			const bbox = element.getBoundingClientRect();
+			const area = bbox.width * bbox.height;
+
+			if (area > largestArea) {
+				largestSVG = element;
+				largestArea = area;
+			}
 		});
 
-		// Ensure img is defined before returning
-		if (!img) {
-			throw new Error('Failed to load image');
-		}
-
-		return img;
+		return largestSVG;
 	};
 
-	// See https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
-	const bytesToBase64 = (bytes: Uint8Array) => window.btoa(String.fromCodePoint(...bytes));
-	const stringToBase64 = (str: string | undefined) => bytesToBase64(new TextEncoder().encode(str));
-
-	const downloadFromSVG = async () => {
-		// This hack is necessary because .drawImage() doesn't work
-		// unless the SVG that is being copied has an explicitly-set size
-		const svgNodeClone = svgNode!.cloneNode(true) as SVGElement;
-		svgNodeClone.setAttribute('width', svgNode!.clientWidth.toString());
-		svgNodeClone.setAttribute('height', svgNode!.clientHeight.toString());
-
-		const svgString = new XMLSerializer().serializeToString(svgNodeClone);
-		const svgURL = 'data:image/svg+xml;base64,' + stringToBase64(svgString);
-		// the non base-64 encoded URL would be: "data:image/svg+xml;utf8," + svgString;
-
-		// an alternative is:
-		// const svgURL = URL.createObjectURL(new Blob([svgNodeClone.outerHTML],{type:'image/svg+xml;charset=utf-8'}))
-
-		const img = await createHTMLImageFromURL(svgURL);
-
-		if (format === 'SVG') {
-			downloadFromURL(svgURL);
-		} else {
-			img.src = svgURL;
-
-			const w = svgNode!.clientWidth * scaleFactor;
-			const h = svgNode!.clientHeight * scaleFactor;
-
-			const canvas = new OffscreenCanvas(w, h);
-
-			canvas.getContext('2d')?.drawImage(img, 0, 0, w, h);
-
-			canvas.convertToBlob().then((blob) => {
-				downloadFromURL(URL.createObjectURL(blob));
-			});
+	// Filter elemts to hide based on class
+	const filter = (node: HTMLElement) => {
+		if (node instanceof HTMLElement) {
+			const ignoreAttributes = ['data-capture-ignore'];
+			return !ignoreAttributes.some((attribute) => node.hasAttribute(attribute));
 		}
-	};
-
-	///
-
-	const preserveDrawingBuffer = () => {
-		function wrapGetContext(ContextClass: typeof HTMLCanvasElement | typeof OffscreenCanvas) {
-			const isWebGL = /webgl/i;
-
-			ContextClass.prototype.getContext = (function (origFn: (type: any, attributes?: any) => any) {
-				return function (this: HTMLCanvasElement | OffscreenCanvas, type: any, attributes: any) {
-					if (isWebGL.test(type)) {
-						attributes = Object.assign({}, attributes || {}, { preserveDrawingBuffer: true });
-					}
-					return origFn.call(this, type, attributes);
-				};
-			})(ContextClass.prototype.getContext);
-		}
-
-		if (typeof HTMLCanvasElement !== 'undefined') {
-			wrapGetContext(HTMLCanvasElement);
-		}
-		if (typeof OffscreenCanvas !== 'undefined') {
-			wrapGetContext(OffscreenCanvas);
-		}
-	};
-
-	const downloadFromHTML = async (el: HTMLElement) => {
-		preserveDrawingBuffer();
-
-		const canvas = await html2canvas(el, {
-			onclone: (clone: Document) => {
-				if (idToPad) {
-					clone.getElementById(idToPad)!.style.padding = padding;
-				}
-			},
-			windowWidth: 1500
-		});
-		const image = canvas.toDataURL('image/png', 1.0);
-		downloadFromURL(image);
+		return node;
 	};
 
 	const download = async () => {
-		if (svgNode) {
-			downloadFromSVG();
-		} else if (htmlNode) {
-			downloadFromHTML(htmlNode);
+		const captureOptions = { style: { padding: padding }, filter };
+		if (format === 'SVG') {
+			const svgNode = findNearestChildSvg(htmlNode);
+			svgNode !== null
+				? toSvg(svgNode, captureOptions).then((dataUrl) => downloadFromURL(dataUrl))
+				: console.warn('No svgNode found');
+		} else if (format === 'PNG') {
+			toPng(htmlNode, captureOptions).then((dataUrl) => downloadFromURL(dataUrl));
 		} else {
-			console.log('CMust supply either an svgNode or htmlNode to be converted to image');
+			console.warn('Must supply an htmlNode to be converted to image');
 		}
 	};
 


### PR DESCRIPTION
**What does this change?**
Replaces html-2-canvas library used for image capture with html-to-image library

**Why?**
Various issues encountered when trying to use the previous lib - around alignment and svg export

**How?**
Re write image download button to use the new library

**Related issues**:
#668 and #630

**Does this introduce new dependencies?**
Yes - html-to-image

**How is it tested?**
Storybook

**How is it documented?**
storybook

**Are light and dark themes considered?**
yes

**Is it complete?**
Will need to confirm full options set specifically use of 'scalefactor' prop and setting of default width and heights, Which is why I'm opening this as a draft PR

- [ ] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
