### PR TITLE
adress a11y issues in async button story

### DIFF
--- a/packages/ui/src/lib/button/AsyncButton.stories.svelte
+++ b/packages/ui/src/lib/button/AsyncButton.stories.svelte
@@ -27,9 +27,6 @@
 				options: ['brand', 'solid', 'outline', 'text', 'square'],
 				control: { type: 'select' }
 			},
-			condition: {
-				control: { type: 'select' }
-			},
 			size: {
 				options: ['sm', 'md', 'lg'],
 				control: { type: 'radio' }
@@ -88,13 +85,20 @@
 <Story name="Variants & emphasis">
 	<div class="flex flex-col gap-4">
 		{#each emphasis as emphasis}
-			<div class="flex gap-4">
+			<div class="flex items-center gap-4">
 				{#each variants as variant}
-					<AsyncButton {variant} {emphasis} onClick={waitFiveSeconds}>
+					<AsyncButton
+						{variant}
+						{emphasis}
+						size={variant === 'square' ? 'lg' : 'md'}
+						onClick={waitFiveSeconds}
+						class="capitalize"
+					>
 						{#if variant === 'square'}
-							<Icon src={DocumentArrowUp} theme="mini" class="w-5 h-5" aria-hidden="true" />
+							<Icon src={DocumentArrowUp} class="w-8 h-8 mb-0.5" aria-hidden="true" />
+							{variant}
 						{:else}
-							<span class="capitalize">{variant}</span>
+							{variant}
 						{/if}
 					</AsyncButton>
 				{/each}


### PR DESCRIPTION
**What does this change?**
Updates story, where incorrect use of square button cause a11y warning. This is not a fault in the component, but a misapplication/ bad example that has been updated.

**Why?**
Don't want failing all examples

**How?**
Buttons should have text so added to square button example

**Related issues**:
#736

**Does this introduce new dependencies?**
no

**How is it tested?**
storybook

**How is it documented?**
storybook

**Are light and dark themes considered?**
na

**Is it complete?**

- [ ] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
