### PR TITLE
hide SVG option by default in table image export button

### DIFF
--- a/.changeset/table-download-buttons.svelte
+++ b/.changeset/table-download-buttons.svelte
@@ -2,4 +2,4 @@
 '@ldn-viz/tables': patch
 ---
 
-CHANGED: default to hide SVG option in image download button, as this ill not give the exported result of downloading an image of the entire table
+CHANGED: default to hide SVG option in image download button, as this will not give the exported result of downloading an image of the entire table

--- a/.changeset/table-download-buttons.svelte
+++ b/.changeset/table-download-buttons.svelte
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/tables': patch
+---
+
+CHANGED: default to hide SVG option in image download button, as this ill not give the exported result of downloading an image of the entire table

--- a/packages/tables/src/lib/table/Table.svelte
+++ b/packages/tables/src/lib/table/Table.svelte
@@ -64,7 +64,7 @@
 	 * If set to `false`, then the button is hidden.
 	 *
 	 */
-	export let imageDownloadButton: true | false | ('PNG' | 'SVG')[] = true;
+	export let imageDownloadButton: true | false | ('PNG' | 'SVG')[] = ['PNG'];
 
 	/**
 	 * The file name to be used for the downloaded data or image file.

--- a/packages/tables/src/lib/table/TableContainer.svelte
+++ b/packages/tables/src/lib/table/TableContainer.svelte
@@ -64,7 +64,7 @@
 	 * If set to `false`, then the button is hidden.
 	 *
 	 */
-	export let imageDownloadButton: true | false | ('PNG' | 'SVG')[] = true;
+	export let imageDownloadButton: true | false | ('PNG' | 'SVG')[] = ['PNG'];
 
 	export let filename = '';
 


### PR DESCRIPTION
Default to hide SVG option in image download button, as this will not give the exported result of downloading an image of the entire table