### PR TITLE
prevent Chrome drawing a second clear icon in Geocoder when used in a Map

### DIFF
--- a/.changeset/geocoder-icons.md
+++ b/.changeset/geocoder-icons.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+FIXED: prevent Chrome drawing a second clear icon in `Geocoder` when used in a map

--- a/packages/ui/src/lib/geolocation/Geocoder.svelte
+++ b/packages/ui/src/lib/geolocation/Geocoder.svelte
@@ -326,3 +326,9 @@
 		/>
 	{/if}
 </search>
+
+<style>
+	[type='search']::-webkit-search-cancel-button {
+		appearance: none;
+	}
+</style>


### PR DESCRIPTION
This fixes #703 

Preview: https://dev.ldn-gis.co.uk/storybook-double-clear-icon/?path=/docs/maps-mapcontrols-mapcontrollocationsearch--documentation