### PR TITLE
calculate image size when ChartContainer uses alignMultiple

### DIFF
--- a/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.svelte
+++ b/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.svelte
@@ -92,6 +92,40 @@
 		return node;
 	};
 
+	const sum = (vals: number[]) => vals.reduce((total, current) => total + +current, 0);
+
+	const getHeight = (div: HTMLElement) => {
+		// N.B. wwe need to check computed style, rather than .style on element, as display is likely to be set by a Tailwind class
+		const display = window.getComputedStyle(div).display;
+
+		if (display !== 'contents') {
+			return div.clientHeight;
+		}
+
+		const children: Element[] = Array.from(div.children);
+
+		const heights = children.map((c: Element) => +c.clientHeight);
+		const marginTop = children.map(
+			(c: Element) => +window.getComputedStyle(c).marginTop.replace('px', '')
+		);
+		const marginBottom = children.map(
+			(c: Element) => +window.getComputedStyle(c).marginBottom.replace('px', '')
+		);
+
+		return sum([...heights, ...marginTop, ...marginBottom]);
+	};
+
+	const getWidth = (div: HTMLElement) => {
+		// N.B. we need to check computed style, rather than .style on element, as display is likely to be set by a Tailwind class
+		const display = window.getComputedStyle(div).display;
+
+		if (display !== 'contents') {
+			return div.clientWidth;
+		}
+
+		return Array.from(div.children)[0]?.clientWidth;
+	};
+
 	const download = async () => {
 		const captureOptions = {
 			style: {
@@ -100,8 +134,8 @@
 
 			// N.B. if we don't specify the width/height, then html-to-image will use the size of the HTML element before
 			// adjusting the style to add the padding. This would result in the content being truncated.
-			width: 2 * padding + htmlNode.clientWidth,
-			height: 2 * padding + htmlNode.clientHeight,
+			width: 2 * padding + getWidth(htmlNode),
+			height: 2 * padding + getHeight(htmlNode),
 
 			filter
 		};


### PR DESCRIPTION
When the `ChartContainer` componenet uses `alignMultiple={true}`, then the chart container `div` uses `display: contents`. This means it has no defined size, so the `ImageDownloadButton` would download an image whose size was `2 * padding` x `2 * padding`. 

This PR tries to handle this case by looking at the size of the child elements. This seems to result in reasonably sized PNG images, but the padding does not seem to be being appleid correctly: it all appears at the bottom and right, rather than being evenly assigned to the top/bottom and left/right.