### PR TITLE
Add defaultPoint to observablePlotFragments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14428,7 +14428,7 @@
     },
     "packages/charts": {
       "name": "@ldn-viz/charts",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@ldn-viz/ui": "*",
@@ -14545,7 +14545,7 @@
     },
     "packages/maps": {
       "name": "@ldn-viz/maps",
-      "version": "6.0.1",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
         "@deck.gl/core": "^8.9.35",

--- a/packages/charts/src/lib/observablePlotFragments/documentation.mdx
+++ b/packages/charts/src/lib/observablePlotFragments/documentation.mdx
@@ -89,6 +89,16 @@ In dark mode, `defaultDot` is:
 
 <pre>{JSON.stringify(getDefaultPlotStyles('dark').defaultDot, null, 2)}</pre>
 
+In light mode, `defaultPoint` is:
+
+<pre>{JSON.stringify(getDefaultPlotStyles('light').defaultPoint, null, 2)}</pre>
+
+In dark mode, `defaultPoint` is:
+
+<pre>{JSON.stringify(getDefaultPlotStyles('dark').defaultPoint, null, 2)}</pre>
+
+**Note:** in order to use `defaultPoint` styles, you should use our API, `Plot.point` which customises Observable's `Plot.dot` under the hood.
+
 In light mode, `defaultArea` is:
 
 <pre>{JSON.stringify(getDefaultPlotStyles('light').defaultArea, null, 2)}</pre>


### PR DESCRIPTION
**What does this change?**
- Added `defaultPoint` to observablePlotFragments Storybook docs
- Clarified how to access point styling using our API (as I previously created a custom function `Plot.point` for this)
- Updated package-json to use latest chart and map versions

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
Yes

**Is it complete?**
Yes

- [ ] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
