### PR TITLE
Button alignment

### DIFF
--- a/.changeset/wet-roses-brake.md
+++ b/.changeset/wet-roses-brake.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+Adds xs button size and 'slim' prop

--- a/packages/charts/src/lib/chartContainer/Footer.svelte
+++ b/packages/charts/src/lib/chartContainer/Footer.svelte
@@ -26,7 +26,7 @@
 				<li data-capture-ignore>
 					<Button
 						variant="text"
-						size="sm"
+						size="xs"
 						emphasis="secondary"
 						class="!p-0"
 						on:click={() => ($isOpen = true)}>View description</Button

--- a/packages/ui/src/lib/button/Button.stories.svelte
+++ b/packages/ui/src/lib/button/Button.stories.svelte
@@ -91,9 +91,31 @@
 
 <Story name="Sizes">
 	<div class="flex items-end space-x-2">
+		<Button size="xs">xs</Button>
 		<Button size="sm">sm</Button>
 		<Button size="md">md</Button>
 		<Button size="lg">lg</Button>
+	</div>
+</Story>
+
+<Story name="Slim">
+	<div class="space-y-4">
+		<p class="flex flex-wrap">
+			sometime you may want a buttton to&nbsp;<Button slim variant="text">go with the flow</Button
+			>&nbsp;a bit more
+		</p>
+
+		<p class="flex flex-wrap text-lg">
+			sometime you may want a buttton to&nbsp<Button slim variant="text" size="lg">
+				go with the flow
+			</Button>&nbspa bit more
+		</p>
+
+		<p class="flex flex-wrap text-lg">
+			sometime you may want a buttton to&nbsp;<Button slim variant="solid" size="lg" class="!px-2">
+				go with the flow
+			</Button>&nbsp; a bit more
+		</p>
 	</div>
 </Story>
 

--- a/packages/ui/src/lib/button/Button.stories.svelte
+++ b/packages/ui/src/lib/button/Button.stories.svelte
@@ -108,13 +108,13 @@
 		<p class="flex flex-wrap text-lg">
 			sometime you may want a buttton to&nbsp<Button slim variant="text" size="lg">
 				go with the flow
-			</Button>&nbspa bit more
+			</Button>&nbsp;a bit more
 		</p>
 
 		<p class="flex flex-wrap text-lg">
 			sometime you may want a buttton to&nbsp;<Button slim variant="solid" size="lg" class="!px-2">
 				go with the flow
-			</Button>&nbsp; a bit more
+			</Button>&nbsp;a bit more
 		</p>
 	</div>
 </Story>

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -13,12 +13,13 @@
 	export interface ButtonProps {
 		variant: 'brand' | 'square' | 'solid' | 'outline' | 'text';
 		emphasis: 'primary' | 'secondary' | 'caution' | 'positive' | 'negative';
-		size: 'sm' | 'md' | 'lg';
+		size: 'xs' | 'sm' | 'md' | 'lg';
 		disabled: boolean;
 		href: string;
 		openInNewTab: boolean;
 		type: 'button' | 'submit';
 		title: string;
+		slim: boolean;
 		action: (node: HTMLElement) => void;
 	}
 
@@ -42,6 +43,11 @@
 	 * Sets the size of the button.
 	 */
 	export let size: ButtonProps['size'] = 'md';
+
+	/**
+	 * When true removes vertical padding and sets line height to 0 - useful for aligning buttons with text.
+	 */
+	export let slim: ButtonProps['slim'] = false;
 
 	/**
 	 * If `true`, then the button cannot be interacted with (either by clicking, or by using the keyboard).
@@ -165,6 +171,7 @@
 	};
 
 	$: sizeClasses = {
+		xs: variant === 'square' ? 'w-6 h-6 flex-col' : 'text-xs px-1 min-w-6 min-h-6',
 		sm: variant === 'square' ? 'w-8 h-8 flex-col' : 'text-sm px-2 py-1.5 min-w-8 min-h-8',
 		md: variant === 'square' ? 'w-11 h-11 flex-col' : 'text-base px-4 py-2 min-w-11 min-h-11',
 		lg:
@@ -181,6 +188,7 @@
 		sizeClasses[size],
 		disabled === true ? disabledClasses[variant] : '',
 		href && disabled === true ? 'pointer-events-none' : '',
+		slim === true ? '!py-0 !px-0 !min-h-0 leading-none text-left' : '',
 		$$props.class
 	);
 </script>

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -188,7 +188,7 @@
 		sizeClasses[size],
 		disabled === true ? disabledClasses[variant] : '',
 		href && disabled === true ? 'pointer-events-none' : '',
-		slim === true ? '!py-0 !px-0 !min-h-0 leading-none text-left' : '',
+		slim === true ? '!py-0 !px-0 !min-h-0 leading-none text-left text-nowrap' : '',
 		$$props.class
 	);
 </script>

--- a/packages/ui/src/lib/overlay/Trigger.svelte
+++ b/packages/ui/src/lib/overlay/Trigger.svelte
@@ -17,6 +17,11 @@
 	export let size: ButtonProps['size'] = 'sm';
 
 	/**
+	 * When true removes vertical padding and sets line height to 0 - useful for aligning buttons with text.
+	 */
+	export let slim: ButtonProps['slim'] = true;
+
+	/**
 	 * Selects which family of styles should be applied to the Trigger button.
 	 */
 	export let variant: ButtonProps['variant'] = 'text';
@@ -34,7 +39,7 @@
 	const { action, actionProps } = getContext<TriggerFuncs>('triggerFuncs');
 </script>
 
-<Button {size} class={$$props.class} {variant} {emphasis} {action} {actionProps}>
+<Button {size} class={$$props.class} {variant} {emphasis} {slim} {action} {actionProps}>
 	<slot>
 		{hintLabel}
 


### PR DESCRIPTION
**What does this change?**
Adds a xs size variation for buttons (24px) and also adds a 'slim' boolean that allows for buttons to align with text or other ui elements in certain contexts

**Why?**
Required in various scenarios

**How?**
additional prop and css tweaks

**Related issues**:
#817 

**Does this introduce new dependencies?**
no

**How is it tested?**
storybook

**How is it documented?**
stories

**Are light and dark themes considered?**
n/a

**Is it complete?**

- [x] Have you included changeset file?
