### PR TITLE
change table sort icons to indicate applied sort direction

### DIFF
--- a/.changeset/table-sort-icons.md
+++ b/.changeset/table-sort-icons.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/tables': patch
+---
+
+FIXED: change icons to indicate sort direction when table is sorted based on column

--- a/.changeset/table-sort-icons.md
+++ b/.changeset/table-sort-icons.md
@@ -2,4 +2,4 @@
 '@ldn-viz/tables': patch
 ---
 
-FIXED: change icons to indicate sort direction when table is sorted based on column
+CHANGED: change icons to indicate sort direction when table is sorted based on column

--- a/packages/tables/src/lib/core/renderers/Header.svelte
+++ b/packages/tables/src/lib/core/renderers/Header.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Tooltip, classNames } from '@ldn-viz/ui';
-	import { ChevronDown, ChevronUp, ChevronUpDown } from '@steeze-ui/heroicons';
+	import { BarsArrowDown, ChevronUpDown } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
 
 	/**
@@ -21,7 +21,7 @@
 	/**
 	 * Current sort order (used to determine icons if `allowSorting` is `true`).
 	 */
-	export let order: 'asc' | 'desc' | undefined = undefined;
+	export let order: 'ascending' | 'descending' | undefined = undefined;
 
 	/**
 	 * Function called when user changes sort order.
@@ -40,12 +40,6 @@
 		center: 'justify-center'
 	};
 	$: alignmentClass = alignmentClasses[alignHeader ?? 'left'];
-
-	const icons = {
-		default: ChevronUpDown,
-		asc: ChevronUp,
-		desc: ChevronDown
-	};
 
 	// This suppresses warnings due to the RowRenderer providing props that aren't used.
 	$$restProps;
@@ -73,11 +67,17 @@
 
 		{#if allowSorting}
 			<Icon
-				src={order ? icons[order] : icons['default']}
+				src={order ? BarsArrowDown : ChevronUpDown}
 				theme="mini"
-				class="ml-0.5 w-4 h-4"
+				class={classNames('ml-0.5 w-4 h-4', order === 'ascending' ? 'flipY' : '')}
 				aria-hidden="true"
 			/>
 		{/if}
 	</div>
 </div>
+
+<style>
+	:global(.flipY) {
+		transform: scaleY(-1);
+	}
+</style>

--- a/packages/tables/src/lib/table/rows/headerRows/ColumnHeadingRow.svelte
+++ b/packages/tables/src/lib/table/rows/headerRows/ColumnHeadingRow.svelte
@@ -45,7 +45,7 @@
 				<div class="flex was-th" role="columnheader" style:width={col.computedWidth + 'px'}>
 					<Header
 						label={col.label ?? col.short_label}
-						order={undefined}
+						order={table.rowOrderSpec.find((f) => f.field === col.short_label)?.direction}
 						toggle={() =>
 							allowSorting && col.sortable !== false && table.toggleSort(col.short_label)}
 						allowSorting={allowSorting && col.sortable !== false}


### PR DESCRIPTION
This fixes https://github.com/Greater-London-Authority/ldn-viz-tools/issues/469