### PR TITLE
Remove hard coded color from layer control group parent

### DIFF
--- a/.changeset/moody-zebras-doubt.md
+++ b/.changeset/moody-zebras-doubt.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+Removed hard coded border color of layer control group parent

--- a/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
@@ -33,13 +33,6 @@
 			label: 'Underground stations',
 			hideOpacityControl: true,
 			hideSizeControl: true
-		},
-		{
-			id: 'taxi',
-			label: 'Taxi ranks',
-			disabled: true,
-			hideOpacityControl: true,
-			hideSizeControl: true
 		}
 	];
 
@@ -72,12 +65,6 @@
 		},
 		underground: {
 			color: '#9E0059',
-			visible: true,
-			opacity: 1.0,
-			size: 1
-		},
-		taxi: {
-			color: 'firebrick',
 			visible: true,
 			opacity: 1.0,
 			size: 1

--- a/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
@@ -116,7 +116,6 @@
 			id={randomId()}
 			form=""
 			label={showAllLabel}
-			color="#3787D2"
 			checked={allCheckboxesCheckedOrDisabled}
 			indeterminate={!allCheckboxesCheckedOrDisabled && !noCheckboxesChecked}
 			on:change={toggleAll}


### PR DESCRIPTION
**What does this change?**
Makes border of layer control group parent appear as standard grey

**Why?**
Because it is logical that it should.

**How?**
By removing hard coded color hex

**Related issues**:
Also updated the 'Hide controls size and opacity controls for some layers' story to remove the disabled option. So demonstrating the change.

**Does this introduce new dependencies?**
no

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**
Yes

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
