### PR TITLE
shift map control groups to avoid overlap with attribution (fix #669)

### DIFF
--- a/.changeset/map-control-positions.md
+++ b/.changeset/map-control-positions.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': patch
+---
+
+CHANGED: shift position of `MapControlGroup` upwards if position is `BottomLeft`/`BottomCenter`/`BottomRight`, to avoid overlap with attribution statement

--- a/packages/maps/src/lib/mapControlGroup/MapControlGroup.svelte
+++ b/packages/maps/src/lib/mapControlGroup/MapControlGroup.svelte
@@ -21,9 +21,9 @@
 		TopRight: 'top-6 right-6 items-end',
 		TopRightOffset: 'top-16 right-6 items-end',
 		CenterRight: 'top-1/2 -translate-y-1/2 right-6 transform items-end',
-		BottomRight: 'bottom-6 right-6 items-end',
-		BottomCenter: 'bottom-6 left-1/2 -translate-x-1/2 transform items-center',
-		BottomLeft: 'bottom-6 left-6',
+		BottomRight: 'bottom-11 right-6 items-end',
+		BottomCenter: 'bottom-11 left-1/2 -translate-x-1/2 transform items-center',
+		BottomLeft: 'bottom-11 left-6',
 		CenterLeft: 'top-1/2 -translate-y-1/2 left-6 transform'
 	};
 </script>


### PR DESCRIPTION
Before: https://greater-london-authority.github.io/ldn-viz-tools/?path=/story/maps-mapcontrols-mapcontrolgroup--positioning-labels

After: https://dev.ldn-gis.co.uk/storybook-map-control-group-positioning/?path=/story/maps-mapcontrols-mapcontrolgroup--positioning-labels