### PR TITLE
Ally: fixed order of chart alt and ignore View description in image download

### DIFF
--- a/.changeset/rotten-turtles-brush.md
+++ b/.changeset/rotten-turtles-brush.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/charts': minor
+---
+
+FIXED: order of alt and description in `ChartContainer` component and removed 'View description' button from image capture on download

--- a/package-lock.json
+++ b/package-lock.json
@@ -8423,6 +8423,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apca-w3": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/apca-w3/-/apca-w3-0.1.9.tgz",
+      "integrity": "sha512-Zrf6AeBeQjNe/fxK7U1jCo5zfdjDl6T4/kdw5Xlky3G7u+EJTZkyItjMYQGtwf9pkftsINxcYyOpuLkzKf1ITQ==",
+      "license": "Limited W3 License",
+      "dependencies": {
+        "colorparsley": "^0.1.8"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -8995,6 +9004,12 @@
       "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/colorparsley": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/colorparsley/-/colorparsley-0.1.8.tgz",
+      "integrity": "sha512-rObESTTTE6G5qO5WFwFxWPggpw4KfpxnLC6Ssl8bITBnNVRhDsyCeTRAUxWQNVTx2pRknKlO2nddYTxjkdNFaw==",
+      "license": "AGPL v3"
     },
     "node_modules/commander": {
       "version": "7.2.0",
@@ -16670,7 +16685,7 @@
     },
     "packages/charts": {
       "name": "@ldn-viz/charts",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@ldn-viz/ui": "*",
@@ -16838,7 +16853,7 @@
     },
     "packages/ui": {
       "name": "@ldn-viz/ui",
-      "version": "15.2.2",
+      "version": "15.3.0",
       "license": "MIT",
       "dependencies": {
         "@ldn-viz/utils": "*",
@@ -16911,11 +16926,13 @@
     },
     "packages/utils": {
       "name": "@ldn-viz/utils",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "apca-w3": "^0.1.9",
         "chroma-js": "^2.4.2",
         "d3-array": "^3.2.4",
+        "d3-color": "^3.1.0",
         "d3-format": "^3.1.0",
         "vite": "^5.4.11"
       },
@@ -16924,7 +16941,8 @@
         "@types/d3-format": "^3.0.4",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^9.1.0",
-        "prettier": "^3.2.5"
+        "prettier": "^3.2.5",
+        "vitest": "^2.1.8"
       }
     }
   }

--- a/packages/charts/src/lib/chartContainer/ChartContainer.svelte
+++ b/packages/charts/src/lib/chartContainer/ChartContainer.svelte
@@ -96,6 +96,10 @@
 </script>
 
 <div class={`chart-container ${chartWidth}`} bind:this={chartToCapture} id="captureElement">
+	{#if alt}
+		<p class="sr-only">{alt}</p>
+	{/if}
+
 	{#if title || subTitle}
 		<div class="mb-4">
 			{#if title}
@@ -105,10 +109,6 @@
 				<SubTitle>{subTitle}</SubTitle>
 			{/if}
 		</div>
-	{/if}
-
-	{#if alt}
-		<p class="sr-only">{alt}</p>
 	{/if}
 
 	<!-- any controls to be displayed below the title and subTitle, but above the chart itself -->

--- a/packages/charts/src/lib/chartContainer/Footer.svelte
+++ b/packages/charts/src/lib/chartContainer/Footer.svelte
@@ -23,7 +23,7 @@
 			{#if source}<li><span class="font-bold mr-1">Source:</span>{source}</li>{/if}
 			{#if note}<li><span class="font-bold mr-1">Note:</span>{note}</li>{/if}
 			{#if chartDescription}
-				<li>
+				<li data-capture-ignore>
 					<Button
 						variant="text"
 						on:click={() => ($isOpen = true)}


### PR DESCRIPTION
**What does this change?**
- The `alt` is now read before the title, subtitle etc in a chart (using `ChartContainer`) so the context is clearer for screen reader users
- I've added `data-capture-ignore` to the 'View description' button in ChartContainer > Footer, so it's not included in image download

**Related issues**: resolves #812

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**
Yes

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
