### PR TITLE
align the icons in LayerControls when different sets of controls enabled

### DIFF
--- a/.changeset/align-layer-controls.md
+++ b/.changeset/align-layer-controls.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: align the icons in `LayerControl` instances within a `LayerControlGroup` with different controls enabled

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -4,6 +4,8 @@
 
 	export let color = '#EE266D';
 
+	export let hideControl = false;
+
 	const colors = [
 		'#EE266D',
 		'#00AEEF',
@@ -22,25 +24,29 @@
 	let openStore: Writable<boolean>;
 </script>
 
-<Popover bind:openStore>
-	<svelte:fragment slot="hint">
-		<div class="w-5 h-5 relative border rounded-full" style:background={color}></div>
-	</svelte:fragment>
+{#if hideControl}
+	<div class="w-5 h-5 relative"></div>
+{:else}
+	<Popover bind:openStore>
+		<svelte:fragment slot="hint">
+			<div class="w-5 h-5 relative border rounded-full" style:background={color}></div>
+		</svelte:fragment>
 
-	<svelte:fragment slot="title">Color</svelte:fragment>
+		<svelte:fragment slot="title">Color</svelte:fragment>
 
-	<span class="text-xs mb-2 inline-block">Click to assign a color to this layer.</span>
+		<span class="text-xs mb-2 inline-block">Click to assign a color to this layer.</span>
 
-	<div class="flex flex-wrap gap-2">
-		{#each colors as colorOption}
-			<button
-				class="w-6 h-6 rounded-full"
-				style:background={colorOption}
-				on:click={() => {
-					color = colorOption;
-					$openStore = false;
-				}}
-			/>
-		{/each}
-	</div>
-</Popover>
+		<div class="flex flex-wrap gap-2">
+			{#each colors as colorOption}
+				<button
+					class="w-6 h-6 rounded-full"
+					style:background={colorOption}
+					on:click={() => {
+						color = colorOption;
+						$openStore = false;
+					}}
+				/>
+			{/each}
+		</div>
+	</Popover>
+{/if}

--- a/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
@@ -26,7 +26,8 @@
 		{
 			id: 'train',
 			label: 'Train stations',
-			hint: 'Excluding underground stations'
+			hint: 'Excluding underground stations',
+			hideColorControl: true
 		},
 		{
 			id: 'underground',

--- a/packages/ui/src/lib/layerControl/LayerControl.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.svelte
@@ -25,6 +25,12 @@
 	export let hideSizeControl = false;
 
 	/**
+	 * List of controls for which placeholder should be displayed in control is hidden.
+	 * This enables alignment of controls between different `LayerControl`s with different controls enabled,
+	 */
+	export let controlsInUse: ('color' | 'opacity' | 'size')[] = [];
+
+	/**
 	 * the name of the layer
 	 */
 	export let label = '';
@@ -66,17 +72,18 @@
 		<Checkbox bind:checked={state.visible} label="" {disabled} />
 	</div>
 
-	{#if !hideColorControl}
-		<ColorPicker bind:color={state.color} />
+	{#if !hideColorControl || controlsInUse.includes('color')}
+		<ColorPicker bind:color={state.color} hideControl={hideColorControl} />
 	{/if}
 
-	{#if !hideOpacityControl}
-		<OpacityControl bind:opacity={state.opacity} />
+	{#if !hideOpacityControl || controlsInUse.includes('opacity')}
+		<OpacityControl bind:opacity={state.opacity} hideControl={hideOpacityControl} />
 	{/if}
 
-	{#if !hideSizeControl}
-		<ResizeControl bind:size={state.size} {minSize} {maxSize} />
+	{#if !hideSizeControl || controlsInUse.includes('size')}
+		<ResizeControl bind:size={state.size} {minSize} {maxSize} hideControl={hideSizeControl} />
 	{/if}
+
 	{#if label}
 		<span class="form-label font-normal leading-none">{label}</span>
 	{/if}

--- a/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
@@ -104,6 +104,21 @@
 			clearAll();
 		}
 	};
+
+	// construct list of controls which are in use
+	let controlsInUse: ('color' | 'opacity' | 'size')[] = [];
+	$: {
+		controlsInUse = [];
+		if (!hideColorControl && !options.every((l) => l.hideColorControl)) {
+			controlsInUse.push('color');
+		}
+		if (!hideOpacityControl && !options.every((l) => l.hideOpacityControl)) {
+			controlsInUse.push('opacity');
+		}
+		if (!hideSizeControl && !options.every((l) => l.hideSizeControl)) {
+			controlsInUse.push('size');
+		}
+	}
 </script>
 
 <div class="flex flex-col space-y-1">
@@ -131,6 +146,7 @@
 				hideColorControl={hideColorControl || option.hideColorControl}
 				hideOpacityControl={hideOpacityControl || option.hideOpacityControl}
 				hideSizeControl={hideSizeControl || option.hideSizeControl}
+				{controlsInUse}
 				bind:state={state[option.id]}
 			/>
 		{/each}

--- a/packages/ui/src/lib/layerControl/OpacityControl.svelte
+++ b/packages/ui/src/lib/layerControl/OpacityControl.svelte
@@ -5,22 +5,28 @@
 	import OpacityIcon from './OpacityIcon.svelte';
 
 	export let opacity = 1;
+
+	export let hideControl = false;
 </script>
 
-<Popover>
-	<svelte:fragment slot="hint">
-		<OpacityIcon
-			class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
-			aria-hidden="true"
-		/>
-	</svelte:fragment>
+{#if hideControl}
+	<div class="w-6 h-6 relative"></div>
+{:else}
+	<Popover>
+		<svelte:fragment slot="hint">
+			<OpacityIcon
+				class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
+				aria-hidden="true"
+			/>
+		</svelte:fragment>
 
-	<svelte:fragment slot="title">Opacity</svelte:fragment>
+		<svelte:fragment slot="title">Opacity</svelte:fragment>
 
-	<div class="flex gap-4 items-center pt-2">
-		<div class="w-32">
-			<input type="range" class="w-32" bind:value={opacity} min="0" max="1" step="0.01" />
+		<div class="flex gap-4 items-center pt-2">
+			<div class="w-32">
+				<input type="range" class="w-32" bind:value={opacity} min="0" max="1" step="0.01" />
+			</div>
+			<div class="w-16"><Input bind:value={opacity} type="number" min="0" max="1"></Input></div>
 		</div>
-		<div class="w-16"><Input bind:value={opacity} type="number" min="0" max="1"></Input></div>
-	</div>
-</Popover>
+	</Popover>
+{/if}

--- a/packages/ui/src/lib/layerControl/ResizeControl.svelte
+++ b/packages/ui/src/lib/layerControl/ResizeControl.svelte
@@ -6,21 +6,27 @@
 
 	export let minSize;
 	export let maxSize;
+
+	export let hideControl = false;
 </script>
 
-<Popover>
-	<svelte:fragment slot="hint">
-		<ResizeIcon
-			class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
-			aria-hidden="true"
-		/>
-	</svelte:fragment>
+{#if hideControl}
+	<div class="w-6 h-6 relative"></div>
+{:else}
+	<Popover>
+		<svelte:fragment slot="hint">
+			<ResizeIcon
+				class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
+				aria-hidden="true"
+			/>
+		</svelte:fragment>
 
-	<svelte:fragment slot="title">Marker size</svelte:fragment>
+		<svelte:fragment slot="title">Marker size</svelte:fragment>
 
-	<div class="flex gap-4 items-center pt-2">
-		<div class="w-40">
-			<input type="range" bind:value={size} min={minSize} max={maxSize} step="0.01" />
+		<div class="flex gap-4 items-center pt-2">
+			<div class="w-40">
+				<input type="range" bind:value={size} min={minSize} max={maxSize} step="0.01" />
+			</div>
 		</div>
-	</div>
-</Popover>
+	</Popover>
+{/if}


### PR DESCRIPTION
This fixes the alignment of controls so that all controls of the same type (e.g., opacity) are in the same column. I think it is a definite improvement, but necessarily the best final design.

![image](https://github.com/user-attachments/assets/3dc1be24-1285-4c09-8192-61418ea0c24c)


However, it potentially looks quite gappy. Adding control buttons that look disabled might cause confusion about why they are disabled, and whether the user can do anything to re-enable them. A disabled color control that is greyed out might be confused with a color control that is set to grey (and something more explicit like a color control that is crossed-out might be confused for a control that is set to "no fill color").

@halimahLDN  also thought that a large gap caused by a series of missing controls between the checkbox and the labels might make it harder to read which checkbox corresponds to which label. @mikeldn suggested zebra-striping could help. A hover state might also help, though would be less effective on mobile. Re-ordering the checkboxes so that the checkbox was beside the label would help, but is not ideal as clicking on the checkbox to toggle whether a layer is enabled is the primary action.


@ChrisKnightLDN, this probably needs your input.