### PR TITLE
add callback function to be called when geocoder searchbox cleared

### DIFF
--- a/.changeset/geocoder-clear-callback.md
+++ b/.changeset/geocoder-clear-callback.md
@@ -1,0 +1,6 @@
+---
+'@ldn-viz/ui': minor
+'@ldn-viz/maps': minor
+---
+
+CHANGED: `Geocoder`, `MapControlGeocoder`, and `MapControlLocationSEarch` accept a callback function to call when the user clears the search box

--- a/.changeset/geocoder-clear-callback.md
+++ b/.changeset/geocoder-clear-callback.md
@@ -3,4 +3,4 @@
 '@ldn-viz/maps': minor
 ---
 
-CHANGED: `Geocoder`, `MapControlGeocoder`, and `MapControlLocationSEarch` accept a callback function to call when the user clears the search box
+CHANGED: `Geocoder`, `MapControlGeocoder`, and `MapControlLocationSearch` accept a callback function to call when the user clears the search box

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlGeocoder.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlGeocoder.svelte
@@ -36,6 +36,11 @@
 	export let onSearchError: undefined | OnGeolocationSearchError;
 
 	/**
+	 * Called when the user clears the search box.
+	 */
+	export let onSearchClear = () => {};
+
+	/**
 	 * Passed to the suggestions dropdown to limit the number of suggestions
 	 * shown at once.
 	 */
@@ -86,6 +91,7 @@
 	{delay}
 	{onSearchError}
 	onLocationSelected={onLocationSelectedGeocoder}
+	{onSearchClear}
 	{classes}
 	{inputClasses}
 	{placeholder}

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
@@ -80,3 +80,25 @@
 		</Map>
 	</div>
 </Story>
+
+<!--
+This story shows how you can provide callback functions to be called when the user selects a location from the search results, or clears the selection.
+-->
+<Story name="Location Search - callback functions">
+	<div class="w-[100dvw] h-[100dvh]">
+		<Map
+			options={{
+				transformRequest
+			}}
+		>
+			<MapControlGroup position="TopLeft">
+				<MapControlLocationSearch
+					{adapter}
+					{onSearchError}
+					onSearchClear={() => console.log('Cleared search')}
+					onLocationFound={(location) => console.log('Location selected:', location)}
+				/>
+			</MapControlGroup>
+		</Map>
+	</div>
+</Story>

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.svelte
@@ -41,6 +41,11 @@
 	export let onSearchError: undefined | OnGeolocationSearchError = undefined;
 
 	/**
+	 * Called when the user clears the search box.
+	 */
+	export let onSearchClear = () => {};
+
+	/**
 	 * Passed to the suggestions dropdown to limit the number of suggestions
 	 * shown at once.
 	 */
@@ -74,6 +79,7 @@
 		{adapter}
 		onLocationSelected={onLocationFound}
 		{onSearchError}
+		{onSearchClear}
 		{maxSuggestions}
 		inputClasses="w-72 {limitWidthClass}"
 		{placeholder}

--- a/packages/ui/src/lib/geolocation/Geocoder.svelte
+++ b/packages/ui/src/lib/geolocation/Geocoder.svelte
@@ -52,6 +52,11 @@
 	export let onSearchError: undefined | OnGeolocationSearchError;
 
 	/**
+	 * Called when the user clears the search box.
+	 */
+	export let onSearchClear = () => {};
+
+	/**
 	 * suggestions can be bound via 'bind:suggestions' to reactively receive
 	 * changes to search results.
 	 */
@@ -275,6 +280,8 @@
 		selected = null;
 		suggestions = [];
 		showSuggestionList = false;
+
+		onSearchClear();
 	};
 
 	$: {


### PR DESCRIPTION
`Geocoder`, `MapControlGeocoder`, and `MapControlLocationSearch` accept a callback function to call when the user clears the search box.

This is useful in apps like the new Small Sites map, where clearing the search box/de-selected the selected location should reset the list of sites.