### PR TITLE
set types of PageMetadata props

### DIFF
--- a/.changeset/page-metadata-types.md
+++ b/.changeset/page-metadata-types.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': patch
+---
+
+FIXED: set types of some props on PageMetadata

--- a/packages/ui/src/lib/pageMetadata/PageMetadata.svelte
+++ b/packages/ui/src/lib/pageMetadata/PageMetadata.svelte
@@ -13,17 +13,17 @@
 	/**
 	 * "The title of your object as it should appear within the graph, e.g., 'The Rock'."
 	 */
-	export let title;
+	export let title: string;
 
 	/**
 	 * "A one to two sentence description of your object."
 	 */
-	export let description;
+	export let description: string;
 
 	/**
 	 * "The canonical URL of your object that will be used as its permanent ID in the graph". Should include the scheme (`http://` or `https://`).
 	 */
-	export let url; // Must be full URL with scheme
+	export let url: string; // Must be full URL with scheme
 
 	if (!title || !description || !url) {
 		// Minimum requirement for SEO.
@@ -49,12 +49,12 @@
 	 * "An image URL which should represent your object within the graph".
 	 * If an `image` is provided, then `imageAlt` should be too.
 	 */
-	export let image = undefined;
+	export let image: string;
 
 	/**
 	 * "A description of what is in the image (not a caption)."
 	 */
-	export let imageAlt = undefined;
+	export let imageAlt: string;
 
 	/**
 	 * Image width in pixels. Recommended value is 1200.

--- a/packages/ui/src/lib/pageMetadata/PageMetadata.svelte
+++ b/packages/ui/src/lib/pageMetadata/PageMetadata.svelte
@@ -49,12 +49,12 @@
 	 * "An image URL which should represent your object within the graph".
 	 * If an `image` is provided, then `imageAlt` should be too.
 	 */
-	export let image: string;
+	export let image = '';
 
 	/**
 	 * "A description of what is in the image (not a caption)."
 	 */
-	export let imageAlt: string;
+	export let imageAlt = '';
 
 	/**
 	 * Image width in pixels. Recommended value is 1200.
@@ -81,10 +81,13 @@
 	<meta property="og:determiner" content="" />
 	<meta property="og:title" content={title} />
 	<meta property="og:description" content={description} />
-	<meta property="og:image" content={image} />
-	<meta property="og:image:alt" content={imageAlt} />
-	<meta property="og:image:width" content={imageWidth.toString()} />
-	<meta property="og:image:height" content={imageHeight.toString()} />
+
+	{#if image}
+		<meta property="og:image" content={image} />
+		<meta property="og:image:alt" content={imageAlt} />
+		<meta property="og:image:width" content={imageWidth.toString()} />
+		<meta property="og:image:height" content={imageHeight.toString()} />
+	{/if}
 
 	<!-- 𝕏 / Twitter -->
 	<meta property="twitter:card" content="summary" />
@@ -92,13 +95,19 @@
 	<meta property="twitter:site" content={site} />
 	<meta property="twitter:title" content={title} />
 	<meta property="twitter:description" content={description} />
-	<meta property="twitter:image" content={image} />
-	<meta property="twitter:image:alt" content={imageAlt} />
-	<meta property="twitter:image:width" content={imageWidth.toString()} />
-	<meta property="twitter:image:height" content={imageHeight.toString()} />
+
+	{#if image}
+		<meta property="twitter:image" content={image} />
+		<meta property="twitter:image:alt" content={imageAlt} />
+		<meta property="twitter:image:width" content={imageWidth.toString()} />
+		<meta property="twitter:image:height" content={imageHeight.toString()} />
+	{/if}
 
 	<!-- Pinterest -->
-	<meta property="pin:media" content={image} />
 	<meta property="pin:url" content={url} />
 	<meta property="pin:description" content={description} />
+
+	{#if image}
+		<meta property="pin:media" content={image} />
+	{/if}
 </svelte:head>


### PR DESCRIPTION
This sets types for some props of `PageMetadata`. Currently, these implicitly have type `undefined`, and so providing a value results in a type error `Type string is not assignable to type undefined`.