### PR TITLE
UI overlays: Tooltips, Popovers, Modals

### DIFF
--- a/.changeset/famous-gorillas-tie.md
+++ b/.changeset/famous-gorillas-tie.md
@@ -2,6 +2,6 @@
 '@ldn-viz/ui': minor
 ---
 
-ADDED `Overlays` component to allow choice of tooltip, modal or popover and implementation in Storybook
+ADDED `Overlay` component to allow choice of tooltip, modal or popover and implementation in Storybook
 ADDED `Trigger` component to handle opening tooltips, modals and popovers
 FIXED `Button` customAction prop is now generic

--- a/.changeset/famous-gorillas-tie.md
+++ b/.changeset/famous-gorillas-tie.md
@@ -1,0 +1,7 @@
+---
+'@ldn-viz/ui': minor
+---
+
+ADDED `Overlays` component to allow choice of tooltip, modal or popover and implementation in Storybook
+ADDED `Trigger` component to handle opening tooltips, modals and popovers
+FIXED `Button` customAction prop is now generic

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -20,7 +20,7 @@
 		openInNewTab: boolean;
 		type: 'button' | 'submit';
 		title: string;
-		customAction: (() => void) | undefined;
+		customAction: ((node?: HTMLElement) => {}) | undefined;
 	}
 
 	type ButtonStyle = Record<
@@ -83,7 +83,7 @@
 
 	/**
 	 * Custom action props such as ARIA attributes and tabindex.
-	 * Primarily used by components using Melt UI triggers.
+	 * Primarily used by components using Melt UI
 	 */
 	export let actionProps = {};
 

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -20,7 +20,7 @@
 		openInNewTab: boolean;
 		type: 'button' | 'submit';
 		title: string;
-		customAction: ((node: HTMLElement) => MeltActionReturn<'keydown' | 'pointerdown'>) | undefined;
+		customAction: (() => {}) | undefined;
 	}
 
 	type ButtonStyle = Record<
@@ -32,8 +32,6 @@
 </script>
 
 <script lang="ts">
-	import type { MeltActionReturn } from '@melt-ui/svelte/internal/types';
-
 	/**
 	 * Selects which family of styles should be applied to the button.
 	 */
@@ -78,12 +76,14 @@
 	export let title: ButtonProps['title'] = '';
 
 	/**
-	 * MeltUI Action passed down from MultipleActionButton
+	 * Custom button action, e.g. mouse/key events.
+	 * Primarily used by components using Melt UI triggers.
 	 */
 	export let customAction: ButtonProps['customAction'] = undefined;
 
 	/**
-	 * MeltUI action props passed down from MultipleActionButton, which include ARIA attributes and tabindex.
+	 * Custom action props such as ARIA attributes and tabindex.
+	 * Primarily used by components using Melt UI triggers.
 	 */
 	export let actionProps = {};
 

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -20,7 +20,7 @@
 		openInNewTab: boolean;
 		type: 'button' | 'submit';
 		title: string;
-		customAction: ((node?: HTMLElement) => {}) | undefined;
+		customAction: ((node?: HTMLElement) => void) | undefined;
 	}
 
 	type ButtonStyle = Record<
@@ -80,6 +80,7 @@
 	 * Primarily used by components using Melt UI triggers.
 	 */
 	export let customAction: ButtonProps['customAction'] = undefined;
+	const action = customAction ? customAction : () => {};
 
 	/**
 	 * Custom action props such as ARIA attributes and tabindex.
@@ -233,8 +234,6 @@
 		href && disabled === true ? 'pointer-events-none' : '',
 		$$props.class
 	);
-
-	const action = customAction ? customAction : () => {};
 </script>
 
 <div class="flex">

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -20,7 +20,7 @@
 		openInNewTab: boolean;
 		type: 'button' | 'submit';
 		title: string;
-		customAction: (() => {}) | undefined;
+		customAction: (() => void) | undefined;
 	}
 
 	type ButtonStyle = Record<

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -20,7 +20,7 @@
 		openInNewTab: boolean;
 		type: 'button' | 'submit';
 		title: string;
-		customAction: ((node?: HTMLElement) => void) | undefined;
+		action: (node: HTMLElement) => void;
 	}
 
 	type ButtonStyle = Record<
@@ -79,8 +79,7 @@
 	 * Custom button action, e.g. mouse/key events.
 	 * Primarily used by components using Melt UI triggers.
 	 */
-	export let customAction: ButtonProps['customAction'] = undefined;
-	const action = customAction ? customAction : () => {};
+	export let action: ButtonProps['action'] = () => {};
 
 	/**
 	 * Custom action props such as ARIA attributes and tabindex.

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -97,6 +97,7 @@ export { default as SchemaForm } from './forms/SchemaForm.svelte';
 export * from './forms/types';
 
 export { default as MergeValuesControl } from './mergeValuesControl/MergeValuesControl.svelte';
+export { default as Overlay } from './overlay/Overlay.svelte';
 
 export { classNames } from './utils/classNames';
 export { randomId } from './utils/randomId';

--- a/packages/ui/src/lib/modal/Modal.stories.svelte
+++ b/packages/ui/src/lib/modal/Modal.stories.svelte
@@ -23,6 +23,7 @@
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 	import { writable } from 'svelte/store';
 	import Button from '../button/Button.svelte';
+	import Trigger from '../overlay/Trigger.svelte';
 
 	let isOpen = writable(false);
 </script>
@@ -138,5 +139,11 @@
 				<li>Three</li>
 			</ul>
 		</div>
+	</Modal>
+</Story>
+
+<Story name="With Trigger">
+	<Modal title="The modal title">
+		<Trigger slot="trigger" variant="solid" emphasis="primary" size="md">Open modal!</Trigger>
 	</Modal>
 </Story>

--- a/packages/ui/src/lib/modal/Modal.stories.svelte
+++ b/packages/ui/src/lib/modal/Modal.stories.svelte
@@ -142,6 +142,8 @@
 	</Modal>
 </Story>
 
+<!-- When using the `<Trigger>` component, you don't need to pass `isOpen` as a prop. -->
+
 <Story name="With Trigger">
 	<Modal title="The modal title">
 		<Trigger slot="trigger" variant="solid" emphasis="primary" size="md">Open modal!</Trigger>

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -91,7 +91,9 @@
 	setContext('triggerFuncs', { customAction: trigger, actionProps: $trigger });
 </script>
 
-<slot name="trigger" />
+{#if $$slots.trigger}
+	<slot name="trigger" />
+{/if}
 
 {#if $open}
 	<div {...$portalled} use:$portalled.action>

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -88,7 +88,7 @@
 		widthClasses[width]
 	);
 
-	setContext('triggerFuncs', { customAction: trigger, actionProps: $trigger });
+	setContext('triggerFuncs', { action: trigger, actionProps: $trigger });
 </script>
 
 {#if $$slots.trigger}

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -11,6 +11,7 @@
 	import { createDialog } from '@melt-ui/svelte';
 	import { XMark } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
+	import { setContext } from 'svelte';
 	import { writable } from 'svelte/store';
 	import Button from '../button/Button.svelte';
 	import { classNames } from '../utils/classNames';
@@ -22,6 +23,7 @@
 
 	const {
 		elements: {
+			trigger,
 			portalled,
 			overlay,
 			content,
@@ -85,10 +87,14 @@
 		'inline-block w-full max-h-full flex flex-col overflow-hidden text-left align-middle transition-all transform bg-color-container-level-0 shadow-xl pointer-events-auto',
 		widthClasses[width]
 	);
+
+	setContext('triggerFuncs', { customAction: trigger, actionProps: $trigger });
 </script>
 
-<div {...$portalled} use:$portalled.action>
-	{#if $open}
+<slot name="trigger" />
+
+{#if $open}
+	<div {...$portalled} use:$portalled.action>
 		<div {...$overlay} use:$overlay.action class="fixed inset-0 bg-black bg-opacity-40 z-40" />
 
 		<div class="fixed inset-8 flex items-center justify-center pointer-events-none z-50">
@@ -124,5 +130,5 @@
 				</div>
 			</div>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}

--- a/packages/ui/src/lib/multipleActionButton/MultipleActionButton.svelte
+++ b/packages/ui/src/lib/multipleActionButton/MultipleActionButton.svelte
@@ -148,7 +148,7 @@
 			{condition}
 			{size}
 			{disabled}
-			customAction={$trigger.action}
+			action={$trigger.action}
 			actionProps={$trigger}
 			class={`${variant === 'outline' ? ' border-l-0 ' : 'border-l border-color-action-border-secondary'}`}
 			ariaLabel={menuTitle ? 'Open popover to ' + menuTitle : 'Open popover'}

--- a/packages/ui/src/lib/overlay/Overlay.stories.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.stories.svelte
@@ -53,9 +53,7 @@ custom icon, custom text
 	<Overlay overlayType="modal">This is a modal.</Overlay>
 </Story> -->
 
-<!-- -->
-
-<Story name="With Tooltip - custom trigger contents">
+<Story name="With Tooltip - custom trigger label">
 	<Overlay overlayType="tooltip">
 		<Trigger slot="trigger">All the button stuff</Trigger>
 
@@ -65,7 +63,7 @@ custom icon, custom text
 
 <Story name="With Tooltip - custom variant">
 	<Overlay overlayType="tooltip">
-		<Trigger slot="trigger" variant="solid">All the button stuff</Trigger>
+		<Trigger slot="trigger" variant="solid" />
 
 		This is a tooltip.
 	</Overlay>
@@ -73,7 +71,7 @@ custom icon, custom text
 
 <Story name="With Tooltip - custom emphasis">
 	<Overlay overlayType="tooltip">
-		<Trigger slot="trigger" emphasis="primary">All the button stuff</Trigger>
+		<Trigger slot="trigger" emphasis="primary" />
 
 		This is a tooltip.
 	</Overlay>
@@ -81,7 +79,15 @@ custom icon, custom text
 
 <Story name="With Tooltip - custom size">
 	<Overlay overlayType="tooltip">
-		<Trigger slot="trigger" size="lg">All the button stuff</Trigger>
+		<Trigger slot="trigger" size="lg" />
+
+		This is a tooltip.
+	</Overlay>
+</Story>
+
+<Story name="With Tooltip - no icon">
+	<Overlay overlayType="tooltip">
+		<Trigger slot="trigger">More Info</Trigger>
 
 		This is a tooltip.
 	</Overlay>
@@ -90,8 +96,7 @@ custom icon, custom text
 <Story name="With Tooltip - with Icon on right">
 	<Overlay overlayType="tooltip">
 		<Trigger slot="trigger">
-			All the button stuff
-
+			More Info
 			<Icon src={ArrowDownTray} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" />
 		</Trigger>
 
@@ -103,14 +108,13 @@ custom icon, custom text
 	<Overlay overlayType="tooltip">
 		<Trigger slot="trigger">
 			<Icon src={ArrowDownTray} theme="mini" class="mr-2 w-5 h-5" aria-hidden="true" />
-
-			All the button stuff
+			More Info
 		</Trigger>
 
 		This is a tooltip.
 	</Overlay>
 </Story>
 
-<Story name="Custom hint label, without Trigger component">
+<Story name="With Tooltip - custom hint label, without Trigger component">
 	<Overlay overlayType="tooltip" hintLabel="foo">This is a tooltip.</Overlay>
 </Story>

--- a/packages/ui/src/lib/overlay/Overlay.stories.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.stories.svelte
@@ -1,0 +1,116 @@
+<script context="module" lang="ts">
+	import Overlay from './Overlay.svelte';
+
+	// possible names: overlay? contextual? info? - ContextualInformation?
+
+	export const meta = {
+		title: 'Ui/Overlay',
+		component: Overlay
+	};
+</script>
+
+<script lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import Trigger from './Trigger.svelte';
+
+	import { ArrowDownTray } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+</script>
+
+<Template let:args>
+	<Overlay {...args}></Overlay>
+</Template>
+
+<!-- 
+Trigger appearance cases:
+
+default icons, default text
+default icon, no text
+default icon, custom text
+
+no icon, default text
+no icon, custom text
+
+custom icon, default text
+custom icon, no text
+custom icon, custom text
+
+(and both orders of icon and text)
+(and with button emphasis, size, and variant - and customClass overrides (all the props of a button))
+-->
+
+<Story name="Default" source />
+
+<Story name="With Tooltip">
+	<Overlay overlayType="tooltip">This is a tooltip.</Overlay>
+</Story>
+
+<!-- <Story name="With Popover" source>
+	<Overlay overlayType="popover">This is a popover.</Overlay>
+</Story>
+
+<Story name="With Modal" source>
+	<Overlay overlayType="modal">This is a modal.</Overlay>
+</Story> -->
+
+<!-- -->
+
+<Story name="With Tooltip - custom trigger contents">
+	<Overlay overlayType="tooltip">
+		<Trigger slot="trigger">All the button stuff</Trigger>
+
+		This is a tooltip.
+	</Overlay>
+</Story>
+
+<Story name="With Tooltip - custom variant">
+	<Overlay overlayType="tooltip">
+		<Trigger slot="trigger" variant="solid">All the button stuff</Trigger>
+
+		This is a tooltip.
+	</Overlay>
+</Story>
+
+<Story name="With Tooltip - custom emphasis">
+	<Overlay overlayType="tooltip">
+		<Trigger slot="trigger" emphasis="primary">All the button stuff</Trigger>
+
+		This is a tooltip.
+	</Overlay>
+</Story>
+
+<Story name="With Tooltip - custom size">
+	<Overlay overlayType="tooltip">
+		<Trigger slot="trigger" size="lg">All the button stuff</Trigger>
+
+		This is a tooltip.
+	</Overlay>
+</Story>
+
+<Story name="With Tooltip - with Icon on right">
+	<Overlay overlayType="tooltip">
+		<Trigger slot="trigger">
+			All the button stuff
+
+			<Icon src={ArrowDownTray} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" />
+		</Trigger>
+
+		This is a tooltip.
+	</Overlay>
+</Story>
+
+<Story name="With Tooltip - with Icon on left ">
+	<Overlay overlayType="tooltip">
+		<Trigger slot="trigger">
+			<Icon src={ArrowDownTray} theme="mini" class="mr-2 w-5 h-5" aria-hidden="true" />
+
+			All the button stuff
+		</Trigger>
+
+		This is a tooltip.
+	</Overlay>
+</Story>
+
+<Story name="Custom hint label, without Trigger component">
+	<Overlay overlayType="tooltip" hintLabel="foo">This is a tooltip.</Overlay>
+</Story>

--- a/packages/ui/src/lib/overlay/Overlay.stories.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.stories.svelte
@@ -39,7 +39,9 @@
 </Story>
 
 <Story name="With Modal - custom width" source>
-	<Overlay overlayType="modal" modalTitle="Modal Title" modalWidth="3xl">This is a modal.</Overlay>
+	<Overlay overlayType="modal" modalTitle="Modal Title" modalWidth="3xl"
+		>This is a very wide modal.</Overlay
+	>
 </Story>
 
 <Story name="With Tooltip - custom trigger label">

--- a/packages/ui/src/lib/overlay/Overlay.stories.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.stories.svelte
@@ -21,24 +21,6 @@
 	<Overlay {...args}></Overlay>
 </Template>
 
-<!-- 
-Trigger appearance cases:
-
-default icons, default text
-default icon, no text
-default icon, custom text
-
-no icon, default text
-no icon, custom text
-
-custom icon, default text
-custom icon, no text
-custom icon, custom text
-
-(and both orders of icon and text)
-(and with button emphasis, size, and variant - and customClass overrides (all the props of a button))
--->
-
 <Story name="Default" source />
 
 <Story name="With Tooltip">
@@ -52,9 +34,13 @@ custom icon, custom text
 	</Overlay>
 </Story>
 
-<!-- <Story name="With Modal" source>
-	<Overlay overlayType="modal">This is a modal.</Overlay>
-</Story> -->
+<Story name="With Modal" source>
+	<Overlay overlayType="modal" modalTitle="Modal Title">This is a modal.</Overlay>
+</Story>
+
+<Story name="With Modal - custom width" source>
+	<Overlay overlayType="modal" modalTitle="Modal Title" modalWidth="3xl">This is a modal.</Overlay>
+</Story>
 
 <Story name="With Tooltip - custom trigger label">
 	<Overlay overlayType="tooltip">

--- a/packages/ui/src/lib/overlay/Overlay.stories.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.stories.svelte
@@ -45,11 +45,14 @@ custom icon, custom text
 	<Overlay overlayType="tooltip">This is a tooltip.</Overlay>
 </Story>
 
-<!-- <Story name="With Popover" source>
-	<Overlay overlayType="popover">This is a popover.</Overlay>
+<Story name="With Popover" source>
+	<Overlay overlayType="popover">
+		<svelte:fragment slot="title">Popover Title</svelte:fragment>
+		This is a popover.
+	</Overlay>
 </Story>
 
-<Story name="With Modal" source>
+<!-- <Story name="With Modal" source>
 	<Overlay overlayType="modal">This is a modal.</Overlay>
 </Story> -->
 
@@ -117,4 +120,87 @@ custom icon, custom text
 
 <Story name="With Tooltip - custom hint label, without Trigger component">
 	<Overlay overlayType="tooltip" hintLabel="foo">This is a tooltip.</Overlay>
+</Story>
+
+<Story name="With Popover - no title">
+	<Overlay overlayType="popover">
+		<Trigger slot="trigger" />
+		This is a popover.
+	</Overlay>
+</Story>
+
+<Story name="With Popover - custom trigger label">
+	<Overlay overlayType="popover">
+		<Trigger slot="trigger">All the button stuff</Trigger>
+		<svelte:fragment slot="title">Popover Title</svelte:fragment>
+		This is a popover.
+	</Overlay>
+</Story>
+
+<Story name="With Popover - custom variant">
+	<Overlay overlayType="popover">
+		<Trigger slot="trigger" variant="solid" />
+
+		<svelte:fragment slot="title">Popover Title</svelte:fragment>
+		This is a popover.
+	</Overlay>
+</Story>
+
+<Story name="With Popover - custom emphasis">
+	<Overlay overlayType="popover">
+		<Trigger slot="trigger" emphasis="primary" />
+
+		<svelte:fragment slot="title">Popover Title</svelte:fragment>
+		This is a popover.
+	</Overlay>
+</Story>
+
+<Story name="With Popover - custom size">
+	<Overlay overlayType="popover">
+		<Trigger slot="trigger" size="lg" />
+
+		<svelte:fragment slot="title">Popover Title</svelte:fragment>
+		This is a popover.
+	</Overlay>
+</Story>
+
+<Story name="With Popover - no icon">
+	<Overlay overlayType="popover">
+		<Trigger slot="trigger">More Info</Trigger>
+
+		This is a popover.
+	</Overlay>
+</Story>
+
+<Story name="With Popover - with Icon on right">
+	<Overlay overlayType="popover">
+		<Trigger slot="trigger">
+			More Info
+
+			<Icon src={ArrowDownTray} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" />
+		</Trigger>
+
+		<svelte:fragment slot="title">Popover Title</svelte:fragment>
+		This is a popover.
+	</Overlay>
+</Story>
+
+<Story name="With Popover - with Icon on left ">
+	<Overlay overlayType="popover">
+		<Trigger slot="trigger">
+			<Icon src={ArrowDownTray} theme="mini" class="mr-2 w-5 h-5" aria-hidden="true" />
+
+			More Info
+		</Trigger>
+
+		<svelte:fragment slot="title">Popover Title</svelte:fragment>
+		This is a popover.
+	</Overlay>
+</Story>
+
+<Story name="With Popover - custom hint label, without Trigger component">
+	<Overlay overlayType="popover" hintLabel="foo">
+		<svelte:fragment slot="title">Popover Title</svelte:fragment>
+		This is a popover.
+	</Overlay>
 </Story>

--- a/packages/ui/src/lib/overlay/Overlay.stories.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.stories.svelte
@@ -44,7 +44,7 @@
 
 <Story name="With Tooltip - custom trigger label">
 	<Overlay overlayType="tooltip">
-		<Trigger slot="trigger">All the button stuff</Trigger>
+		<Trigger slot="trigger" hintLabel="All the button stuff" />
 
 		This is a tooltip.
 	</Overlay>
@@ -117,7 +117,7 @@
 
 <Story name="With Popover - custom trigger label">
 	<Overlay overlayType="popover">
-		<Trigger slot="trigger">All the button stuff</Trigger>
+		<Trigger slot="trigger" hintLabel="All the button stuff" />
 		<svelte:fragment slot="title">Popover Title</svelte:fragment>
 		This is a popover.
 	</Overlay>

--- a/packages/ui/src/lib/overlay/Overlay.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	/**
-	 * The `<sidebarHint>` component provides additional explanatory or help text when a user interacts with a trigger.
+	 * The `<Overlay>` component provides additional explanatory or help text when a user interacts with a trigger.
+	 * You can choose whether this is a modal, popover or tooltip, depending on your needs.
+	 *
+	 * The trigger can either be the built in `<Trigger>` component or a custom trigger passed into the relevant slot.
 	 * @component
 	 */
 
@@ -51,7 +54,6 @@
 {#if overlayType === 'tooltip'}
 	<Tooltip>
 		<slot slot="trigger" name="trigger">
-			<!-- TODO: set the props of trigger correctly-->
 			<Trigger {hintLabel} />
 		</slot>
 
@@ -61,7 +63,6 @@
 {:else if overlayType === 'popover'}
 	<Popover>
 		<slot slot="trigger" name="trigger">
-			<!-- TODO: set the props of trigger correctly-->
 			<Trigger {hintLabel} />
 		</slot>
 
@@ -73,11 +74,10 @@
 {:else if overlayType === 'modal'}
 	<Modal title={modalTitle || ''} description={modalDescription} width={modalWidth}>
 		<slot slot="trigger" name="trigger">
-			<!-- TODO: set the props of trigger correctly-->
 			<Trigger {hintLabel} />
 		</slot>
 
-		<!-- The help message. -->
+		<!-- The modal content (not including description). -->
 		<slot />
 	</Modal>
 {/if}

--- a/packages/ui/src/lib/overlay/Overlay.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.svelte
@@ -71,10 +71,11 @@
 		<slot />
 	</Popover>
 {:else if overlayType === 'modal'}
-	<Modal title={modalTitle || ''} description={modalDescription} width={modalWidth} showTrigger>
-		<svelte:fragment slot="hintText">
-			{hintLabel}
-		</svelte:fragment>
+	<Modal title={modalTitle || ''} description={modalDescription} width={modalWidth}>
+		<slot slot="trigger" name="trigger">
+			<!-- TODO: set the props of trigger correctly-->
+			<Trigger {hintLabel} />
+		</slot>
 
 		<!-- The help message. -->
 		<slot />

--- a/packages/ui/src/lib/overlay/Overlay.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.svelte
@@ -59,7 +59,14 @@
 		<slot />
 	</Tooltip>
 {:else if overlayType === 'popover'}
-	<Popover {hintLabel}>
+	<Popover>
+		<slot slot="trigger" name="trigger">
+			<!-- TODO: set the props of trigger correctly-->
+			<Trigger {hintLabel} />
+		</slot>
+
+		<slot slot="title" name="title" />
+
 		<!-- The help message. -->
 		<slot />
 	</Popover>

--- a/packages/ui/src/lib/overlay/Overlay.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	/**
+	 * The `<sidebarHint>` component provides additional explanatory or help text when a user interacts with a trigger.
+	 * @component
+	 */
+
+	import Modal from '../modal/Modal.svelte';
+	import Popover from '../popover/Popover.svelte';
+	import Tooltip from '../tooltip/Tooltip.svelte';
+	import Trigger from './Trigger.svelte';
+
+	/**
+	 * Form in which the help text should be displayed.
+	 */
+	export let overlayType: 'tooltip' | 'popover' | 'modal' = 'tooltip';
+
+	/**
+	 * Text to be displayed next to icon in trigger
+	 */
+	export let hintLabel = 'More Info';
+
+	/**
+	 * Title of modal (if `overlayType` is `'modal'`)
+	 */
+	export let modalTitle: string | undefined = undefined;
+
+	/**
+	 * Description of modal (if `overlayType` is `'modal'`)
+	 */
+	export let modalDescription: string | undefined = undefined;
+
+	/**
+	 * Width of modal (if `overlayType` is `'modal'`)
+	 */
+	export let modalWidth:
+		| 'sm'
+		| 'md'
+		| 'lg'
+		| 'xs'
+		| 'xl'
+		| '2xl'
+		| '3xl'
+		| '4xl'
+		| '5xl'
+		| '6xl'
+		| '7xl'
+		| 'full'
+		| undefined = undefined;
+</script>
+
+{#if overlayType === 'tooltip'}
+	<Tooltip>
+		<slot slot="trigger" name="trigger">
+			<!-- TODO: set the props of trigger correctly-->
+			<Trigger {hintLabel} />
+		</slot>
+
+		<!-- The help message. -->
+		<slot />
+	</Tooltip>
+{:else if overlayType === 'popover'}
+	<Popover {hintLabel}>
+		<!-- The help message. -->
+		<slot />
+	</Popover>
+{:else if overlayType === 'modal'}
+	<Modal title={modalTitle || ''} description={modalDescription} width={modalWidth} showTrigger>
+		<svelte:fragment slot="hintText">
+			{hintLabel}
+		</svelte:fragment>
+
+		<!-- The help message. -->
+		<slot />
+	</Modal>
+{/if}

--- a/packages/ui/src/lib/overlay/Trigger.svelte
+++ b/packages/ui/src/lib/overlay/Trigger.svelte
@@ -26,10 +26,15 @@
 	 */
 	export let emphasis: ButtonProps['emphasis'] = 'secondary';
 
-	const { customAction, actionProps } = getContext('triggerFuncs');
+	interface TriggerFuncs {
+		action: (node: HTMLElement) => void;
+		actionProps: {};
+	}
+
+	const { action, actionProps } = getContext<TriggerFuncs>('triggerFuncs');
 </script>
 
-<Button {size} class={$$props.class} {variant} {emphasis} {customAction} {actionProps}>
+<Button {size} class={$$props.class} {variant} {emphasis} {action} {actionProps}>
 	<slot>
 		{hintLabel}
 

--- a/packages/ui/src/lib/overlay/Trigger.svelte
+++ b/packages/ui/src/lib/overlay/Trigger.svelte
@@ -9,7 +9,7 @@
 	/**
 	 * text that appears in the tooltip target, next to the icon
 	 */
-	export let hintLabel = 'what is this?';
+	export let hintLabel = 'More Info';
 
 	/**
 	 * text size for the tooltip target

--- a/packages/ui/src/lib/overlay/Trigger.svelte
+++ b/packages/ui/src/lib/overlay/Trigger.svelte
@@ -28,7 +28,7 @@
 
 	interface TriggerFuncs {
 		action: (node: HTMLElement) => void;
-		actionProps: {};
+		actionProps: { [key: string]: any };
 	}
 
 	const { action, actionProps } = getContext<TriggerFuncs>('triggerFuncs');

--- a/packages/ui/src/lib/overlay/Trigger.svelte
+++ b/packages/ui/src/lib/overlay/Trigger.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { InformationCircle } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+
+	import { getContext } from 'svelte';
+
+	import Button, { type ButtonProps } from '../button/Button.svelte';
+
+	/**
+	 * text that appears in the tooltip target, next to the icon
+	 */
+	export let hintLabel = 'what is this?';
+
+	/**
+	 * text size for the tooltip target
+	 */
+	export let size: ButtonProps['size'] = 'sm';
+
+	/**
+	 * Selects which family of styles should be applied to the Trigger button.
+	 */
+	export let variant: ButtonProps['variant'] = 'text';
+
+	/**
+	 * Determines how much visual emphasis is placed on the Trigger button.
+	 */
+	export let emphasis: ButtonProps['emphasis'] = 'secondary';
+
+	const { customAction, actionProps } = getContext('triggerFuncs');
+</script>
+
+<Button {size} class={$$props.class} {variant} {emphasis} {customAction} {actionProps}>
+	<slot>
+		{hintLabel}
+
+		<Icon
+			src={InformationCircle}
+			theme="mini"
+			class="w-[18px] h-[18px] ml-0.5"
+			aria-hidden="true"
+		/>
+	</slot>
+</Button>

--- a/packages/ui/src/lib/popover/Popover.stories.svelte
+++ b/packages/ui/src/lib/popover/Popover.stories.svelte
@@ -1,5 +1,4 @@
 <script context="module">
-	import Button from '../button/Button.svelte';
 	import Popover from './Popover.svelte';
 
 	export const meta = {
@@ -10,10 +9,12 @@
 
 <script lang="ts">
 	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import Trigger from '../overlay/Trigger.svelte';
 </script>
 
 <Template let:args>
 	<Popover {...args}>
+		<Trigger slot="trigger" />
 		<svelte:fragment slot="title">Metric note</svelte:fragment>
 
 		The contents of the popover...
@@ -24,23 +25,25 @@
 
 <Story name="No title" source>
 	<Popover>
+		<Trigger slot="trigger" />
 		<svelte:fragment>Some text explaining this metric...</svelte:fragment>
 	</Popover>
 </Story>
 
 <Story name="Custom hint text" source>
-	<Popover hintLabel="Click for more information!">
+	<Popover>
+		<Trigger slot="trigger" hintLabel="Click for more information!" />
 		<svelte:fragment slot="title">Metric note</svelte:fragment>
 
-		<svelte:fragment>Some text explaining this metric...</svelte:fragment>
+		<p>Some text explaining this metric...</p>
 	</Popover>
 </Story>
 
 <Story name="Custom trigger" source>
-	<Popover hintLabel="Click for more information!">
-		<svelte:fragment slot="hint"
-			><Button>Click here to see popover contents</Button></svelte:fragment
-		>
+	<Popover>
+		<Trigger slot="trigger" emphasis="primary" variant="solid">
+			Click here to see popover contents
+		</Trigger>
 
 		<svelte:fragment slot="title">Metric note</svelte:fragment>
 

--- a/packages/ui/src/lib/popover/Popover.svelte
+++ b/packages/ui/src/lib/popover/Popover.svelte
@@ -29,7 +29,7 @@
 	/**
 	 * Sets trigger actions and attributes (ARIA) for access by `Trigger` component
 	 */
-	setContext('triggerFuncs', { customAction: trigger, actionProps: $trigger });
+	setContext('triggerFuncs', { action: trigger, actionProps: $trigger });
 </script>
 
 <!-- The trigger that opens the popover, usually `Trigger` button but allows customisation -->

--- a/packages/ui/src/lib/popover/Popover.svelte
+++ b/packages/ui/src/lib/popover/Popover.svelte
@@ -12,10 +12,10 @@
 	import { createPopover } from '@melt-ui/svelte';
 	import { fade } from 'svelte/transition';
 
-	import { InformationCircle, XMark } from '@steeze-ui/heroicons';
+	import { XMark } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
 
-	import type { Writable } from 'svelte/store';
+	import { setContext } from 'svelte';
 	import Button from '../button/Button.svelte';
 
 	const {
@@ -27,40 +27,13 @@
 	});
 
 	/**
-	 * text that appears in the tooltip target, next to the icon
+	 * Sets trigger actions and attributes (ARIA) for access by `Trigger` component
 	 */
-	export let hintLabel = 'more info';
-
-	/**
-	 * text size for the tooltip target
-	 */
-	export let hintSize: 'sm' | 'md' | 'lg' | undefined = undefined;
-
-	/**
-	 * Store controlling whether popover is open.
-	 */
-	export let openStore: Writable<boolean> | undefined = undefined;
-	$: openStore = open;
+	setContext('triggerFuncs', { customAction: trigger, actionProps: $trigger });
 </script>
 
-<!-- TODO: as this button wraps the hint slot any slotted item inherits button styles (color etc) This should be refactored to be more generic -->
-<Button variant="text" size={hintSize} class="!p-0" emphasis="secondary">
-	<span {...$trigger} use:trigger class="inline-flex items-center">
-		{#if $$slots.hint}
-			<!-- if present, replaces the default `hintLabel` and icon  -->
-			<slot name="hint" />
-		{:else}
-			{hintLabel}
-
-			<Icon
-				src={InformationCircle}
-				theme="mini"
-				class="w-[18px] h-[18px] ml-0.5"
-				aria-hidden="true"
-			/>
-		{/if}
-	</span>
-</Button>
+<!-- The trigger that opens the popover, usually `Trigger` button but allows customisation -->
+<slot name="trigger" />
 
 {#if $open}
 	<div

--- a/packages/ui/src/lib/tooltip/Tooltip.stories.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.stories.svelte
@@ -1,4 +1,5 @@
 <script context="module">
+	import Trigger from '../overlay/Trigger.svelte';
 	import Tooltip from './Tooltip.svelte';
 
 	export const meta = {
@@ -15,33 +16,40 @@
 </script>
 
 <script lang="ts">
-	import { Story, Template } from '@storybook/addon-svelte-csf';
-
 	import { Cog6Tooth } from '@steeze-ui/heroicons';
-
 	import { Icon } from '@steeze-ui/svelte-icon';
+	import { Story, Template } from '@storybook/addon-svelte-csf';
 </script>
 
 <Template let:args>
-	<Tooltip {...args}>This is some text</Tooltip>
+	<Tooltip {...args}>
+		<Trigger slot="trigger" />
+		This is some text
+	</Tooltip>
 </Template>
 
 <Story name="Default" source />
 
-<Story name="Hint Size">
-	<Tooltip hintSize="sm">This is some text</Tooltip>
+<Story name="Custom size">
+	<Tooltip>
+		<Trigger slot="trigger" size="lg" />
+		This is some text inside a bigger button
+	</Tooltip>
 </Story>
 
 <Story name="Custom hint label">
-	<Tooltip hintLabel="Hover over me!">This is some text</Tooltip>
+	<Tooltip>
+		<Trigger slot="trigger" hintLabel="Hover over me!" />
+		This is some text
+	</Tooltip>
 </Story>
 
 <Story name="Custom hint icon">
 	<Tooltip>
-		<svelte:fragment slot="hint">
+		<Trigger slot="trigger">
 			I have a different icon
 			<Icon src={Cog6Tooth} theme="mini" class="w-[18px] h-[18px] ml-0.5" aria-hidden="true" />
-		</svelte:fragment>
+		</Trigger>
 		But I still work the same
 	</Tooltip>
 </Story>

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -47,7 +47,7 @@
 	/**
 	 * Sets trigger actions and attributes (ARIA) for access by `Trigger` component
 	 */
-	setContext('triggerFuncs', { customAction: trigger, actionProps: $trigger });
+	setContext('triggerFuncs', { action: trigger, actionProps: $trigger });
 </script>
 
 <!-- The trigger that opens the tooltip, usually `Trigger` button but allows customisation -->

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -1,99 +1,65 @@
 <script lang="ts">
 	/**
-	 * The `<Tooltip>` component renders a tooltip target, and displays a message in a tooltip when a user mouses-over it.
+	 * The `<Tooltip>` component renders a tooltip target, and displays a message in a tooltip when a user focuses it (mouseover and keyboard).
 	 *
 	 * **Alternatives**: for longer messages, or messages that must persist until being dismissed, consider using a [Modal](./?path=/docs/ui-modal--documentation)
 	 * or [Popover](./?path=/docs/ui-popover--documentation).
 	 * @component
 	 */
 
-	import { arrow } from 'svelte-floating-ui';
-	import { flip, offset, shift } from 'svelte-floating-ui/dom';
-	import { writable, type Writable } from 'svelte/store';
-	import { floatingContent } from './tooltip';
-
-	import { InformationCircle } from '@steeze-ui/heroicons';
-	import { Icon } from '@steeze-ui/svelte-icon';
-
-	import Button from '../button/Button.svelte';
-	import { floatingRef } from '../tooltip/tooltip.js';
+	import { createTooltip } from '@melt-ui/svelte';
+	import { setContext } from 'svelte';
+	import { fade } from 'svelte/transition';
 
 	/**
-	 * text that appears in the tooltip target, next to the icon
+	 * Options for position of tooltip
 	 */
-	export let hintLabel = 'more info';
+	type PlacementOptions =
+		| 'top'
+		| 'top-start'
+		| 'top-end'
+		| 'right'
+		| 'right-start'
+		| 'right-end'
+		| 'bottom'
+		| 'bottom-start'
+		| 'bottom-end'
+		| 'left'
+		| 'left-start'
+		| 'left-end';
 
+	// TODO: Check whether placement updates responsively
 	/**
-	 * text size for the tooltip target
+	 * Determines the placement of the tooltip, relative to Trigger
 	 */
-	export let hintSize: 'sm' | 'md' | 'lg' | undefined = undefined;
+	export let placement: PlacementOptions = 'top';
 
-	let showTooltip = false;
+	const {
+		elements: { trigger, content, arrow },
+		states: { open }
+	} = createTooltip({
+		positioning: { placement },
+		openDelay: 0,
+		closeDelay: 0,
+		closeOnPointerDown: false
+	});
 
-	let element: HTMLSpanElement;
-
-	const arrowRef: Writable<HTMLElement> = writable();
-	let dynamicOptions = {};
-	$: if (showTooltip) {
-		dynamicOptions = {
-			middleware: [offset(10), flip(), shift(), arrow({ element: arrowRef })],
-			onComputed({ placement, middlewareData }: { placement: string; middlewareData: any }) {
-				const { x, y } = middlewareData.arrow || {};
-				const staticSide = {
-					top: 'bottom',
-					right: 'left',
-					bottom: 'top',
-					left: 'right'
-				}[placement.split('-')[0]];
-
-				// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-				$arrowRef &&
-					Object.assign($arrowRef.style, {
-						left: x != null ? `${x}px` : '',
-						top: y != null ? `${y}px` : '',
-						[staticSide!.toString()]: '-8px'
-					});
-			}
-		};
-	}
+	setContext('triggerFuncs', { customAction: trigger, actionProps: $trigger });
 </script>
 
-<Button variant="text" size={hintSize} class="!p-0" emphasis="secondary">
-	<span
-		use:floatingRef
-		bind:this={element}
-		on:mouseenter={() => {
-			showTooltip = true;
-			floatingRef(element);
-		}}
-		on:mouseleave|stopPropagation={() => (showTooltip = false)}
-		role="tooltip"
-		class="inline-flex items-center"
-	>
-		{#if $$slots.hint}
-			<!-- if present, replaces the default `hintLabel` and icon  -->
-			<slot name="hint" />
-		{:else}
-			{hintLabel}
+<!-- The trigger that opens the tooltip, usually `Trigger` button but allows customisation -->
+<slot name="trigger" />
 
-			<Icon
-				src={InformationCircle}
-				theme="mini"
-				class="w-[18px] h-[18px] ml-0.5"
-				aria-hidden="true"
-			/>
-		{/if}
-	</span>
-</Button>
-
-{#if showTooltip}
+{#if $open}
 	<div
+		{...$content}
+		use:content
+		transition:fade={{ duration: 100 }}
 		class="absolute max-w-[200px] text-sm p-2 bg-color-container-level-1 shadow z-50"
-		use:floatingContent={dynamicOptions}
 	>
-		<!-- the text that will be displayed in the tooltip -->
+		<!-- The text that will be displayed in the tooltip -->
 		<slot />
 
-		<div class="absolute bg-color-container-level-1 rotate-45 w-4 h-4" bind:this={$arrowRef} />
+		<div {...$arrow} use:arrow />
 	</div>
 {/if}

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -44,6 +44,9 @@
 		closeOnPointerDown: false
 	});
 
+	/**
+	 * Sets trigger actions and attributes (ARIA) for access by `Trigger` component
+	 */
 	setContext('triggerFuncs', { customAction: trigger, actionProps: $trigger });
 </script>
 


### PR DESCRIPTION
**What does this change?**
- Added `Overlay` component to enable choice of tooltip, modal or popover in components like `InputWrapper`
- Added `Trigger` component which handles opening different overlays and demonstrated implementation. It's in a slot, so it is optional (can be overridden with custom button trigger)
- Demonstrated implementation of Overlay, Tooltip, Modal and Popover in Overlay stories and relevant individual component stories in Storybook
- Refactored Button `customAction` prop to be generic

**Why?**
Review and refactor of our similar components to:
- Align implementation
- Align the technologies
- Align the component API

Modal, tooltips and popovers had slightly different implementations and we wanted to make our components flexible enough for the trigger to trigger the different overlay types and for that trigger to be customisable, logical and consistent. 

**Related issues**: #834, #738 

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**
- Still needs accessibility for screen readers but that's blocked by limitations of Melt UI package

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
