### PR TITLE
add colorWithBestContrast function

### DIFF
--- a/.changeset/text-color-picker.md
+++ b/.changeset/text-color-picker.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/utils': minor
+---
+
+ADDED: `colorWithBestContrast()` function to select which of two text colors has better contrast with given background color

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,9 +19,10 @@
     "format": "prettier --check . --write",
     "lint": "prettier --check . && eslint src",
     "test": "echo no tests",
-    "test:unit": "echo no tests"
+    "test:unit": "vitest run"
   },
   "dependencies": {
+    "apca-w3": "^0.1.9",
     "chroma-js": "^2.4.2",
     "d3-array": "^3.2.4",
     "d3-format": "^3.1.0",
@@ -32,6 +33,7 @@
     "@types/d3-format": "^3.0.4",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.0",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/utils/src/colors/colorWithBestContrast.test.js
+++ b/packages/utils/src/colors/colorWithBestContrast.test.js
@@ -5,7 +5,6 @@ import colors from '@ldn-viz/themes/styles/js/theme-tokens';
 test('chooses white rather than black for white background, regardless sof order of choices', () => {
   expect(colorWithBestContrast('#FFFFFF', '#FFFFFF', '#000000')).toBe('#000000');
   expect(colorWithBestContrast('#FFFFFF', '#000000', '#FFFFFF')).toBe('#000000');
-
 });
 
 test('chooses black rather than white for black background, regardless sof order of choices', () => {
@@ -14,9 +13,13 @@ test('chooses black rather than white for black background, regardless sof order
 });
 
 test('chooses black rather than white for yellow background', () => {
-  expect(colorWithBestContrast(colors.theme.light.color.data.categorical.yellow, '#FFFFFF', '#000000')).toBe('#000000');
+  expect(
+    colorWithBestContrast(colors.theme.light.color.data.categorical.yellow, '#FFFFFF', '#000000')
+  ).toBe('#000000');
 });
 
 test('chooses white rather than black for primary background', () => {
-  expect(colorWithBestContrast(colors.theme.light.color.data.primary, '#FFFFFF', '#000000')).toBe('#FFFFFF');
+  expect(colorWithBestContrast(colors.theme.light.color.data.primary, '#FFFFFF', '#000000')).toBe(
+    '#FFFFFF'
+  );
 });

--- a/packages/utils/src/colors/colorWithBestContrast.test.js
+++ b/packages/utils/src/colors/colorWithBestContrast.test.js
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest';
+import { colorWithBestContrast } from './colorWithBestContrast';
+import colors from '@ldn-viz/themes/styles/js/theme-tokens';
+
+test('chooses white rather than black for white background, regardless sof order of choices', () => {
+  expect(colorWithBestContrast('#FFFFFF', '#FFFFFF', '#000000')).toBe('#000000');
+  expect(colorWithBestContrast('#FFFFFF', '#000000', '#FFFFFF')).toBe('#000000');
+
+});
+
+test('chooses black rather than white for black background, regardless sof order of choices', () => {
+  expect(colorWithBestContrast('#000000', '#FFFFFF', '#000000')).toBe('#FFFFFF');
+  expect(colorWithBestContrast('#000000', '#000000', '#FFFFFF')).toBe('#FFFFFF');
+});
+
+test('chooses black rather than white for yellow background', () => {
+  expect(colorWithBestContrast(colors.theme.light.color.data.categorical.yellow, '#FFFFFF', '#000000')).toBe('#000000');
+});
+
+test('chooses white rather than black for primary background', () => {
+  expect(colorWithBestContrast(colors.theme.light.color.data.primary, '#FFFFFF', '#000000')).toBe('#FFFFFF');
+});

--- a/packages/utils/src/colors/colorWithBestContrast.ts
+++ b/packages/utils/src/colors/colorWithBestContrast.ts
@@ -1,0 +1,14 @@
+    import { APCAcontrast, sRGBtoY } from 'apca-w3';
+    import { colorParsley } from 'colorparsley';  // optional string parsing
+
+    /**
+     * Return the text color with the greatest color from the background color, as judged by the
+     * Accessible Perceptual Contrast Algorithm specified in WCAG3.
+     *
+     */
+    export const colorWithBestContrast = (backgroundColor: string, textColorOne: string, textColorTwo: string) => {
+    const contrastOne = APCAcontrast( sRGBtoY( colorParsley(textColorOne) ), sRGBtoY( colorParsley(backgroundColor) ) );
+    const contrastTwo = APCAcontrast( sRGBtoY( colorParsley(textColorTwo) ), sRGBtoY( colorParsley(backgroundColor) ) );
+
+    return Math.abs(contrastOne) > Math.abs(contrastTwo) ? textColorOne : textColorTwo;
+}

--- a/packages/utils/src/colors/colorWithBestContrast.ts
+++ b/packages/utils/src/colors/colorWithBestContrast.ts
@@ -1,14 +1,24 @@
-    import { APCAcontrast, sRGBtoY } from 'apca-w3';
-    import { colorParsley } from 'colorparsley';  // optional string parsing
+import { APCAcontrast, sRGBtoY } from 'apca-w3';
+import { colorParsley } from 'colorparsley'; // optional string parsing
 
-    /**
-     * Return the text color with the greatest color from the background color, as judged by the
-     * Accessible Perceptual Contrast Algorithm specified in WCAG3.
-     *
-     */
-    export const colorWithBestContrast = (backgroundColor: string, textColorOne: string, textColorTwo: string) => {
-    const contrastOne = APCAcontrast( sRGBtoY( colorParsley(textColorOne) ), sRGBtoY( colorParsley(backgroundColor) ) );
-    const contrastTwo = APCAcontrast( sRGBtoY( colorParsley(textColorTwo) ), sRGBtoY( colorParsley(backgroundColor) ) );
+/**
+ * Return the text color with the greatest color from the background color, as judged by the
+ * Accessible Perceptual Contrast Algorithm specified in WCAG3.
+ *
+ */
+export const colorWithBestContrast = (
+  backgroundColor: string,
+  textColorOne: string,
+  textColorTwo: string
+) => {
+  const contrastOne = APCAcontrast(
+    sRGBtoY(colorParsley(textColorOne)),
+    sRGBtoY(colorParsley(backgroundColor))
+  );
+  const contrastTwo = APCAcontrast(
+    sRGBtoY(colorParsley(textColorTwo)),
+    sRGBtoY(colorParsley(backgroundColor))
+  );
 
-    return Math.abs(contrastOne) > Math.abs(contrastTwo) ? textColorOne : textColorTwo;
-}
+  return Math.abs(contrastOne) > Math.abs(contrastTwo) ? textColorOne : textColorTwo;
+};

--- a/packages/utils/src/main.ts
+++ b/packages/utils/src/main.ts
@@ -1,1 +1,2 @@
 export { getColorRamp, getThresholdBreaksColorsLabels } from './colors/scales';
+export { colorWithBestContrast } from './colors/colorWithBestContrast';


### PR DESCRIPTION
This add a colorWithBestContrast function that selects which of two potential text colors has better contrast with given background color.


**Does this introduce new dependencies?**

Yes - `apca-w3` and (transitively) `colorparsely`.

**How is it tested?**

There are some vittest tests.

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
