### PR TITLE
Example line charts - accessibility

### DIFF
--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -1,0 +1,78 @@
+<script context="module">
+	import ObservablePlot from '../observablePlot/ObservablePlot.svelte';
+
+	/* This is an example `LineChart` chart using default plot styles. */
+
+	export const meta = {
+		title: 'Charts/Examples/LineChart'
+	};
+</script>
+
+<script lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import ghgLondonTotalByYear from '../../data/ghgLondonTotalByYear.json';
+	import { Plot } from '../observablePlotFragments/plot';
+
+	$: chartData = ghgLondonTotalByYear.map((d) => {
+		return { ...d, year: new Date(d.Year, 0) };
+	});
+
+	$: defaultMarks = [
+		Plot.gridX({ interval: '2 years' }),
+		Plot.gridY(),
+		Plot.ruleY([0]),
+		Plot.line(chartData, { x: 'year', y: 'Domestic - Total' }),
+		Plot.axisX({ interval: '2 years' }),
+		Plot.axisY({ label: 'ktCO₂e' })
+	];
+
+	$: defaultSpec = {
+		x: { insetLeft: 80, insetRight: 20, type: 'utc' },
+		marks: defaultMarks
+	};
+
+	$: specWithTooltip = {
+		...defaultSpec,
+		marks: [
+			...defaultMarks,
+			Plot.tip(
+				chartData,
+				Plot.pointerX({
+					x: 'year',
+					y: 'Domestic - Total',
+					channels: { Year: 'year', Value: 'Value' },
+					format: {
+						x: false,
+						Year: (d) => d.getFullYear()
+					}
+				})
+			)
+		]
+	};
+</script>
+
+<Template let:args>
+	<ObservablePlot {...args} />
+</Template>
+
+<Story
+	name="Default"
+	args={{
+		spec: defaultSpec,
+		title: 'Domestic Greenhouse Gas Emissions',
+		subTitle: 'Total Domestic Greenhouse Gas Emissions in London have fallen between 2005 and 2022',
+		data: { chartData }
+	}}
+	source
+/>
+
+<Story
+	name="With Tooltip"
+	args={{
+		spec: specWithTooltip,
+		title: 'Domestic Greenhouse Gas Emissions',
+		subTitle: 'Total Domestic Greenhouse Gas Emissions in London have fallen between 2005 and 2022',
+		data: { chartData }
+	}}
+	source
+/>

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -1,7 +1,10 @@
 <script context="module">
 	import ObservablePlot from '../observablePlot/ObservablePlot.svelte';
 
-	/* This is an example `LineChart` chart using default plot styles. */
+	/** This is an example `LineChart` chart using default plot styles.
+	 *
+	 * This incorporates `ariaHidden` and `ariaLabel` props inside the spec to ensure the screen reader ignores individual SVG elements for accessibility.
+	 */
 
 	export const meta = {
 		title: 'Charts/Examples/LineChart'

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -18,17 +18,26 @@
 	});
 
 	$: defaultMarks = [
-		Plot.gridX({ interval: '2 years' }),
-		Plot.gridY(),
-		Plot.ruleY([0]),
-		Plot.line(chartData, { x: 'year', y: 'Domestic - Total' }),
-		Plot.axisX({ interval: '2 years' }),
-		Plot.axisY({ label: 'ktCO₂e' })
+		Plot.gridX({ interval: '2 years', ariaHidden: 'true' }),
+		Plot.gridY({ ariaHidden: 'true' }),
+		Plot.ruleY([0], { ariaHidden: 'true' }),
+		Plot.line(chartData, {
+			x: 'year',
+			y: 'Domestic - Total',
+			ariaHidden: 'true'
+		}),
+		Plot.axisX({ interval: '2 years', ariaHidden: 'true' }),
+		Plot.axisY({
+			label: 'ktCO₂e',
+			ariaHidden: 'true'
+		})
 	];
 
 	$: defaultSpec = {
 		x: { insetLeft: 80, insetRight: 20, type: 'utc' },
-		marks: defaultMarks
+		marks: defaultMarks,
+		ariaLabel:
+			'Domestic Greenhouse Gas Emissions dropped from over 16,000 kilotons of carbon dioxide emissions in 2005, to below 10,000 kilotons in 2022'
 	};
 
 	$: specWithTooltip = {


### PR DESCRIPTION
**What does this change?**
I've added `ariaLabel` and `ariaHidden` attributes to the example line chart, to demonstrate how we can incorporate accessibility best practice.

I don't think this is quite perfect due to the following:
- Adding ariaHidden: 'true' to Plot marks, successfully hides the SVG elements from the screen reader. Except for the axis marks, if they have a label.
- `ariaDescription` doesn’t appear to work inside marks or the spec - the screen reader ignores it
- `ariaLabel` on the `Plot.line()` makes the line disappear
- `ariaLabel` on the spec (outside of marks) DOES work but the screen reader still reads the y axis label, as it's not hidden
- The `ariaLabel` isn't achieving much more than the subTitle is, so we could instead replace it with a slightly more descriptive subTitle and hide the chart (though how to hide the chart remains to be seen, given the above re axis labels)

**Related issues**: #762 
