### PR TITLE
Input hints

### DIFF
--- a/.changeset/two-poets-hope.md
+++ b/.changeset/two-poets-hope.md
@@ -1,0 +1,6 @@
+---
+'@ldn-viz/ui': minor
+'@ldn-viz/docs': patch
+---
+
+Added input wrapper to grouped inputs

--- a/packages/ui/src/lib/checkBox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.svelte
@@ -13,6 +13,8 @@
 </script>
 
 <script lang="ts">
+	import Overlay from '../overlay/Overlay.svelte';
+
 	/**
 	 * The `<Checkbox>` component provides a checkbox control as a Boolean input.
 	 * It creates an `<input type="checkbox">`HTML element ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox)), but enhances this with the ability to easily change the checkbox color, and add tooltips providing explanatory text.
@@ -23,7 +25,6 @@
 	 * @component
 	 */
 
-	import Tooltip from '../tooltip/Tooltip.svelte';
 	import { randomId } from '../utils/randomId';
 
 	/**
@@ -99,9 +100,13 @@
 	{#if label}
 		<label class="ml-2 form-label font-normal" for={id}>{label}</label>
 	{/if}
+	{#if $$slots.hint}
+		<!-- An optional `<Overlay>` component to provide additional explanation. -->
+		<slot name="hint" />
+	{/if}
 	{#if hint}
-		<Tooltip {hintLabel}>
+		<Overlay {hintLabel}>
 			{hint}
-		</Tooltip>
+		</Overlay>
 	{/if}
 </div>

--- a/packages/ui/src/lib/checkBox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.svelte
@@ -97,9 +97,11 @@
 			: ''}
 		{...$$restProps}
 	/>
+
 	{#if label}
 		<label class="ml-2 form-label font-normal" for={id}>{label}</label>
 	{/if}
+
 	{#if $$slots.hint}
 		<!-- An optional `<Overlay>` component to provide additional explanation. -->
 		<slot name="hint" />

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
@@ -29,27 +29,89 @@
 
 <Template let:args>
 	<CheckboxGroup options={optionsForGroup} bind:selectedOptions {...args} />
-	<p class="mt-8 text-color-text-secondary">
+	<p class="mt-4 text-color-text-secondary">
 		selectedOptions: {JSON.stringify(selectedOptions)}
 	</p>
 </Template>
 
 <Story name="Default" source />
 
-<Story name="Checkbox Group - disabled buttons">
-	<CheckboxGroup options={optionsForGroup} bind:selectedOptions buttonsHidden />
-	<p class="mt-8 text-color-text-secondary">
+<Story name="with title">
+	<CheckboxGroup options={optionsForGroup} bind:selectedOptions label="Transport method" />
+	<p class="mt-4 text-color-text-secondary">
 		selectedOptions: {JSON.stringify(selectedOptions)}
 	</p>
 </Story>
 
-<Story name="Checkbox Group - externally updated">
+<Story name="with hint">
+	<CheckboxGroup
+		options={optionsForGroup}
+		bind:selectedOptions
+		label="Transport method"
+		hint="contextual hint text"
+	/>
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<Story name="with description">
+	<CheckboxGroup
+		options={optionsForGroup}
+		buttonsHidden
+		bind:selectedOptions
+		label="Transport method"
+		description="Pick you prefered method of transport - taxis are currently not available"
+	/>
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<Story name="disabled buttons">
+	<CheckboxGroup options={optionsForGroup} bind:selectedOptions buttonsHidden />
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<Story name="externally updated">
 	<Button on:click={() => (selectedOptions = ['bus', 'train'])}>Select bus and train!</Button>
 
 	<div class="my-4">
 		<CheckboxGroup options={optionsForGroup} bind:selectedOptions buttonsHidden />
 	</div>
-	<p class="text-color-text-secondary">
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<Story name="Disabled (global)">
+	<CheckboxGroup
+		options={optionsForGroup}
+		bind:selectedOptions
+		buttonsHidden
+		label="Preferred mode of transport"
+		hint="Contextual Hint"
+		description="This is a description"
+		disabled
+	/>
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<Story name="With error">
+	<CheckboxGroup
+		options={optionsForGroup}
+		bind:selectedOptions
+		buttonsHidden
+		label="Preferred mode of transport"
+		hint="Contextual Hint"
+		description="Deselect all to see an error state!"
+		error={!selectedOptions.length ? 'You must select an option' : undefined}
+	/>
+	<p class="mt-4 text-color-text-secondary">
 		selectedOptions: {JSON.stringify(selectedOptions)}
 	</p>
 </Story>

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -6,8 +6,62 @@
 	 * @component
 	 */
 
+	import InputWrapper from '../input/InputWrapper.svelte';
 	import { randomId } from '../utils/randomId';
 	import Checkbox from './Checkbox.svelte';
+
+	/**
+	 * The `id` of the `<input>` element: defaults to a randomly-generated value.
+	 */
+	export let id = randomId();
+
+	/**
+	 * Text displayed above the `<input>` element.
+	 */
+	export let label = '';
+
+	/**
+	 * Text that appears below the `<input>` element, in smaller font than the `label`.
+	 */
+	export let description = '';
+
+	/**
+	 * Determines which edge of the `<input>` the description is aligned with.
+	 */
+	export let descriptionAlignment: 'left' | 'right' = 'left';
+
+	/**
+	 * Help text to be displayed in tooltip
+	 */
+	export let hint = '';
+
+	/**
+	 * Text to be displayed next to icon in tooltip trigger.
+	 */
+	export let hintLabel: undefined | string = undefined;
+
+	/**
+	 * If `false`, then `required` attribute is applied to `<input>`.
+	 */
+	export let optional = false;
+
+	/**
+	 * If `true`, then user is prevented from interacting with the `<input>`.
+	 */
+	export let disabled = false;
+
+	/**
+	 * Message to be displayed below `<input>` in red text (replacing description).
+	 * If set, then the border of the `<input>` is also red.
+	 */
+	export let error = '';
+
+	/**
+	 * Only generate `descriptionId` and/or `errorId` when `description` and/or `error` exist.
+	 * `descriptionId` is static but `errorId` is reactive as error state could change.
+	 */
+	const descriptionId = description ? `${id}-description` : undefined;
+	$: errorId = error ? `${id}-error` : undefined;
 
 	/**
 	 * Each element of this array defines a checkbox, and is an object with the properties:
@@ -83,35 +137,51 @@
 	};
 </script>
 
-<div class="flex flex-col space-y-1">
-	{#if !buttonsHidden}
-		<!--
+<InputWrapper
+	{label}
+	{id}
+	{descriptionId}
+	{description}
+	{descriptionAlignment}
+	{hintLabel}
+	{hint}
+	{errorId}
+	{error}
+	{disabled}
+	{optional}
+>
+	<slot name="hint" slot="hint" />
+	<div class="flex flex-col space-y-1">
+		{#if !buttonsHidden}
+			<!--
 			form="" should prevent this checkbox from being included in form
 			submissions.
 		-->
-		<Checkbox
-			id={randomId()}
-			form=""
-			label="Select all"
-			color="#3787D2"
-			checked={allCheckboxesCheckedOrDisabled}
-			indeterminate={!allCheckboxesCheckedOrDisabled && !noCheckboxesChecked}
-			on:change={toggleAll}
-		/>
-	{/if}
-
-	<div class={`flex flex-col space-y-1 ${buttonsHidden ? '' : 'pl-5'}`}>
-		{#each options as option (option.id)}
 			<Checkbox
-				id={option.id}
-				name={option.name}
-				label={option.label}
-				color={option.color}
-				disabled={option.disabled}
-				hint={option.hint}
-				hintLabel={option.hintLabel}
-				bind:checked={selectionState[option.id]}
+				id={randomId()}
+				form=""
+				label="Select all"
+				color="#3787D2"
+				checked={allCheckboxesCheckedOrDisabled}
+				indeterminate={!allCheckboxesCheckedOrDisabled && !noCheckboxesChecked}
+				on:change={toggleAll}
+				{disabled}
 			/>
-		{/each}
+		{/if}
+
+		<div class={`flex flex-col space-y-1 ${buttonsHidden ? '' : 'pl-5'}`}>
+			{#each options as option (option.id)}
+				<Checkbox
+					id={option.id}
+					name={option.name}
+					label={option.label}
+					color={option.color}
+					disabled={option.disabled || disabled}
+					hint={option.hint}
+					hintLabel={option.hintLabel}
+					bind:checked={selectionState[option.id]}
+				/>
+			{/each}
+		</div>
 	</div>
-</div>
+</InputWrapper>

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
+	import Trigger from '../overlay/Trigger.svelte';
 	import Popover from '../popover/Popover.svelte';
 
-	import Trigger from '../overlay/Trigger.svelte';
+	import { NoSymbol } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+
 	import { currentTheme, tokenNameToValue } from '../theme/themeStore';
 
 	export let colorName = 'data.categorical.darkpink';
+
+	export let disabled = false;
 
 	const colorNames = [
 		'data.categorical.blue',
@@ -23,28 +28,38 @@
 	let isOpen = false;
 </script>
 
-<Popover bind:isOpen>
-	<Trigger slot="trigger" size="xs">
-		<div
-			class="w-[22px] h-[22px] relative border rounded-full"
-			style:background={tokenNameToValue(colorName, $currentTheme)}
-		></div>
-	</Trigger>
+{#if disabled}
+	<Icon
+		src={NoSymbol}
+		theme="mini"
+		class="w-6 h-6 text-color-action-disabled cursor-not-allowed"
+		aria-hidden="true"
+	/>
+{:else}
+	<Popover bind:isOpen>
+		<Trigger slot="trigger" size="xs">
+			<div
+				class="w-[22px] h-[22px] relative border rounded-full"
+				style:background={tokenNameToValue(colorName, $currentTheme)}
+			></div>
+			<span class="sr-only">Click to open color picker.</span>
+		</Trigger>
 
-	<svelte:fragment slot="title">Color</svelte:fragment>
+		<svelte:fragment slot="title">Color</svelte:fragment>
 
-	<span class="text-xs mb-2 inline-block">Click to assign a color to this layer.</span>
+		<span class="text-xs mb-2 inline-block">Click to assign a color to this layer.</span>
 
-	<div class="flex flex-wrap gap-2">
-		{#each colorNames as colorOption}
-			<button
-				class="w-6 h-6 rounded-full"
-				style:background={tokenNameToValue(colorOption, $currentTheme)}
-				on:click={() => {
-					colorName = colorOption;
-					isOpen = false;
-				}}
-			/>
-		{/each}
-	</div>
-</Popover>
+		<div class="flex flex-wrap gap-2">
+			{#each colorNames as colorOption}
+				<button
+					class="w-6 h-6 rounded-full"
+					style:background={tokenNameToValue(colorOption, $currentTheme)}
+					on:click={() => {
+						colorName = colorOption;
+						isOpen = false;
+					}}
+				/>
+			{/each}
+		</div>
+	</Popover>
+{/if}

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -7,7 +7,9 @@
 
 	import { currentTheme, tokenNameToValue } from '../theme/themeStore';
 
-	export let colorName = 'data.categorical.darkpink';
+	export let label;
+
+	export let colorName = 'data.primary';
 
 	export let disabled = false;
 
@@ -40,9 +42,9 @@
 		<Trigger slot="trigger" size="xs">
 			<div
 				class="w-[22px] h-[22px] relative border rounded-full"
+				aria-label="Click to open {label} layer color picker "
 				style:background={tokenNameToValue(colorName, $currentTheme)}
-			></div>
-			<span class="sr-only">Click to open color picker.</span>
+			/>
 		</Trigger>
 
 		<svelte:fragment slot="title">Color</svelte:fragment>

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -56,6 +56,7 @@
 				<button
 					class="w-6 h-6 rounded-full"
 					style:background={tokenNameToValue(colorOption, $currentTheme)}
+					aria-label="Color code: {colorOption}"
 					on:click={() => {
 						colorName = colorOption;
 						isOpen = false;

--- a/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
@@ -58,20 +58,20 @@
 		},
 		taxi: {
 			colorName: 'data.categorical.orange',
-			visible: true,
+			visible: false,
 			opacity: 1.0,
 			size: 1
 		}
 	};
 	let state2 = {
 		bus: {
-			color: '#00AEEF',
+			colorName: '#00AEEF',
 			visible: true,
 			opacity: 1.0,
 			size: 1
 		},
 		underground: {
-			color: '#9E0059',
+			colorName: '#9E0059',
 			visible: true,
 			opacity: 1.0,
 			size: 1
@@ -86,15 +86,53 @@
 
 <Story name="Default" source />
 
+<Story name="With label">
+	<LayerControlGroup
+		bind:options={optionsForGroup}
+		bind:state={state1}
+		hideOpacityControl
+		hideSizeControl
+		label="Layer Control Group"
+	/>
+
+	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
+</Story>
+
+<Story name="With hint">
+	<LayerControlGroup
+		bind:options={optionsForGroup}
+		bind:state={state1}
+		hideOpacityControl
+		hideSizeControl
+		label="Layer Control Group"
+		hint="Turn the layers of the map on and off"
+	/>
+
+	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
+</Story>
+
+<Story name="With description">
+	<LayerControlGroup
+		bind:options={optionsForGroup}
+		bind:state={state1}
+		hideOpacityControl
+		hideSizeControl
+		label="Layer Control Group"
+		hint="Turn the layers of the map on and off"
+		description="Transport layers - Taxis disabled"
+	/>
+
+	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
+</Story>
+
 <Story name="Hide controls size and opacity controls">
-	<div class="space-y-4">
-		<LayerControlGroup
-			bind:options={optionsForGroup}
-			bind:state={state1}
-			hideOpacityControl
-			hideSizeControl
-		/>
-	</div>
+	<LayerControlGroup
+		bind:options={optionsForGroup}
+		bind:state={state1}
+		hideOpacityControl
+		hideSizeControl
+	/>
+
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
 </Story>
 
@@ -124,6 +162,27 @@ For example, choropleth layers would cover each other.
 		bind:state={state1}
 		mutuallyExclusive
 		name="mutually-exclusive-layers"
+	/>
+
+	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
+</Story>
+
+<Story name="Disabled (global)">
+	<LayerControlGroup bind:options={optionsForGroup} bind:state={state1} disabled name="Disabled" />
+
+	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
+</Story>
+
+<Story name="With error">
+	<LayerControlGroup
+		bind:options={optionsForGroup}
+		bind:state={state1}
+		label="Preferred mode of transport"
+		hint="Contextual Hint"
+		description="Deselect all to see an error state!"
+		error={Object.values(state1).every((layer) => layer.visible === false)
+			? 'You must select an option'
+			: undefined}
 	/>
 
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>

--- a/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
@@ -10,15 +10,14 @@
 
 <script lang="ts">
 	let optionsForGroup = [
-		{ id: 'bus', label: 'Bus stops', colorName: 'data.categorical.blue' },
+		{ id: 'bus', label: 'Bus stops' },
 		{
 			id: 'train',
 			label: 'Train stations',
-			colorName: 'data.categorical.green',
 			hint: 'Excluding underground stations'
 		},
-		{ id: 'underground', label: 'Underground stations', colorName: 'data.categorical.darkpink' },
-		{ id: 'taxi', label: 'Taxi ranks', colorName: 'data.categorical.orange', disabled: true }
+		{ id: 'underground', label: 'Underground stations' },
+		{ id: 'taxi', label: 'Taxi ranks', disabled: true }
 	];
 
 	let optionsForGroup2 = [
@@ -31,8 +30,8 @@
 		{
 			id: 'underground',
 			label: 'Underground stations',
-			hideOpacityControl: true,
-			hideSizeControl: true
+			disableOpacityControl: true,
+			disableSizeControl: true
 		}
 	];
 
@@ -65,13 +64,19 @@
 	};
 	let state2 = {
 		bus: {
-			colorName: '#00AEEF',
+			colorName: 'data.categorical.blue',
+			visible: true,
+			opacity: 1.0,
+			size: 1
+		},
+		train: {
+			colorName: 'data.categorical.green',
 			visible: true,
 			opacity: 1.0,
 			size: 1
 		},
 		underground: {
-			colorName: '#9E0059',
+			colorName: 'data.categorical.darkpink',
 			visible: true,
 			opacity: 1.0,
 			size: 1
@@ -90,8 +95,8 @@
 	<LayerControlGroup
 		bind:options={optionsForGroup}
 		bind:state={state1}
-		hideOpacityControl
-		hideSizeControl
+		disableOpacityControl
+		disableSizeControl
 		label="Layer Control Group"
 	/>
 
@@ -102,8 +107,8 @@
 	<LayerControlGroup
 		bind:options={optionsForGroup}
 		bind:state={state1}
-		hideOpacityControl
-		hideSizeControl
+		disableOpacityControl
+		disableSizeControl
 		label="Layer Control Group"
 		hint="Turn the layers of the map on and off"
 	/>
@@ -115,8 +120,8 @@
 	<LayerControlGroup
 		bind:options={optionsForGroup}
 		bind:state={state1}
-		hideOpacityControl
-		hideSizeControl
+		disableOpacityControl
+		disableSizeControl
 		label="Layer Control Group"
 		hint="Turn the layers of the map on and off"
 		description="Transport layers - Taxis disabled"
@@ -129,16 +134,16 @@
 	<LayerControlGroup
 		bind:options={optionsForGroup}
 		bind:state={state1}
-		hideOpacityControl
-		hideSizeControl
+		disableOpacityControl
+		disableSizeControl
 	/>
 
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
 </Story>
 
-<Story name="Hide controls size and opacity controls for some layers">
+<Story name="Disable controls size and opacity controls for some layers">
 	<LayerControlGroup bind:options={optionsForGroup2} bind:state={state2} />
-	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
+	<pre class="mt-4 text-xs">{JSON.stringify(state2, null, 2)}</pre>
 </Story>
 
 <Story name="In small text size context">
@@ -146,8 +151,8 @@
 		<LayerControlGroup
 			bind:options={optionsForGroup}
 			bind:state={state1}
-			hideOpacityControl
-			hideSizeControl
+			disableOpacityControl
+			disableSizeControl
 		/>
 	</div>
 </Story>

--- a/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
@@ -68,19 +68,25 @@
 </Story>
 
 <Story name="Hide color control" source>
-	<LayerControl bind:state label="Borough" hideColorControl />
+	<LayerControl bind:state label="Borough" disableColorControl />
 </Story>
 
 <Story name="Hide opacity control" source>
-	<LayerControl bind:state label="Borough" hideOpacityControl />
+	<LayerControl bind:state label="Borough" disableOpacityControl />
 </Story>
 
 <Story name="Hide size control" source>
-	<LayerControl bind:state label="Borough" hideSizeControl />
+	<LayerControl bind:state label="Borough" disableSizeControl />
 </Story>
 
 <Story name="Checkbox only" source>
-	<LayerControl bind:state label="Borough" hideOpacityControl hideColorControl hideSizeControl />
+	<LayerControl
+		bind:state
+		label="Borough"
+		disableOpacityControl
+		disableColorControl
+		disableSizeControl
+	/>
 </Story>
 
 <Story name="Multiple control instances" source>
@@ -95,4 +101,14 @@
 
 		<pre>{JSON.stringify(state, null, 2)}</pre>
 	</div>
+</Story>
+
+<Story name="Disabled (Color)" source>
+	<LayerControl bind:state label="Borough" disableColorControl />
+</Story>
+<Story name="Disabled (Opacity)" source>
+	<LayerControl bind:state label="Borough" disableOpacityControl />
+</Story>
+<Story name="Disabled (Size)" source>
+	<LayerControl bind:state label="Borough" disableSizeControl />
 </Story>

--- a/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
@@ -9,8 +9,6 @@
 </script>
 
 <script lang="ts">
-	import Theme from '../theme/Theme.svelte';
-	import ThemeSwitcher from '../theme/ThemeSwitcher.svelte';
 	import { colorTokenNameToRGBArray, currentTheme, tokenNameToValue } from '../theme/themeStore';
 
 	let layerStates = {

--- a/packages/ui/src/lib/layerControl/LayerControl.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.svelte
@@ -11,20 +11,22 @@
 	import ColorPicker from './ColorPicker.svelte';
 	import ResizeControl from './ResizeControl.svelte';
 
+	import { randomId } from '../utils/randomId';
+
 	/**
 	 * if `true`, then the trigger to open the color picker is not displayed
 	 */
-	export let hideColorControl = false;
+	export let disableColorControl = false;
 
 	/**
 	 * if `true`, then the trigger to open the opacity control is not displayed
 	 */
-	export let hideOpacityControl = false;
+	export let disableOpacityControl = false;
 
 	/**
 	 * if `true`, then the trigger to open the size control is not displayed
 	 */
-	export let hideSizeControl = false;
+	export let disableSizeControl = false;
 
 	/**
 	 * the name of the layer
@@ -84,14 +86,20 @@
 	 */
 	export let selectedOptionId: string | undefined = undefined;
 	/**
-	 * Id of this option  (used only if `mutuallyExclusive` is true).
+	 * Id of this option.
 	 */
-	export let optionId = '';
+	export let optionId = randomId();
 
 	/**
 	 * Name of the radio button group  (used only if `mutuallyExclusive` is true)
 	 */
 	export let name = '';
+
+	/**
+	 * List of controls for which placeholder should be displayed in control is hidden.
+	 * This enables alignment of controls between different `LayerControl`s with different controls enabled,
+	 */
+	export let controlsInUse: ('color' | 'opacity' | 'size')[] = ['color', 'opacity', 'size'];
 </script>
 
 <div class="flex items-center space-x-1">
@@ -106,28 +114,36 @@
 				{name}
 			/>
 		{:else}
-			<Checkbox bind:checked={state.visible} label="" {disabled} />
+			<Checkbox bind:checked={state.visible} label="" {disabled} id={optionId} />
 		{/if}
 	</div>
 
-	{#if !hideColorControl}
-		<ColorPicker bind:colorName={state.colorName} />
+	{#if controlsInUse.includes('color')}
+		<ColorPicker bind:colorName={state.colorName} disabled={disabled || disableColorControl} />
 	{/if}
 
-	{#if !hideOpacityControl}
-		<OpacityControl bind:opacity={state.opacity} />
+	{#if controlsInUse.includes('opacity')}
+		<OpacityControl bind:opacity={state.opacity} disabled={disabled || disableOpacityControl} />
 	{/if}
 
-	{#if !hideSizeControl}
-		<ResizeControl bind:size={state.size} {minSize} {maxSize} />
+	{#if controlsInUse.includes('size')}
+		<ResizeControl
+			bind:size={state.size}
+			{minSize}
+			{maxSize}
+			disabled={disabled || disableSizeControl}
+		/>
 	{/if}
+
 	{#if label}
-		<span class="form-label font-normal leading-none">{label}</span>
+		<label class="form-label font-normal leading-none" for={optionId}>{label}</label>
 	{/if}
+
 	{#if $$slots.hint}
 		<!-- An optional `<Overlay>` component to provide additional explanation. -->
 		<slot name="hint" />
 	{/if}
+
 	{#if hint}
 		<Overlay>
 			<Trigger slot="trigger" size="xs" {hintLabel} />

--- a/packages/ui/src/lib/layerControl/LayerControl.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.svelte
@@ -5,7 +5,7 @@
 	 */
 	import Checkbox from '../checkBox/Checkbox.svelte';
 	import OpacityControl from '../layerControl/OpacityControl.svelte';
-	import Tooltip from '../tooltip/Tooltip.svelte';
+	import Overlay from '../overlay/Overlay.svelte';
 	import ColorPicker from './ColorPicker.svelte';
 	import ResizeControl from './ResizeControl.svelte';
 
@@ -30,9 +30,16 @@
 	export let label = '';
 
 	/**
-	 * (optional) explanatory help text to be displayed in tooltip
+	 * Optional help text that appears in a tooltip when a user interacts with the tooltip trigger.
+	 * It provides additional information intended to help the user decide whether to check the checkbox.
 	 */
 	export let hint = '';
+
+	/**
+	 * Optional text that appears next to the information icon (the letter "i" in a circle) in the tooltip trigger.
+	 * It provides additional clues that help text is available (e.g. "More information", "About", "Help")
+	 */
+	export let hintLabel = '';
 
 	export let disabled = false;
 
@@ -85,34 +92,13 @@
 	{#if label}
 		<span class="form-label font-normal leading-none">{label}</span>
 	{/if}
+	{#if $$slots.hint}
+		<!-- An optional `<Overlay>` component to provide additional explanation. -->
+		<slot name="hint" />
+	{/if}
 	{#if hint}
-		<Tooltip hintLabel="">
+		<Overlay {hintLabel}>
 			{hint}
-		</Tooltip>
+		</Overlay>
 	{/if}
 </div>
-
-<!-- <div class="flex items-center content-center space-x-1">
-	<div class="flex items-center content-center space-x-1">
-		<Checkbox bind:checked={state.visible} label="" {disabled} />
-
-		{#if !hideColorControl}
-			<ColorPicker bind:color={state.color} />
-		{/if}
-
-		{#if !hideOpacityControl}
-			<OpacityControl bind:opacity={state.opacity} />
-		{/if}
-
-		{#if !hideSizeControl}
-			<ResizeControl bind:size={state.size} {minSize} {maxSize} />
-		{/if}
-	</div>
-
-	<div class="flex pl-1">
-		{label}
-		{#if hint}
-			<Tooltip hintLabel="">{hint}</Tooltip>
-		{/if}
-	</div>
-</div> -->

--- a/packages/ui/src/lib/layerControl/LayerControl.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.svelte
@@ -119,11 +119,19 @@
 	</div>
 
 	{#if controlsInUse.includes('color')}
-		<ColorPicker bind:colorName={state.colorName} disabled={disabled || disableColorControl} />
+		<ColorPicker
+			bind:colorName={state.colorName}
+			disabled={disabled || disableColorControl}
+			{label}
+		/>
 	{/if}
 
 	{#if controlsInUse.includes('opacity')}
-		<OpacityControl bind:opacity={state.opacity} disabled={disabled || disableOpacityControl} />
+		<OpacityControl
+			bind:opacity={state.opacity}
+			disabled={disabled || disableOpacityControl}
+			{label}
+		/>
 	{/if}
 
 	{#if controlsInUse.includes('size')}
@@ -132,6 +140,7 @@
 			{minSize}
 			{maxSize}
 			disabled={disabled || disableSizeControl}
+			{label}
 		/>
 	{/if}
 

--- a/packages/ui/src/lib/layerControl/LayerControl.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.svelte
@@ -92,11 +92,6 @@
 	 * Name of the radio button group  (used only if `mutuallyExclusive` is true)
 	 */
 	export let name = '';
-
-	/**
-	 * text that appears in the hint tooltip target, next to the icon
-	 */
-	export let hintLabel = '';
 </script>
 
 <div class="flex items-center space-x-1">

--- a/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
@@ -6,10 +6,64 @@
 	 */
 
 	import Checkbox from '../checkBox/Checkbox.svelte';
+	import InputWrapper from '../input/InputWrapper.svelte';
 
+	import Button from '../button/Button.svelte';
 	import { randomId } from '../utils/randomId';
 	import LayerControl from './LayerControl.svelte';
-	import Button from '../button/Button.svelte';
+
+	/**
+	 * The `id` of the `<input>` element: defaults to a randomly-generated value.
+	 */
+	export let id = randomId();
+
+	/**
+	 * Text displayed above the `<input>` element.
+	 */
+	export let label = '';
+
+	/**
+	 * Text that appears below the `<input>` element, in smaller font than the `label`.
+	 */
+	export let description = '';
+
+	/**
+	 * Determines which edge of the `<input>` the description is aligned with.
+	 */
+	export let descriptionAlignment: 'left' | 'right' = 'left';
+
+	/**
+	 * Help text to be displayed in tooltip
+	 */
+	export let hint = '';
+
+	/**
+	 * Text to be displayed next to icon in tooltip trigger.
+	 */
+	export let hintLabel: undefined | string = undefined;
+
+	/**
+	 * If `false`, then `required` attribute is applied to `<input>`.
+	 */
+	export let optional = false;
+
+	/**
+	 * If `true`, then user is prevented from interacting with the `<input>`.
+	 */
+	export let disabled = false;
+
+	/**
+	 * Message to be displayed below `<input>` in red text (replacing description).
+	 * If set, then the border of the `<input>` is also red.
+	 */
+	export let error = '';
+
+	/**
+	 * Only generate `descriptionId` and/or `errorId` when `description` and/or `error` exist.
+	 * `descriptionId` is static but `errorId` is reactive as error state could change.
+	 */
+	const descriptionId = description ? `${id}-description` : undefined;
+	$: errorId = error ? `${id}-error` : undefined;
 
 	/**
 	 * Each element of this array defines the control for a layer, and is an object with the properties:
@@ -110,7 +164,7 @@
 	};
 
 	let selectedOptionId: string | undefined; // only used by radioButtons, if mutuallyExclusive
-	const updateStateFromCheckbox = (selectedId) => {
+	const updateStateFromCheckbox = (selectedId: string | undefined) => {
 		// For Radio Buttons, state is updated by LayerControlGroup.
 		// For Checkboxes, each LayerControl updates part of state directly.
 		for (const o of options) {
@@ -126,53 +180,69 @@
 	$: mutuallyExclusive && updateStateFromCheckbox(selectedOptionId);
 </script>
 
-<div class="flex flex-col space-y-1">
-	{#if mutuallyExclusive}
-		{#if !buttonsHidden}
-			<Button variant="text" class="!px-0" on:click={clearRadioButtons}>Clear</Button>
-		{/if}
+<InputWrapper
+	{label}
+	{id}
+	{descriptionId}
+	{description}
+	{descriptionAlignment}
+	{hintLabel}
+	{hint}
+	{errorId}
+	{error}
+	{disabled}
+	{optional}
+>
+	<slot name="hint" slot="hint" />
+	<div class="flex flex-col space-y-1">
+		{#if mutuallyExclusive}
+			{#if !buttonsHidden}
+				<Button {disabled} variant="text" class="!px-0" on:click={clearRadioButtons}>Clear</Button>
+			{/if}
 
-		<div class={'flex flex-col space-y-1'}>
-			{#each options as option}
-				<LayerControl
-					label={option.label}
-					{name}
-					bind:state={state[option.id]}
-					optionId={option.id}
-					disabled={option.disabled}
-					bind:selectedOptionId
-					mutuallyExclusive
-				/>
-			{/each}
-		</div>
-	{:else}
-		{#if !buttonsHidden}
-			<!--
+			<div class={'flex flex-col space-y-1'}>
+				{#each options as option}
+					<LayerControl
+						label={option.label}
+						{name}
+						bind:state={state[option.id]}
+						optionId={option.id}
+						disabled={option.disabled || disabled}
+						bind:selectedOptionId
+						mutuallyExclusive
+					/>
+				{/each}
+			</div>
+		{:else}
+			{#if !buttonsHidden}
+				<!--
         form="" should prevent this checkbox from being included in form
         submissions.
       -->
-			<Checkbox
-				id={randomId()}
-				form=""
-				label={showAllLabel}
-				checked={allCheckboxesCheckedOrDisabled}
-				indeterminate={!allCheckboxesCheckedOrDisabled && !noCheckboxesChecked}
-				on:change={toggleAll}
-			/>
-		{/if}
-
-		<div class={`flex flex-col space-y-1 ${buttonsHidden ? '' : 'pl-5'}`}>
-			{#each options as option (option.id)}
-				<LayerControl
-					label={option.label}
-					disabled={option.disabled}
-					hint={option.hint}
-					hideColorControl={hideColorControl || option.hideColorControl}
-					hideOpacityControl={hideOpacityControl || option.hideOpacityControl}
-					hideSizeControl={hideSizeControl || option.hideSizeControl}
-					bind:state={state[option.id]}
+				<Checkbox
+					id={randomId()}
+					form=""
+					label={showAllLabel}
+					checked={allCheckboxesCheckedOrDisabled}
+					indeterminate={!allCheckboxesCheckedOrDisabled && !noCheckboxesChecked}
+					on:change={toggleAll}
+					{disabled}
 				/>
-			{/each}
-		</div>
-	{/if}
-</div>
+			{/if}
+
+			<div class={`flex flex-col space-y-1 ${buttonsHidden ? '' : 'pl-5'}`}>
+				{#each options as option (option.id)}
+					<LayerControl
+						label={option.label}
+						disabled={option.disabled || disabled}
+						hint={option.hint}
+						hideColorControl={hideColorControl || option.hideColorControl}
+						hideOpacityControl={hideOpacityControl || option.hideOpacityControl}
+						hideSizeControl={hideSizeControl || option.hideSizeControl}
+						bind:state={state[option.id]}
+					/>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</InputWrapper>

--- a/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
@@ -71,9 +71,9 @@
 	 * * `label` (string) - the text displayed next to the checkbox
 	 * * `hint` (string, optional) - help text to be displayed in tooltip
 	 *
-	 * * `hideColorControl` (boolean) - if `true`, then the trigger to open the opacity control for this layer is not displayed
-	 * * `hideOpacityControl` (boolean) - if `true`, then the trigger to open the opacity control for this layer is not displayed
-	 * * `hideSizeControl` (boolean) - if `true`, then the trigger to open the opacity control for this layer is not displayed
+	 * * `disableColorControl` (boolean) - if `true`, then the trigger to open the opacity control for this layer is not displayed
+	 * * `disableOpacityControl` (boolean) - if `true`, then the trigger to open the opacity control for this layer is not displayed
+	 * * `disableSizeControl` (boolean) - if `true`, then the trigger to open the opacity control for this layer is not displayed
 	 *
 	 * * `disabled` (boolean, optional) - if `true`, users cannot change whether the checkbox is checked
 	 * * `color` (string, optional) - color of the layer
@@ -87,9 +87,9 @@
 		hint?: string;
 
 		disabled?: boolean;
-		hideColorControl?: boolean;
-		hideOpacityControl?: boolean;
-		hideSizeControl?: boolean;
+		disableColorControl?: boolean;
+		disableOpacityControl?: boolean;
+		disableSizeControl?: boolean;
 	}[] = [];
 
 	type LayerControlGroupState = Record<
@@ -115,17 +115,17 @@
 	/**
 	 * if `true`, then the trigger to open the color picker is not displayed for any layers
 	 */
-	export let hideColorControl = false;
+	export let disableColorControl = false;
 
 	/**
 	 * if `true`, then the trigger to open the opacity control is not displayed for any layers
 	 */
-	export let hideOpacityControl = false;
+	export let disableOpacityControl = false;
 
 	/**
 	 * if `true`, then the trigger to open the size control is not displayed for any layers
 	 */
-	export let hideSizeControl = false;
+	export let disableSizeControl = false;
 
 	/**
 	 * Message to be displayed next to the checkbox that toggles the visibility of all layers.
@@ -178,6 +178,21 @@
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 	$: mutuallyExclusive && updateStateFromCheckbox(selectedOptionId);
+
+	// construct list of controls which are in use
+	let controlsInUse: ('color' | 'opacity' | 'size')[] = [];
+	$: {
+		controlsInUse = [];
+		if (!disableColorControl && !options.every((l) => l.disableColorControl)) {
+			controlsInUse.push('color');
+		}
+		if (!disableOpacityControl && !options.every((l) => l.disableOpacityControl)) {
+			controlsInUse.push('opacity');
+		}
+		if (!disableSizeControl && !options.every((l) => l.disableSizeControl)) {
+			controlsInUse.push('size');
+		}
+	}
 </script>
 
 <InputWrapper
@@ -236,10 +251,11 @@
 						label={option.label}
 						disabled={option.disabled || disabled}
 						hint={option.hint}
-						hideColorControl={hideColorControl || option.hideColorControl}
-						hideOpacityControl={hideOpacityControl || option.hideOpacityControl}
-						hideSizeControl={hideSizeControl || option.hideSizeControl}
+						disableColorControl={disableColorControl || option.disableColorControl}
+						disableOpacityControl={disableOpacityControl || option.disableOpacityControl}
+						disableSizeControl={disableSizeControl || option.disableSizeControl}
 						bind:state={state[option.id]}
+						{controlsInUse}
 					/>
 				{/each}
 			</div>

--- a/packages/ui/src/lib/layerControl/OpacityControl.svelte
+++ b/packages/ui/src/lib/layerControl/OpacityControl.svelte
@@ -1,27 +1,41 @@
 <script lang="ts">
 	import Input from '../input/Input.svelte';
-
 	import Trigger from '../overlay/Trigger.svelte';
+
+	import { NoSymbol } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+
 	import Popover from '../popover/Popover.svelte';
 	import OpacityIcon from './OpacityIcon.svelte';
 
 	export let opacity = 1;
+	export let disabled = false;
 </script>
 
-<Popover>
-	<Trigger slot="trigger" size="xs">
-		<OpacityIcon
-			class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
-			aria-hidden="true"
-		/>
-	</Trigger>
+{#if disabled}
+	<Icon
+		src={NoSymbol}
+		theme="mini"
+		class="w-6 h-6 text-color-action-disabled cursor-not-allowed"
+		aria-hidden="true"
+	/>
+{:else}
+	<Popover>
+		<Trigger slot="trigger" size="xs">
+			<OpacityIcon
+				class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
+				aria-hidden="true"
+			/>
+			<span class="sr-only">Click to open opacity control.</span>
+		</Trigger>
 
-	<svelte:fragment slot="title">Opacity</svelte:fragment>
+		<svelte:fragment slot="title">Opacity</svelte:fragment>
 
-	<div class="flex gap-4 items-center pt-2">
-		<div class="w-32">
-			<input type="range" class="w-32" bind:value={opacity} min="0" max="1" step="0.01" />
+		<div class="flex gap-4 items-center">
+			<div class="w-32">
+				<input type="range" class="w-32" bind:value={opacity} min="0" max="1" step="0.01" />
+			</div>
+			<div class="w-16"><Input bind:value={opacity} type="number" min="0" max="1"></Input></div>
 		</div>
-		<div class="w-16"><Input bind:value={opacity} type="number" min="0" max="1"></Input></div>
-	</div>
-</Popover>
+	</Popover>
+{/if}

--- a/packages/ui/src/lib/layerControl/OpacityControl.svelte
+++ b/packages/ui/src/lib/layerControl/OpacityControl.svelte
@@ -8,6 +8,8 @@
 	import Popover from '../popover/Popover.svelte';
 	import OpacityIcon from './OpacityIcon.svelte';
 
+	export let label;
+
 	export let opacity = 1;
 	export let disabled = false;
 </script>
@@ -26,7 +28,7 @@
 				class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
 				aria-hidden="true"
 			/>
-			<span class="sr-only">Click to open opacity control.</span>
+			<span class="sr-only">Click to open {label} opacity control.</span>
 		</Trigger>
 
 		<svelte:fragment slot="title">Opacity</svelte:fragment>

--- a/packages/ui/src/lib/layerControl/ResizeControl.svelte
+++ b/packages/ui/src/lib/layerControl/ResizeControl.svelte
@@ -1,27 +1,43 @@
 <script lang="ts">
 	import Trigger from '../overlay/Trigger.svelte';
 	import Popover from '../popover/Popover.svelte';
+
+	import { NoSymbol } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+
 	import ResizeIcon from './ResizeIcon.svelte';
 
 	export let size = 1;
 
 	export let minSize;
 	export let maxSize;
+
+	export let disabled = false;
 </script>
 
-<Popover>
-	<Trigger slot="trigger" size="xs">
-		<ResizeIcon
-			class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
-			aria-hidden="true"
-		/>
-	</Trigger>
+{#if disabled}
+	<Icon
+		src={NoSymbol}
+		theme="mini"
+		class="w-6 h-6 text-color-action-disabled cursor-not-allowed"
+		aria-hidden="true"
+	/>
+{:else}
+	<Popover>
+		<Trigger slot="trigger" size="xs">
+			<ResizeIcon
+				class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
+				aria-hidden="true"
+			/>
+			<span class="sr-only">Click to open marker size control.</span>
+		</Trigger>
 
-	<svelte:fragment slot="title">Marker size</svelte:fragment>
+		<svelte:fragment slot="title">Marker size</svelte:fragment>
 
-	<div class="flex gap-4 items-center pt-2">
-		<div class="w-40">
-			<input type="range" bind:value={size} min={minSize} max={maxSize} step="0.01" />
+		<div class="flex gap-4 items-center pt-2">
+			<div class="w-40">
+				<input type="range" bind:value={size} min={minSize} max={maxSize} step="0.01" />
+			</div>
 		</div>
-	</div>
-</Popover>
+	</Popover>
+{/if}

--- a/packages/ui/src/lib/layerControl/ResizeControl.svelte
+++ b/packages/ui/src/lib/layerControl/ResizeControl.svelte
@@ -7,6 +7,8 @@
 
 	import ResizeIcon from './ResizeIcon.svelte';
 
+	export let label;
+
 	export let size = 1;
 
 	export let minSize;
@@ -29,7 +31,7 @@
 				class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
 				aria-hidden="true"
 			/>
-			<span class="sr-only">Click to open marker size control.</span>
+			<span class="sr-only">Click to open {label} marker size control</span>
 		</Trigger>
 
 		<svelte:fragment slot="title">Marker size</svelte:fragment>

--- a/packages/ui/src/lib/radioButton/RadioButton.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButton.svelte
@@ -70,7 +70,9 @@
 			? `--theme-input-border: ${color}; --theme-input-border-selected: ${color}; --theme-input-background-active: ${color}; --tw-ring-color: ${color};`
 			: ''}
 	/>
-	<span class="form-label ml-2 font-normal">{label}</span>
+	{#if label}
+		<span class="form-label ml-2 font-normal">{label}</span>
+	{/if}
 	{#if $$slots.hint}
 		<!-- An optional `<Overlay>` component to provide additional explanation. -->
 		<slot name="hint" />

--- a/packages/ui/src/lib/radioButton/RadioButton.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButton.svelte
@@ -6,7 +6,7 @@
 	 * @component
 	 */
 
-	import Tooltip from '../tooltip/Tooltip.svelte';
+	import Overlay from '../overlay/Overlay.svelte';
 
 	/**
 	 * Color of the radio button, as a string in any CSS color format
@@ -71,10 +71,14 @@
 			: ''}
 	/>
 	<span class="form-label ml-2 font-normal">{label}</span>
+	{#if $$slots.hint}
+		<!-- An optional `<Overlay>` component to provide additional explanation. -->
+		<slot name="hint" />
+	{/if}
 	{#if hint}
-		<Tooltip {hintLabel}>
+		<Overlay {hintLabel}>
 			{hint}
-		</Tooltip>
+		</Overlay>
 	{/if}
 </label>
 

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
@@ -10,6 +10,7 @@
 
 <script lang="ts">
 	let selectedId: string;
+	let selectedId2: undefined | string = undefined;
 
 	let optionsForGroup = [
 		{ id: 'bus', label: 'Bus stops', color: '#00AEEF' },
@@ -31,7 +32,12 @@
 
 <Story name="Default" source />
 
-<Story name="RadioGroup">
+<Story name="With title">
+	<RadioButtonGroup options={optionsForGroup} name="station-type" bind:selectedId label="Radio" />
+	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
+</Story>
+
+<Story name="With hint">
 	<RadioButtonGroup
 		options={optionsForGroup}
 		name="station-type"
@@ -42,17 +48,55 @@
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>
 
-<Story name="RadioGroup - no clear button">
+<Story name="With description">
+	<RadioButtonGroup
+		options={optionsForGroup}
+		buttonsHidden
+		name="station-type"
+		bind:selectedId
+		label="Transport method"
+		description="Pick you prefered method of transport - taxis are currently not available"
+	/>
+	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
+</Story>
+
+<Story name="No clear button">
 	<RadioButtonGroup options={optionsForGroup} name="station-type" bind:selectedId buttonsHidden />
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>
 
-<Story name="RadioGroup - aligned in row">
+<Story name="Aligned in row">
 	<RadioButtonGroup
 		options={optionsForGroup}
 		name="station-type"
 		bind:selectedId
 		orientation="horizontal"
+	/>
+	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
+</Story>
+
+<Story name="Disabled (global)">
+	<RadioButtonGroup
+		options={optionsForGroup}
+		name="station-type"
+		bind:selectedId
+		label="RadioGroup Label"
+		hint="Contextual Hint"
+		description="This is a description"
+		disabled
+	/>
+	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
+</Story>
+
+<Story name="With error">
+	<RadioButtonGroup
+		options={optionsForGroup}
+		name="station-type"
+		bind:selectedId={selectedId2}
+		label="Preferred mode of transport"
+		hint="Contextual Hint"
+		description="How you prefer to get around London."
+		error={!selectedId2 ? 'You must select an option' : undefined}
 	/>
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
@@ -10,7 +10,7 @@
 
 <script lang="ts">
 	let selectedId: string;
-	let selectedId2: undefined | string = undefined;
+	let selectedId2: string = '';
 
 	let optionsForGroup = [
 		{ id: 'bus', label: 'Bus stops', color: '#00AEEF' },

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
@@ -32,7 +32,13 @@
 <Story name="Default" source />
 
 <Story name="RadioGroup">
-	<RadioButtonGroup options={optionsForGroup} name="station-type" bind:selectedId />
+	<RadioButtonGroup
+		options={optionsForGroup}
+		name="station-type"
+		bind:selectedId
+		label="Radio"
+		hint="gaga"
+	/>
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>
 

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
@@ -55,7 +55,7 @@
 		name="station-type"
 		bind:selectedId
 		label="Transport method"
-		description="Pick you prefered method of transport - taxis are currently not available"
+		description="Pick you preferred method of transport - taxis are currently not available"
 	/>
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
@@ -123,15 +123,21 @@
 	<slot name="hint" slot="hint" />
 	<div class="flex flex-col space-y-0.5">
 		{#if !buttonsHidden}
-			<Button variant="text" class="!px-0" on:click={() => (selectedId = '')}>Clear</Button>
+			<Button {disabled} variant="text" class="!px-0" size="sm" on:click={() => (selectedId = '')}
+				>Clear</Button
+			>
 		{/if}
-		<div class={orientation === 'vertical' ? 'flex flex-col space-y-1' : 'flex space-x-3'}>
+		<div
+			class={orientation === 'vertical'
+				? 'flex flex-col space-y-1'
+				: 'flex gap-x-3 gap-y-1 flex-wrap'}
+		>
 			{#each options as option}
 				<RadioButton
 					id={option.id}
 					label={option.label}
 					color={option.color}
-					disabled={option.disabled}
+					disabled={option.disabled || disabled}
 					hint={option.hint}
 					hintLabel={option.hintLabel}
 					bind:selectedId

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
@@ -6,9 +6,63 @@
 	 * If the number of alternatives is small and one must be selected, consider using the [RadioButtonSolid](./?path=/docs/ui-components-radiobuttons-radiobuttongroupsolid--documentation).
 	 * @component
 	 */
-
 	import Button from '../button/Button.svelte';
+	import InputWrapper from '../input/InputWrapper.svelte';
+	import { randomId } from '../utils/randomId';
 	import RadioButton from './RadioButton.svelte';
+
+	/**
+	 * The `id` of the `<input>` element: defaults to a randomly-generated value.
+	 */
+	export let id = randomId();
+
+	/**
+	 * Text displayed above the `<input>` element.
+	 */
+	export let label = '';
+
+	/**
+	 * Text that appears below the `<input>` element, in smaller font than the `label`.
+	 */
+	export let description = '';
+
+	/**
+	 * Determines which edge of the `<input>` the description is aligned with.
+	 */
+	export let descriptionAlignment: 'left' | 'right' = 'left';
+
+	/**
+	 * Help text to be displayed in tooltip
+	 */
+	export let hint = '';
+
+	/**
+	 * Text to be displayed next to icon in tooltip trigger.
+	 */
+	export let hintLabel: undefined | string = undefined;
+
+	/**
+	 * If `false`, then `required` attribute is applied to `<input>`.
+	 */
+	export let optional = false;
+
+	/**
+	 * If `true`, then user is prevented from interacting with the `<input>`.
+	 */
+	export let disabled = false;
+
+	/**
+	 * Message to be displayed below `<input>` in red text (replacing description).
+	 * If set, then the border of the `<input>` is also red.
+	 */
+	export let error = '';
+
+	/**
+	 * Only generate `descriptionId` and/or `errorId` when `description` and/or `error` exist.
+	 * `descriptionId` is static but `errorId` is reactive as error state could change.
+	 */
+	const descriptionId = description ? `${id}-description` : undefined;
+	$: errorId = error ? `${id}-error` : undefined;
 
 	/**
 	 * the `id` of the entry in the `options` array that is currently selected.
@@ -53,22 +107,37 @@
 	export let buttonsHidden = false;
 </script>
 
-<div class="flex flex-col space-y-0.5">
-	{#if !buttonsHidden}
-		<Button variant="text" class="!px-0" on:click={() => (selectedId = '')}>Clear</Button>
-	{/if}
-	<div class={orientation === 'vertical' ? 'flex flex-col space-y-1' : 'flex space-x-3'}>
-		{#each options as option}
-			<RadioButton
-				id={option.id}
-				label={option.label}
-				color={option.color}
-				disabled={option.disabled}
-				hint={option.hint}
-				hintLabel={option.hintLabel}
-				bind:selectedId
-				{name}
-			/>
-		{/each}
+<InputWrapper
+	{label}
+	{id}
+	{descriptionId}
+	{description}
+	{descriptionAlignment}
+	{hintLabel}
+	{hint}
+	{errorId}
+	{error}
+	{disabled}
+	{optional}
+>
+	<slot name="hint" slot="hint" />
+	<div class="flex flex-col space-y-0.5">
+		{#if !buttonsHidden}
+			<Button variant="text" class="!px-0" on:click={() => (selectedId = '')}>Clear</Button>
+		{/if}
+		<div class={orientation === 'vertical' ? 'flex flex-col space-y-1' : 'flex space-x-3'}>
+			{#each options as option}
+				<RadioButton
+					id={option.id}
+					label={option.label}
+					color={option.color}
+					disabled={option.disabled}
+					hint={option.hint}
+					hintLabel={option.hintLabel}
+					bind:selectedId
+					{name}
+				/>
+			{/each}
+		</div>
 	</div>
-</div>
+</InputWrapper>

--- a/packages/ui/src/lib/radioButtonSolid/RadioButtonGroupSolid.svelte
+++ b/packages/ui/src/lib/radioButtonSolid/RadioButtonGroupSolid.svelte
@@ -118,7 +118,12 @@
 	<div class="flex">
 		{#if options.length}
 			{#each options as option}
-				<RadioButtonSolid id={option.id} label={option.label} disabled={option.disabled} {name} />
+				<RadioButtonSolid
+					id={option.id}
+					label={option.label}
+					disabled={option.disabled || disabled}
+					{name}
+				/>
 			{/each}
 		{:else}
 			<!-- should contain a series of `<RadioButtonSolid>` components  -->

--- a/packages/ui/src/lib/radioButtonSolid/RadioButtonGroupSolid.svelte
+++ b/packages/ui/src/lib/radioButtonSolid/RadioButtonGroupSolid.svelte
@@ -8,7 +8,62 @@
 
 	import { setContext } from 'svelte';
 	import { writable, type Writable } from 'svelte/store';
+	import InputWrapper from '../input/InputWrapper.svelte';
+	import { randomId } from '../utils/randomId';
 	import RadioButtonSolid from './RadioButtonSolid.svelte';
+
+	/**
+	 * The `id` of the `<input>` element: defaults to a randomly-generated value.
+	 */
+	export let id = randomId();
+
+	/**
+	 * Text displayed above the `<input>` element.
+	 */
+	export let label = '';
+
+	/**
+	 * Text that appears below the `<input>` element, in smaller font than the `label`.
+	 */
+	export let description = '';
+
+	/**
+	 * Determines which edge of the `<input>` the description is aligned with.
+	 */
+	export let descriptionAlignment: 'left' | 'right' = 'left';
+
+	/**
+	 * Help text to be displayed in tooltip
+	 */
+	export let hint = '';
+
+	/**
+	 * Text to be displayed next to icon in tooltip trigger.
+	 */
+	export let hintLabel: undefined | string = undefined;
+
+	/**
+	 * If `false`, then `required` attribute is applied to `<input>`.
+	 */
+	export let optional = false;
+
+	/**
+	 * If `true`, then user is prevented from interacting with the `<input>`.
+	 */
+	export let disabled = false;
+
+	/**
+	 * Message to be displayed below `<input>` in red text (replacing description).
+	 * If set, then the border of the `<input>` is also red.
+	 */
+	export let error = '';
+
+	/**
+	 * Only generate `descriptionId` and/or `errorId` when `description` and/or `error` exist.
+	 * `descriptionId` is static but `errorId` is reactive as error state could change.
+	 */
+	const descriptionId = description ? `${id}-description` : undefined;
+	$: errorId = error ? `${id}-error` : undefined;
 
 	/**
 	 * the `id` of the entry in the `options` array that is currently selected.
@@ -46,13 +101,28 @@
 	}
 </script>
 
-<div class="flex">
-	{#if options.length}
-		{#each options as option}
-			<RadioButtonSolid id={option.id} label={option.label} disabled={option.disabled} {name} />
-		{/each}
-	{:else}
-		<!-- should contain a series of `<RadioButtonSolid>` components  -->
-		<slot />
-	{/if}
-</div>
+<InputWrapper
+	{label}
+	{id}
+	{descriptionId}
+	{description}
+	{descriptionAlignment}
+	{hintLabel}
+	{hint}
+	{errorId}
+	{error}
+	{disabled}
+	{optional}
+>
+	<slot name="hint" slot="hint" />
+	<div class="flex">
+		{#if options.length}
+			{#each options as option}
+				<RadioButtonSolid id={option.id} label={option.label} disabled={option.disabled} {name} />
+			{/each}
+		{:else}
+			<!-- should contain a series of `<RadioButtonSolid>` components  -->
+			<slot />
+		{/if}
+	</div>
+</InputWrapper>

--- a/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.stories.svelte
+++ b/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.stories.svelte
@@ -124,3 +124,14 @@ different values as the `name` prop.
 	</RadioButtonGroupSolid>
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>
+
+<Story name="RadioGroup with wrapper">
+	<RadioButtonGroupSolid
+		options={optionsForGroup}
+		name="station-type"
+		bind:selectedId
+		label="RadioGroup"
+		hint="Contextual Hint"
+	/>
+	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
+</Story>

--- a/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.stories.svelte
+++ b/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.stories.svelte
@@ -27,8 +27,41 @@
 	];
 </script>
 
-<Story name="RadioGroup">
+<Story name="Default">
 	<RadioButtonGroupSolid options={optionsForGroup} name="station-type" bind:selectedId />
+	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
+</Story>
+
+<Story name="With title">
+	<RadioButtonGroupSolid
+		options={optionsForGroup}
+		name="station-type"
+		bind:selectedId
+		label="RadioGroup Label"
+	/>
+	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
+</Story>
+
+<Story name="With description">
+	<RadioButtonGroupSolid
+		options={optionsForGroup}
+		name="station-type"
+		bind:selectedId
+		label="RadioGroup Label"
+		description="This is a description"
+	/>
+	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
+</Story>
+
+<Story name="With hint">
+	<RadioButtonGroupSolid
+		options={optionsForGroup}
+		name="station-type"
+		bind:selectedId
+		label="RadioGroup Label"
+		hint="Contextual Hint"
+		description="This is a description"
+	/>
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>
 
@@ -54,7 +87,7 @@ different values as the `name` prop.
 	</div>
 </Story>
 
-<Story name="RadioGroup with Icons above">
+<Story name="With Icons above">
 	<RadioButtonGroupSolid name="station-type" bind:selectedId>
 		<RadioButtonSolid id="bus" name="station-type-bus">
 			<Icon src={Funnel} theme="mini" class="w-5 h-5 mb-1" aria-hidden="true" />
@@ -72,7 +105,7 @@ different values as the `name` prop.
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>
 
-<Story name="RadioGroup with Icons below">
+<Story name="With Icons below">
 	<RadioButtonGroupSolid name="station-type" bind:selectedId>
 		<RadioButtonSolid id="bus" name="station-type-bus">
 			Bus
@@ -126,19 +159,7 @@ different values as the `name` prop.
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>
 
-<Story name="RadioGroup with wrapper">
-	<RadioButtonGroupSolid
-		options={optionsForGroup}
-		name="station-type"
-		bind:selectedId
-		label="RadioGroup Label"
-		hint="Contextual Hint"
-		description="This is a description"
-	/>
-	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
-</Story>
-
-<Story name="RadioGroup with wrapper disabled">
+<Story name="Disabled (global)">
 	<RadioButtonGroupSolid
 		options={optionsForGroup}
 		name="station-type"
@@ -151,7 +172,7 @@ different values as the `name` prop.
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>
 
-<Story name="RadioGroup with error">
+<Story name="With error">
 	<RadioButtonGroupSolid
 		options={optionsForGroup}
 		name="station-type"

--- a/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.stories.svelte
+++ b/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.stories.svelte
@@ -17,6 +17,7 @@
 
 	let selectedId = 'bus';
 	let selectedId2 = 'train';
+	let selectedId3: undefined | string = undefined;
 
 	let optionsForGroup = [
 		{ id: 'bus', label: 'Bus stops' },
@@ -146,6 +147,19 @@ different values as the `name` prop.
 		hint="Contextual Hint"
 		description="This is a description"
 		disabled
+	/>
+	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
+</Story>
+
+<Story name="RadioGroup with error">
+	<RadioButtonGroupSolid
+		options={optionsForGroup}
+		name="station-type"
+		bind:selectedId={selectedId3}
+		label="Preferred mode of transport"
+		hint="Contextual Hint"
+		description="How you prefer to get around London."
+		error={!selectedId3 ? 'You must select an option' : undefined}
 	/>
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>

--- a/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.stories.svelte
+++ b/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.stories.svelte
@@ -130,8 +130,22 @@ different values as the `name` prop.
 		options={optionsForGroup}
 		name="station-type"
 		bind:selectedId
-		label="RadioGroup"
+		label="RadioGroup Label"
 		hint="Contextual Hint"
+		description="This is a description"
+	/>
+	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
+</Story>
+
+<Story name="RadioGroup with wrapper disabled">
+	<RadioButtonGroupSolid
+		options={optionsForGroup}
+		name="station-type"
+		bind:selectedId
+		label="RadioGroup Label"
+		hint="Contextual Hint"
+		description="This is a description"
+		disabled
 	/>
 	<p class="mt-8 text-color-text-secondary">Selected id: {selectedId}</p>
 </Story>

--- a/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.svelte
+++ b/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.svelte
@@ -42,6 +42,7 @@
 		{name}
 		bind:group={$selectedId}
 		value={id}
+		aria-disabled={disabled}
 		{disabled}
 		class="peer absolute top-0 left-0 opacity-0"
 	/>
@@ -51,7 +52,7 @@
 			disabled
 				? 'cursor-not-allowed !bg-color-input-background-disabled !text-color-text-disabled '
 				: 'cursor-pointer bg-color-input-background-off text-color-text-primary',
-			'form-label flex flex-col justify-center items-center p-2 min-h-11 w-full ring-1 ring-color-container-level-1 hover:bg-color-input-background-hover peer-checked:text-color-static-white peer-checked:bg-color-input-background-on'
+			'form-label flex flex-col justify-center items-center text-center p-2 min-h-11 w-full ring-1 ring-color-container-level-1 hover:bg-color-input-background-hover peer-checked:text-color-static-white peer-checked:bg-color-input-background-on'
 		)}
 	>
 		<!-- contents of the radio button (name and/or icon) -->


### PR DESCRIPTION
**What does this change?**
a) Adds input wrapper to grouped inputs
b) Uses 'overlay' instead of tooltip for checkbox/ radio hints
c) Updates layer control to allow indivvidual control triggers to be disabled

**Why?**
Universality

**How?**
Use exiting components 

**Related issues**: 
#667, #834, #818

**Does this introduce new dependencies?**
no

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
yes

**Is it complete?**
yes

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
