### PR TITLE
Added ariaHidden to exampleLineCharts

### DIFF
--- a/.changeset/chilled-rabbits-shake.md
+++ b/.changeset/chilled-rabbits-shake.md
@@ -1,0 +1,6 @@
+---
+'@ldn-viz/charts': minor
+'@ldn-viz/ui': minor
+---
+
+ADDED: chartDescription modal to Footer for use in chart and chartDescription for accessibility to ChartContainer

--- a/.changeset/chilled-rabbits-shake.md
+++ b/.changeset/chilled-rabbits-shake.md
@@ -4,3 +4,4 @@
 ---
 
 ADDED: chartDescription modal to Footer for use in chart and chartDescription for accessibility to ChartContainer
+ADDED: `randomId` generator to `@ldn-viz/ui` exports

--- a/.changeset/chilled-rabbits-shake.md
+++ b/.changeset/chilled-rabbits-shake.md
@@ -1,7 +1,5 @@
 ---
-'@ldn-viz/charts': minor
 '@ldn-viz/ui': minor
 ---
 
-ADDED: chartDescription modal to Footer for use in chart and chartDescription for accessibility to ChartContainer
 ADDED: `randomId` generator to `@ldn-viz/ui` exports

--- a/.changeset/weak-years-grow.md
+++ b/.changeset/weak-years-grow.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/charts': minor
+---
+
+ADDED: ARIA attributes and global ariaHidden for accessibility

--- a/.changeset/weak-years-grow.md
+++ b/.changeset/weak-years-grow.md
@@ -3,3 +3,4 @@
 ---
 
 ADDED: ARIA attributes and global ariaHidden for accessibility
+ADDED: chartDescription modal to Footer for use in chart and chartDescription for accessibility to ChartContainer

--- a/package-lock.json
+++ b/package-lock.json
@@ -15377,7 +15377,7 @@
       "dependencies": {
         "@ldn-viz/ui": "*",
         "@ldn-viz/utils": "*",
-        "@observablehq/plot": "^0.6.14",
+        "@observablehq/plot": "^0.6.16",
         "layercake": "^8.1.1"
       },
       "devDependencies": {

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -32,7 +32,7 @@
 	"dependencies": {
 		"@ldn-viz/ui": "*",
 		"@ldn-viz/utils": "*",
-		"@observablehq/plot": "^0.6.14",
+		"@observablehq/plot": "^0.6.16",
 		"layercake": "^8.1.1"
 	},
 	"devDependencies": {

--- a/packages/charts/src/lib/chartContainer/ChartContainer.svelte
+++ b/packages/charts/src/lib/chartContainer/ChartContainer.svelte
@@ -112,6 +112,9 @@
 		<slot />
 	</div>
 
+	<!-- long description for screen readers -->
+	<slot name="description" class="sr-only" />
+
 	{#if source || byline || note || dataDownloadButton || imageDownloadButton}
 		<Footer {source} {byline} {note}>
 			<ExportBtns

--- a/packages/charts/src/lib/chartContainer/ChartContainer.svelte
+++ b/packages/charts/src/lib/chartContainer/ChartContainer.svelte
@@ -113,7 +113,7 @@
 	</div>
 
 	<!-- long description for screen readers -->
-	<slot name="description" class="sr-only" />
+	<slot name="description" />
 
 	{#if source || byline || note || dataDownloadButton || imageDownloadButton}
 		<Footer {source} {byline} {note}>

--- a/packages/charts/src/lib/chartContainer/ChartContainer.svelte
+++ b/packages/charts/src/lib/chartContainer/ChartContainer.svelte
@@ -120,7 +120,7 @@
 	<!-- long description for screen readers -->
 	<slot name="description" />
 
-	{#if source || byline || note || dataDownloadButton || imageDownloadButton}
+	{#if source || byline || note || chartDescription || dataDownloadButton || imageDownloadButton}
 		<Footer {source} {byline} {note} {chartDescription}>
 			<ExportBtns
 				{chartToCapture}

--- a/packages/charts/src/lib/chartContainer/ChartContainer.svelte
+++ b/packages/charts/src/lib/chartContainer/ChartContainer.svelte
@@ -86,6 +86,11 @@
 
 	// For save as image
 	let chartToCapture: HTMLDivElement;
+
+	/**
+	 * Description of the chart for use in a modal for sighted users.
+	 */
+	export let chartDescription = '';
 </script>
 
 <div class={`chart-container ${chartWidth}`} bind:this={chartToCapture} id="captureElement">
@@ -116,7 +121,7 @@
 	<slot name="description" />
 
 	{#if source || byline || note || dataDownloadButton || imageDownloadButton}
-		<Footer {source} {byline} {note}>
+		<Footer {source} {byline} {note} {chartDescription}>
 			<ExportBtns
 				{chartToCapture}
 				{filename}

--- a/packages/charts/src/lib/chartContainer/ChartContainer.svelte
+++ b/packages/charts/src/lib/chartContainer/ChartContainer.svelte
@@ -101,7 +101,7 @@
 	{/if}
 
 	{#if alt}
-		<h5 class="sr-only">{alt}</h5>
+		<p class="sr-only">{alt}</p>
 	{/if}
 
 	<!-- any controls to be displayed below the title and subTitle, but above the chart itself -->

--- a/packages/charts/src/lib/chartContainer/Footer.svelte
+++ b/packages/charts/src/lib/chartContainer/Footer.svelte
@@ -24,7 +24,7 @@
 					<Button
 						variant="text"
 						on:click={() => ($isOpen = true)}
-						class="font-bold space-y-0.5 text-xs m-0 py-0 px-0">View description</Button
+						class="font-bold text-xs !py-0 !px-0">View description</Button
 					>
 				</li>
 				<Modal bind:isOpen title="Description" description={chartDescription}></Modal>

--- a/packages/charts/src/lib/chartContainer/Footer.svelte
+++ b/packages/charts/src/lib/chartContainer/Footer.svelte
@@ -15,7 +15,10 @@
 
 <div class="w-full flex flex-wrap justify-between mt-1 items-end">
 	{#if byline || source || note || chartDescription}
-		<ul class="flex flex-col space-y-0.5 text-color-text-secondary text-xs min-w-40 max-w-xl mr-4">
+		<ul
+			title="Chart footnotes and description"
+			class="flex flex-col space-y-0.5 text-color-text-secondary text-xs min-w-40 max-w-xl mr-4"
+		>
 			{#if byline}<li>{byline}</li>{/if}
 			{#if source}<li><span class="font-bold mr-1">Source:</span>{source}</li>{/if}
 			{#if note}<li><span class="font-bold mr-1">Note:</span>{note}</li>{/if}

--- a/packages/charts/src/lib/chartContainer/Footer.svelte
+++ b/packages/charts/src/lib/chartContainer/Footer.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
+	import { Button, Modal } from '@ldn-viz/ui';
+	import { writable } from 'svelte/store';
+
 	export let byline = '';
 	export let source = '';
 	export let note = '';
 	export let chartDescription = '';
+
+	/**
+	 * Controls whether the Modal is open or closed
+	 */
+	let isOpen = writable(false);
 </script>
 
 <div class="w-full flex flex-wrap justify-between mt-1 items-end">
@@ -11,6 +19,16 @@
 			{#if byline}<li>{byline}</li>{/if}
 			{#if source}<li><span class="font-bold mr-1">Source:</span>{source}</li>{/if}
 			{#if note}<li><span class="font-bold mr-1">Note:</span>{note}</li>{/if}
+			{#if chartDescription}
+				<li>
+					<Button
+						variant="text"
+						on:click={() => ($isOpen = true)}
+						class="font-bold space-y-0.5 text-xs m-0 py-0 px-0">View description</Button
+					>
+				</li>
+				<Modal bind:isOpen title="Description" description={chartDescription}></Modal>
+			{/if}
 		</ul>
 	{/if}
 	{#if $$slots.exportBtns}

--- a/packages/charts/src/lib/chartContainer/Footer.svelte
+++ b/packages/charts/src/lib/chartContainer/Footer.svelte
@@ -2,10 +2,11 @@
 	export let byline = '';
 	export let source = '';
 	export let note = '';
+	export let chartDescription = '';
 </script>
 
 <div class="w-full flex flex-wrap justify-between mt-1 items-end">
-	{#if byline || source || note}
+	{#if byline || source || note || chartDescription}
 		<ul class="flex flex-col space-y-0.5 text-color-text-secondary text-xs min-w-40 max-w-xl mr-4">
 			{#if byline}<li>{byline}</li>{/if}
 			{#if source}<li><span class="font-bold mr-1">Source:</span>{source}</li>{/if}

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -184,13 +184,13 @@
 	/>
 </Story>
 
-<Story name="With Tooltip" source>
+<Story name="Multiple lines" source>
 	<ObservablePlot
 		spec={multiLineSpec}
 		data={chartData}
 		title="Domestic Greenhouse Gas Emissions in London have fallen steadily since 2005"
-		subTitle="London annual domestic greenhouse gas emissions, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022"
+		subTitle="London annual domestic greenhouse gas emissions split by gas and electric energy, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022"
 		alt="Line chart of London annual domestic greenhouse gas emissions"
-		chartDescription="The chart shows total domestic greenhouse gas emissions in London fell by almost 8,000 kilotonnes of carbon dioxide equivalent from 2005 to 2022. In 2005, there were 16,833 kilotonnes of carbon dioxide equivalent, which fell to 9,066 kilotonnes of carbon dioxide equivalent in 2022."
+		chartDescription="The chart shows domestic greenhouse gas emissions in London fell by almost 8,000 kilotonnes of carbon dioxide equivalent from 2005 to 2022. There are two lines, one shows domestic gas emissions and the second shows domestic electricity emissions. In 2005, for gas, there were 9,748 kilotonnes of carbon dioxide equivalent which dropped to 6,343 kilotonnes in 2022. In 2005, for electricity, there were 6,986 kilotonnes of carbon dioxide equivalent which dropped to 2,632 kilotonnes in 2022."
 	/>
 </Story>

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -72,8 +72,8 @@
 			'London annual domestic greenhouse gas emissions, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022',
 		data: { chartData },
 		alt: 'Line chart of London annual domestic greenhouse gas emissions',
-		ariaChartDescription:
-			'The chart shows total domestic greenhouse gas emissions in London fell by almost 8,000 kilotonnes of carbon dioxide emissions from 2005 to 2022. In 2005, there were 16,833 kilotonnes of carbon dioxide emissions, which fell to 9,066 kilotonnes of carbon dioxide emissions in 2022.'
+		chartDescription:
+			'The chart shows total domestic greenhouse gas emissions in London fell by almost 8,000 kilotonnes of carbon dioxide equivalent from 2005 to 2022. In 2005, there were 16,833 kilotonnes of carbon dioxide equivalent, which fell to 9,066 kilotonnes of carbon dioxide equivalent in 2022.'
 	}}
 	source
 />
@@ -87,8 +87,8 @@
 			'London annual domestic greenhouse gas emissions, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022',
 		data: { chartData },
 		alt: 'Line chart of London annual domestic greenhouse gas emissions',
-		ariaChartDescription:
-			'The chart shows total domestic greenhouse gas emissions in London fell by almost 8,000 kilotonnes of carbon dioxide emissions from 2005 to 2022. In 2005, there were 16,833 kilotonnes of carbon dioxide emissions, which fell to 9,066 kilotonnes of carbon dioxide emissions in 2022.'
+		chartDescription:
+			'The chart shows total domestic greenhouse gas emissions in London fell by almost 8,000 kilotonnes of carbon dioxide equivalent from 2005 to 2022. In 2005, there were 16,833 kilotonnes of carbon dioxide equivalent, which fell to 9,066 kilotonnes of carbon dioxide equivalent in 2022.'
 	}}
 	source
 />

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -158,9 +158,14 @@
 
 <ObservablePlot
 	spec={spec}
-	title={'Domestic Greenhouse Gas Emissions'}
-	subTitle={'Total Domestic Greenhouse Gas Emissions in London have fallen between 2005 and 2022'}
-	data={ chartData }
+	data={chartData}
+	title="Domestic Greenhouse Gas Emissions in London have fallen steadily since 2005"
+	subTitle="London annual domestic greenhouse gas emissions, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022"
+	alt="Line chart of London annual domestic greenhouse gas emissions"
+	note="This is for footnotes"
+	source="GLA Environment Team"
+	byline="GLA City Intelligence Unit"
+	chartDescription="The chart shows total domestic greenhouse gas emissions in London fell by almost 8,000 kilotonnes of carbon dioxide equivalent from 2005 to 2022. In 2005, there were 16,833 kilotonnes of carbon dioxide equivalent, which fell to 9,066 kilotonnes of carbon dioxide equivalent in 2022."
 />
 ```
 -->

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -170,7 +170,7 @@
 ```
 -->
 
-<Story name="default" source>
+<Story name="Default" source>
 	<ObservablePlot
 		spec={defaultSpec}
 		data={chartData}

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -72,6 +72,9 @@
 			'London annual domestic greenhouse gas emissions, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022',
 		data: { chartData },
 		alt: 'Line chart of London annual domestic greenhouse gas emissions',
+		note: 'This is for footnotes',
+		source: 'GLA Environment Team',
+		byline: 'GLA City Intelligence Unit',
 		chartDescription:
 			'The chart shows total domestic greenhouse gas emissions in London fell by almost 8,000 kilotonnes of carbon dioxide equivalent from 2005 to 2022. In 2005, there were 16,833 kilotonnes of carbon dioxide equivalent, which fell to 9,066 kilotonnes of carbon dioxide equivalent in 2022.'
 	}}

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -67,9 +67,9 @@
 	name="Default"
 	args={{
 		spec: defaultSpec,
-		title: 'Total Domestic Greenhouse Gas Emissions in London have fallen between 2005 and 2022',
+		title: 'Domestic Greenhouse Gas Emissions in London have fallen steadily since 2005',
 		subTitle:
-			'Line chart showing total domestic greenhouse gas emissions in London fell by almost 8,000 kilotons of carbon dioxide emissions from 2005 to 2022. In 2005, there were almost 17,000 kilotons of carbon dioxide emissions, falling to 9,066 kilotons of carbon dioxide emissions in 2022.',
+			'Line chart showing London annual domestic greenhouse gas emissions, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022',
 		data: { chartData }
 	}}
 	source
@@ -79,9 +79,9 @@
 	name="With Tooltip"
 	args={{
 		spec: specWithTooltip,
-		title: 'Total Domestic Greenhouse Gas Emissions in London have fallen between 2005 and 2022',
+		title: 'Domestic Greenhouse Gas Emissions in London have fallen steadily since 2005',
 		subTitle:
-			'Line chart showing total domestic greenhouse gas emissions in London fell by almost 8,000 kilotons of carbon dioxide emissions from 2005 to 2022. In 2005, there were almost 17,000 kilotons of carbon dioxide emissions, falling to 9,066 kilotons of carbon dioxide emissions in 2022.',
+			'Line chart showing London annual domestic greenhouse gas emissions, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022',
 		data: { chartData }
 	}}
 	source

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -1,7 +1,10 @@
 <script context="module">
 	import ObservablePlot from '../observablePlot/ObservablePlot.svelte';
 
-	/* This is an example `LineChart` chart using default plot styles. */
+	/** This is an example `LineChart` chart using default plot styles.
+	 *
+	 * This incorporates `ariaHidden` and `ariaLabel` props inside the spec to ensure the screen reader ignores individual SVG elements for accessibility.
+	 */
 
 	export const meta = {
 		title: 'Charts/Examples/LineChart'

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -21,26 +21,22 @@
 	});
 
 	$: defaultMarks = [
-		Plot.gridX({ interval: '2 years', ariaHidden: 'true' }),
-		Plot.gridY({ ariaHidden: 'true' }),
-		Plot.ruleY([0], { ariaHidden: 'true' }),
+		Plot.gridX({ interval: '2 years' }),
+		Plot.gridY({}),
+		Plot.ruleY([0], {}),
 		Plot.line(chartData, {
 			x: 'year',
-			y: 'Domestic - Total',
-			ariaHidden: 'true'
+			y: 'Domestic - Total'
 		}),
-		Plot.axisX({ interval: '2 years', ariaHidden: 'true' }),
+		Plot.axisX({ interval: '2 years' }),
 		Plot.axisY({
-			label: 'ktCO₂e',
-			ariaHidden: 'true'
+			label: 'ktCO₂e'
 		})
 	];
 
 	$: defaultSpec = {
 		x: { insetLeft: 80, insetRight: 20, type: 'utc' },
-		marks: defaultMarks,
-		ariaLabel:
-			'Domestic Greenhouse Gas Emissions dropped from over 16,000 kilotons of carbon dioxide emissions in 2005, to below 10,000 kilotons in 2022'
+		marks: defaultMarks
 	};
 
 	$: specWithTooltip = {

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -3,7 +3,7 @@
 
 	/** This is an example `LineChart` chart using default plot styles.
 	 *
-	 * This incorporates `ariaHidden` and `ariaLabel` props inside the spec to ensure the screen reader ignores individual SVG elements for accessibility.
+	 * By default, charts are hidden from screen readers to improve accessibility. Instead, use descriptive `title`, `subTitle` and surrounding text description so all users understand what the chart shows.
 	 */
 
 	export const meta = {

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -69,8 +69,11 @@
 		spec: defaultSpec,
 		title: 'Domestic Greenhouse Gas Emissions in London have fallen steadily since 2005',
 		subTitle:
-			'Line chart showing London annual domestic greenhouse gas emissions, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022',
-		data: { chartData }
+			'London annual domestic greenhouse gas emissions, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022',
+		data: { chartData },
+		alt: 'Line chart of London annual domestic greenhouse gas emissions',
+		ariaChartDescription:
+			'The chart shows total domestic greenhouse gas emissions in London fell by almost 8,000 kilotonnes of carbon dioxide emissions from 2005 to 2022. In 2005, there were 16,833 kilotonnes of carbon dioxide emissions, which fell to 9,066 kilotonnes of carbon dioxide emissions in 2022.'
 	}}
 	source
 />
@@ -81,8 +84,11 @@
 		spec: specWithTooltip,
 		title: 'Domestic Greenhouse Gas Emissions in London have fallen steadily since 2005',
 		subTitle:
-			'Line chart showing London annual domestic greenhouse gas emissions, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022',
-		data: { chartData }
+			'London annual domestic greenhouse gas emissions, measured in kilotonnes of carbon dioxide equivalent (ktCO₂e), from 2005 to 2022',
+		data: { chartData },
+		alt: 'Line chart of London annual domestic greenhouse gas emissions',
+		ariaChartDescription:
+			'The chart shows total domestic greenhouse gas emissions in London fell by almost 8,000 kilotonnes of carbon dioxide emissions from 2005 to 2022. In 2005, there were 16,833 kilotonnes of carbon dioxide emissions, which fell to 9,066 kilotonnes of carbon dioxide emissions in 2022.'
 	}}
 	source
 />

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -18,17 +18,26 @@
 	});
 
 	$: defaultMarks = [
-		Plot.gridX({ interval: '2 years' }),
-		Plot.gridY(),
-		Plot.ruleY([0]),
-		Plot.line(chartData, { x: 'year', y: 'Domestic - Total' }),
-		Plot.axisX({ interval: '2 years' }),
-		Plot.axisY({ label: 'ktCO₂e' })
+		Plot.gridX({ interval: '2 years', ariaHidden: 'true' }),
+		Plot.gridY({ ariaHidden: 'true' }),
+		Plot.ruleY([0], { ariaHidden: 'true' }),
+		Plot.line(chartData, {
+			x: 'year',
+			y: 'Domestic - Total',
+			ariaHidden: 'true'
+		}),
+		Plot.axisX({ interval: '2 years', ariaHidden: 'true' }),
+		Plot.axisY({
+			label: 'ktCO₂e',
+			ariaHidden: 'true'
+		})
 	];
 
 	$: defaultSpec = {
 		x: { insetLeft: 80, insetRight: 20, type: 'utc' },
-		marks: defaultMarks
+		marks: defaultMarks,
+		ariaLabel:
+			'Domestic Greenhouse Gas Emissions dropped from over 16,000 kilotons of carbon dioxide emissions in 2005, to below 10,000 kilotons in 2022'
 	};
 
 	$: specWithTooltip = {

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -67,8 +67,9 @@
 	name="Default"
 	args={{
 		spec: defaultSpec,
-		title: 'Domestic Greenhouse Gas Emissions',
-		subTitle: 'Total Domestic Greenhouse Gas Emissions in London have fallen between 2005 and 2022',
+		title: 'Total Domestic Greenhouse Gas Emissions in London have fallen between 2005 and 2022',
+		subTitle:
+			'Line chart showing total domestic greenhouse gas emissions in London fell by almost 8,000 kilotons of carbon dioxide emissions from 2005 to 2022. In 2005, there were almost 17,000 kilotons of carbon dioxide emissions, falling to 9,066 kilotons of carbon dioxide emissions in 2022.',
 		data: { chartData }
 	}}
 	source
@@ -78,8 +79,9 @@
 	name="With Tooltip"
 	args={{
 		spec: specWithTooltip,
-		title: 'Domestic Greenhouse Gas Emissions',
-		subTitle: 'Total Domestic Greenhouse Gas Emissions in London have fallen between 2005 and 2022',
+		title: 'Total Domestic Greenhouse Gas Emissions in London have fallen between 2005 and 2022',
+		subTitle:
+			'Line chart showing total domestic greenhouse gas emissions in London fell by almost 8,000 kilotons of carbon dioxide emissions from 2005 to 2022. In 2005, there were almost 17,000 kilotons of carbon dioxide emissions, falling to 9,066 kilotons of carbon dioxide emissions in 2022.',
 		data: { chartData }
 	}}
 	source

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
@@ -115,7 +115,7 @@
 	 * If `false`, screen readers will dictate the content of the charts, which is largely undesirable.
 	 * Instead ensure the title and subtitle of the chart and/or surrounding text explains the key takeaways.
 	 */
-	export let ariaHidden: boolean;
+	export let ariaHidden = 'true';
 </script>
 
 {#key spec}

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
@@ -108,7 +108,7 @@
 	/**
 	 * Description of the chart for use by screen readers and in a modal for sighted users.
 	 */
-	export let ariaChartDescription = '';
+	export let chartDescription = '';
 
 	/**
 	 * Defaults to `true` inside `ObservablePlotInner` but exposed here in case you want to change to `false`.
@@ -133,6 +133,7 @@
 		{...$$restProps}
 		chartHeight={'h-fit'}
 		{chartWidth}
+		{chartDescription}
 	>
 		<!-- any controls to be displayed below the title and subTitle, but above the chart itself -->
 		<slot name="controls" />
@@ -150,7 +151,7 @@
 		/>
 
 		<p slot="description" class="sr-only" id="{id}-description">
-			{ariaChartDescription}
+			{chartDescription}
 		</p>
 	</ChartContainer>
 {/key}

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
@@ -109,6 +109,13 @@
 	 * Description of the chart for use by screen readers and in a modal for sighted users.
 	 */
 	export let ariaChartDescription = '';
+
+	/**
+	 * Defaults to `true` inside `ObservablePlotInner` but exposed here in case you want to change to `false`.
+	 * If `false`, screen readers will dictate the content of the charts, which is largely undesirable.
+	 * Instead ensure the title and subtitle of the chart and/or surrounding text explains the key takeaways.
+	 */
+	export let ariaHidden: boolean;
 </script>
 
 {#key spec}

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
@@ -149,7 +149,7 @@
 			{id}
 		/>
 
-		<p slot="description" id="{id}-description">
+		<p slot="description" class="sr-only" id="{id}-description">
 			{ariaChartDescription}
 		</p>
 	</ChartContainer>

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
@@ -149,9 +149,9 @@
 			{id}
 		/>
 
-		<div slot="description" id="{id}-description">
+		<p slot="description" id="{id}-description">
 			{ariaChartDescription}
-		</div>
+		</p>
 	</ChartContainer>
 {/key}
 

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
@@ -106,7 +106,7 @@
 	export let id = randomId();
 
 	/**
-	 * Description of the chart for use by screen readers and in a modal for sighted users.
+	 * Detailed description of the chart for use by screen readers and in a modal for sighted users.
 	 */
 	export let chartDescription = '';
 

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
@@ -115,7 +115,7 @@
 	 * If `false`, screen readers will dictate the content of the charts, which is largely undesirable.
 	 * Instead ensure the title and subtitle of the chart and/or surrounding text explains the key takeaways.
 	 */
-	export let ariaHidden = 'true';
+	export let ariaHidden = true;
 </script>
 
 {#key spec}

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
@@ -7,8 +7,8 @@
 
 	import type { Position } from './types.ts';
 
+	import { randomId } from '@ldn-viz/ui';
 	import { writable } from 'svelte/store';
-	import { randomId } from '../../../../ui/src/lib/utils/randomId.js';
 	import ChartContainer from '../chartContainer/ChartContainer.svelte';
 	import ObservablePlotInner from './ObservablePlotInner.svelte';
 

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.svelte
@@ -8,6 +8,7 @@
 	import type { Position } from './types.ts';
 
 	import { writable } from 'svelte/store';
+	import { randomId } from '../../../../ui/src/lib/utils/randomId.js';
 	import ChartContainer from '../chartContainer/ChartContainer.svelte';
 	import ObservablePlotInner from './ObservablePlotInner.svelte';
 
@@ -98,6 +99,16 @@
 	 * so that default chart-level styling is not applied.
 	 */
 	export let applyDefaults = true;
+
+	/**
+	 * Value set as the `id` attribute of the chart, for use in description (defaults to randomly generated value).
+	 */
+	export let id = randomId();
+
+	/**
+	 * Description of the chart for use by screen readers and in a modal for sighted users.
+	 */
+	export let ariaChartDescription = '';
 </script>
 
 {#key spec}
@@ -119,7 +130,21 @@
 		<!-- any controls to be displayed below the title and subTitle, but above the chart itself -->
 		<slot name="controls" />
 
-		<ObservablePlotInner {data} {domNode} {tooltipStore} {tooltipOffset} {spec} {applyDefaults} />
+		<ObservablePlotInner
+			{data}
+			{domNode}
+			{tooltipStore}
+			{tooltipOffset}
+			{spec}
+			{applyDefaults}
+			{ariaHidden}
+			ariaDescribedBy="{id}-description"
+			{id}
+		/>
+
+		<div slot="description" id="{id}-description">
+			{ariaChartDescription}
+		</div>
 	</ChartContainer>
 {/key}
 

--- a/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
@@ -183,6 +183,11 @@
 	 */
 	export let ariaDescribedBy = '';
 
+	/**
+	 * Defaults to randomly generated id passed in by `ObservablePlot`
+	 */
+	export let id;
+
 	const renderPlot = (node: HTMLDivElement) => {
 		if (applyDefaults) {
 			node.appendChild(Plot.plot(spec));
@@ -225,6 +230,7 @@
 		bind:clientWidth={width}
 		aria-hidden={ariaHidden}
 		aria-describedby={ariaDescribedBy}
+		{id}
 	/>
 
 	<!-- IMPORTANT TODO: data prop and exportData prop for buttons - align usage-->

--- a/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
@@ -172,6 +172,12 @@
 	 */
 	export let applyDefaults = true;
 
+	/**
+	 * If `false`, screen readers will dictate the content of the charts, which is largely undesirable.
+	 * Instead ensure the title and subtitle of the chart and/or surrounding text explains the key takeaways.
+	 */
+	export let ariaHidden = true;
+
 	const renderPlot = (node: HTMLDivElement) => {
 		if (applyDefaults) {
 			node.appendChild(Plot.plot(spec));
@@ -207,7 +213,13 @@
 </script>
 
 {#key spec}
-	<div use:renderPlot {...$$restProps} bind:this={domNode} bind:clientWidth={width} />
+	<div
+		use:renderPlot
+		{...$$restProps}
+		bind:this={domNode}
+		bind:clientWidth={width}
+		aria-hidden={ariaHidden}
+	/>
 
 	<!-- IMPORTANT TODO: data prop and exportData prop for buttons - align usage-->
 	{#if $tooltipStore && $tooltipData}

--- a/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
@@ -224,7 +224,6 @@
 		bind:this={domNode}
 		bind:clientWidth={width}
 		aria-hidden={ariaHidden}
-		aria-details={ariaDetails}
 		aria-describedby={ariaDescribedBy}
 	/>
 

--- a/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
@@ -183,12 +183,6 @@
 	 */
 	export let ariaDescribedBy = '';
 
-	/**
-	 * The ID for the complex description of the chart. This should be used when the content contains a large amount of information,
-	 * useful semantics or has a complex structure requiring user navigation.
-	 */
-	export let ariaDetails = '';
-
 	const renderPlot = (node: HTMLDivElement) => {
 		if (applyDefaults) {
 			node.appendChild(Plot.plot(spec));

--- a/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlotInner.svelte
@@ -178,6 +178,17 @@
 	 */
 	export let ariaHidden = true;
 
+	/**
+	 * This should be the ID for the simple plain text description of the chart. Defaults to empty string.
+	 */
+	export let ariaDescribedBy = '';
+
+	/**
+	 * The ID for the complex description of the chart. This should be used when the content contains a large amount of information,
+	 * useful semantics or has a complex structure requiring user navigation.
+	 */
+	export let ariaDetails = '';
+
 	const renderPlot = (node: HTMLDivElement) => {
 		if (applyDefaults) {
 			node.appendChild(Plot.plot(spec));
@@ -219,6 +230,8 @@
 		bind:this={domNode}
 		bind:clientWidth={width}
 		aria-hidden={ariaHidden}
+		aria-details={ariaDetails}
+		aria-describedby={ariaDescribedBy}
 	/>
 
 	<!-- IMPORTANT TODO: data prop and exportData prop for buttons - align usage-->

--- a/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
+++ b/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
@@ -7,11 +7,11 @@ export const fontStack = "'Inter', system-ui, sans-serif"; // TODO: swap for int
 
 export type ThemeMode = 'light' | 'dark';
 
-type DeafultPlotStyleFunctions = {
+type DefaultPlotStyleFunctions = {
 	[key: string]: ((mode: ThemeMode) => any) | (() => any);
 };
 
-export const defaultPlotStyleFunctions: DeafultPlotStyleFunctions = {
+export const defaultPlotStyleFunctions: DefaultPlotStyleFunctions = {
 	defaultStyle: (mode) => defaultStyle(mode),
 	defaultSize: () => defaultSize,
 	defaultSizeFacet: () => defaultSizeFacet,

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -99,6 +99,7 @@ export * from './forms/types';
 export { default as MergeValuesControl } from './mergeValuesControl/MergeValuesControl.svelte';
 
 export { classNames } from './utils/classNames';
+export { randomId } from './utils/randomId';
 
 export {
 	mediaQueryStore,


### PR DESCRIPTION
**What does this change?**
**Originally**
I've added `ariaLabel` and `ariaHidden` attributes to the example line chart, to demonstrate how we can incorporate accessibility best practice.

I don't think this is quite perfect due to the following:
- Adding ariaHidden: 'true' to Plot marks, successfully hides the SVG elements from the screen reader. Except for the axis marks, if they have a label.
- `ariaDescription` doesn’t appear to work inside marks or the spec - the screen reader ignores it
- `ariaLabel` on the `Plot.line()` makes the line disappear
- `ariaLabel` on the spec (outside of marks) DOES work but the screen reader still reads the y axis label, as it's not hidden
- The `ariaLabel` isn't achieving much more than the subTitle is, so we could instead replace it with a slightly more descriptive subTitle and hide the chart (though how to hide the chart remains to be seen, given the above re axis labels)

**Now**
I've instead added an optional prop `ariaHidden` to `ObservablePlotInner` which defaults to true, hiding the chart contents. I've removed the individual ARIA attributes in the exampleLineChart marks and updated the title and subtitle to be more descriptive.

I've since also added `ariaDetails` and `ariaDescribedBy` props which default to empty strings. So more detailed descriptions of the chart contents can be shared.

**Related issues**: #762

**Is it complete?**

- [x] Have you included changeset file?