### PR TITLE
Layer controls

### DIFF
--- a/.changeset/mutually-exclusive-layers.md
+++ b/.changeset/mutually-exclusive-layers.md
@@ -1,0 +1,6 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: LayerControlGroup now accepts a `mutuallyExclusive` prop
+

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -3,6 +3,7 @@
 	import Popover from '../popover/Popover.svelte';
 
 	import { currentTheme, tokenNameToValue } from '../theme/themeStore';
+	import Trigger from '../overlay/Trigger.svelte';
 
 	export let colorName = 'data.categorical.darkpink';
 
@@ -20,16 +21,16 @@
 		'data.neutral.1'
 	];
 
-	let openStore: Writable<boolean>;
+	let isOpen = false;
 </script>
 
-<Popover bind:openStore>
-	<svelte:fragment slot="hint">
+<Popover bind:isOpen>
+	<Trigger slot="trigger">
 		<div
 			class="w-5 h-5 relative border rounded-full"
 			style:background={tokenNameToValue(colorName, $currentTheme)}
 		></div>
-	</svelte:fragment>
+	</Trigger>
 
 	<svelte:fragment slot="title">Color</svelte:fragment>
 
@@ -42,7 +43,7 @@
 				style:background={tokenNameToValue(colorOption, $currentTheme)}
 				on:click={() => {
 					colorName = colorOption;
-					$openStore = false;
+					isOpen = false;
 				}}
 			/>
 		{/each}

--- a/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
@@ -113,3 +113,18 @@
 		/>
 	</div>
 </Story>
+
+<!--
+Sometimes a set of layers is mutually exclusive, as only one will be visible at any one time.
+For example, choropleth layers would cover each other.
+-->
+<Story name="Mutually exclusive layers">
+	<LayerControlGroup
+		bind:options={optionsForGroup}
+		bind:state={state1}
+		mutuallyExclusive
+		name="mutually-exclusive-layers"
+	/>
+
+	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
+</Story>

--- a/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
@@ -10,15 +10,15 @@
 
 <script lang="ts">
 	let optionsForGroup = [
-		{ id: 'bus', label: 'Bus stops', color: '#00AEEF' },
+		{ id: 'bus', label: 'Bus stops', colorName: 'data.categorical.blue' },
 		{
 			id: 'train',
 			label: 'Train stations',
-			color: '#008D48',
+			colorName: 'data.categorical.green',
 			hint: 'Excluding underground stations'
 		},
-		{ id: 'underground', label: 'Underground stations', color: '#9E0059' },
-		{ id: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
+		{ id: 'underground', label: 'Underground stations', colorName: 'data.categorical.darkpink' },
+		{ id: 'taxi', label: 'Taxi ranks', colorName: 'data.categorical.orange', disabled: true }
 	];
 
 	let optionsForGroup2 = [
@@ -38,19 +38,26 @@
 
 	let state1 = {
 		bus: {
-			color: '#00AEEF',
+			colorName: 'data.categorical.blue',
 			visible: true,
 			opacity: 1.0,
 			size: 1
 		},
+		train: {
+			colorName: 'data.categorical.green',
+			visible: true,
+			opacity: 1.0,
+			size: 1
+		},
+
 		underground: {
-			color: '#9E0059',
+			colorName: 'data.categorical.darkpink',
 			visible: true,
 			opacity: 1.0,
 			size: 1
 		},
 		taxi: {
-			color: 'firebrick',
+			colorName: 'data.categorical.orange',
 			visible: true,
 			opacity: 1.0,
 			size: 1

--- a/packages/ui/src/lib/layerControl/LayerControl.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.svelte
@@ -4,6 +4,7 @@
 	 * @component
 	 */
 	import Checkbox from '../checkBox/Checkbox.svelte';
+	import RadioButton from '../radioButton/RadioButton.svelte';
 	import OpacityControl from '../layerControl/OpacityControl.svelte';
 	import Tooltip from '../tooltip/Tooltip.svelte';
 	import ColorPicker from './ColorPicker.svelte';
@@ -64,11 +65,41 @@
 	 * maximum permitted value for the marker size
 	 */
 	export let maxSize = 100;
+
+	/**
+	 * If true, then control is rendered as a radio button rather than checkbox.
+	 */
+	export let mutuallyExclusive = false;
+
+	/**
+	 * Id of selected option (used only if `mutuallyExclusive` is true)
+	 */
+	export let selectedOptionId;
+	/**
+	 * Id of this option  (used only if `mutuallyExclusive` is true).
+	 */
+	export let optionId = '';
+
+	/**
+	 * Name of the radio button group  (used only if `mutuallyExclusive` is true)
+	 */
+	export let name = '';
 </script>
 
 <div class="flex items-center space-x-1">
 	<div class="mr-1">
-		<Checkbox bind:checked={state.visible} label="" {disabled} />
+		{#if mutuallyExclusive}
+			<RadioButton
+				id={optionId}
+				bind:selectedId={selectedOptionId}
+				label=""
+				{disabled}
+				{hint}
+				{name}
+			/>
+		{:else}
+			<Checkbox bind:checked={state.visible} label="" {disabled} />
+		{/if}
 	</div>
 
 	{#if !hideColorControl}

--- a/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
@@ -111,9 +111,8 @@
 
 	let selectedOptionId: string | undefined; // only used by radioButtons, if mutuallyExclusive
 	const updateStateFromCheckbox = (selectedId) => {
-		// For radioButtons, state is updated by group.
-		// For checkboxes, each LayerControl updates part of state directly.
-		console.log({ options, state });
+		// For Radio Buttons, state is updated by LayerControlGroup.
+		// For Checkboxes, each LayerControl updates part of state directly.
 		for (const o of options) {
 			state[o.id].visible = o.disabled ? state[o.id].visible : o.id === selectedId;
 		}

--- a/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
@@ -9,6 +9,7 @@
 
 	import { randomId } from '../utils/randomId';
 	import LayerControl from './LayerControl.svelte';
+	import Button from '../button/Button.svelte';
 
 	/**
 	 * Each element of this array defines the control for a layer, and is an object with the properties:
@@ -40,7 +41,7 @@
 	type LayerControlGroupState = Record<
 		string,
 		{
-			color: string;
+			colorName: string;
 			visible: boolean;
 			opacity: number;
 			size: number;
@@ -77,6 +78,9 @@
 	 */
 	export let showAllLabel = 'Show all';
 
+	export let mutuallyExclusive = false;
+	export let name = '';
+
 	let allCheckboxesCheckedOrDisabled: boolean;
 	$: allCheckboxesCheckedOrDisabled = options.every((o) =>
 		o.disabled ? true : state[o.id]?.visible
@@ -104,35 +108,70 @@
 			clearAll();
 		}
 	};
+
+	let selectedOptionId: string | undefined; // only used by radioButtons, if mutuallyExclusive
+	const updateStateFromCheckbox = (selectedId) => {
+		// For radioButtons, state is updated by group.
+		// For checkboxes, each LayerControl updates part of state directly.
+		console.log({ options, state });
+		for (const o of options) {
+			state[o.id].visible = o.disabled ? state[o.id].visible : o.id === selectedId;
+		}
+	};
+	const clearRadioButtons = () => {
+		clearAll();
+		selectedOptionId = undefined;
+	};
+	$: mutuallyExclusive && updateStateFromCheckbox(selectedOptionId);
 </script>
 
 <div class="flex flex-col space-y-1">
-	{#if !buttonsHidden}
-		<!--
-			form="" should prevent this checkbox from being included in form
-			submissions.
-		-->
-		<Checkbox
-			id={randomId()}
-			form=""
-			label={showAllLabel}
-			checked={allCheckboxesCheckedOrDisabled}
-			indeterminate={!allCheckboxesCheckedOrDisabled && !noCheckboxesChecked}
-			on:change={toggleAll}
-		/>
-	{/if}
+	{#if mutuallyExclusive}
+		{#if !buttonsHidden}
+			<Button variant="text" class="!px-0" on:click={clearRadioButtons}>Clear</Button>
+		{/if}
 
-	<div class={`flex flex-col space-y-1 ${buttonsHidden ? '' : 'pl-5'}`}>
-		{#each options as option (option.id)}
-			<LayerControl
-				label={option.label}
-				disabled={option.disabled}
-				hint={option.hint}
-				hideColorControl={hideColorControl || option.hideColorControl}
-				hideOpacityControl={hideOpacityControl || option.hideOpacityControl}
-				hideSizeControl={hideSizeControl || option.hideSizeControl}
-				bind:state={state[option.id]}
+		<div class={'flex flex-col space-y-1'}>
+			{#each options as option}
+				<LayerControl
+					label={option.label}
+					{name}
+					bind:state={state[option.id]}
+					optionId={option.id}
+					disabled={option.disabled}
+					bind:selectedOptionId
+					mutuallyExclusive
+				/>
+			{/each}
+		</div>
+	{:else}
+		{#if !buttonsHidden}
+			<!--
+        form="" should prevent this checkbox from being included in form
+        submissions.
+      -->
+			<Checkbox
+				id={randomId()}
+				form=""
+				label={showAllLabel}
+				checked={allCheckboxesCheckedOrDisabled}
+				indeterminate={!allCheckboxesCheckedOrDisabled && !noCheckboxesChecked}
+				on:change={toggleAll}
 			/>
-		{/each}
-	</div>
+		{/if}
+
+		<div class={`flex flex-col space-y-1 ${buttonsHidden ? '' : 'pl-5'}`}>
+			{#each options as option (option.id)}
+				<LayerControl
+					label={option.label}
+					disabled={option.disabled}
+					hint={option.hint}
+					hideColorControl={hideColorControl || option.hideColorControl}
+					hideOpacityControl={hideOpacityControl || option.hideOpacityControl}
+					hideSizeControl={hideSizeControl || option.hideSizeControl}
+					bind:state={state[option.id]}
+				/>
+			{/each}
+		</div>
+	{/if}
 </div>

--- a/packages/ui/src/lib/layerControl/OpacityControl.svelte
+++ b/packages/ui/src/lib/layerControl/OpacityControl.svelte
@@ -3,17 +3,18 @@
 
 	import Popover from '../popover/Popover.svelte';
 	import OpacityIcon from './OpacityIcon.svelte';
+	import Trigger from '../overlay/Trigger.svelte';
 
 	export let opacity = 1;
 </script>
 
 <Popover>
-	<svelte:fragment slot="hint">
+	<Trigger slot="trigger">
 		<OpacityIcon
 			class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
 			aria-hidden="true"
 		/>
-	</svelte:fragment>
+	</Trigger>
 
 	<svelte:fragment slot="title">Opacity</svelte:fragment>
 

--- a/packages/ui/src/lib/layerControl/ResizeControl.svelte
+++ b/packages/ui/src/lib/layerControl/ResizeControl.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Popover from '../popover/Popover.svelte';
 	import ResizeIcon from './ResizeIcon.svelte';
+	import Trigger from '../overlay/Trigger.svelte';
 
 	export let size = 1;
 
@@ -9,12 +10,12 @@
 </script>
 
 <Popover>
-	<svelte:fragment slot="hint">
+	<Trigger slot="trigger">
 		<ResizeIcon
 			class="w-6 h-6 text-color-text-primary hover:text-color-action-text-secondary-hover"
 			aria-hidden="true"
 		/>
-	</svelte:fragment>
+	</Trigger>
 
 	<svelte:fragment slot="title">Marker size</svelte:fragment>
 

--- a/packages/ui/src/lib/popover/Popover.svelte
+++ b/packages/ui/src/lib/popover/Popover.svelte
@@ -17,14 +17,37 @@
 
 	import { setContext } from 'svelte';
 	import Button from '../button/Button.svelte';
+	import { writable } from 'svelte/store';
+
+	/**
+	 * Boolean that determines whether the Popover is currently open.
+	 */
+	export let isOpen = false;
+
+	const isOpenStore = writable(isOpen);
 
 	const {
 		elements: { trigger, content, arrow, close },
 		states: { open }
 	} = createPopover({
 		forceVisible: true,
+		open: isOpenStore,
 		positioning: { placement: 'top' }
 	});
+
+	$: toggledExternally(isOpen);
+	const toggledExternally = (newIsOpen: boolean) => {
+		if ($isOpenStore != newIsOpen) {
+			$isOpenStore = newIsOpen;
+		}
+	};
+
+	$: toggledInternally($isOpenStore);
+	const toggledInternally = (newStoreValue: boolean) => {
+		if (newStoreValue != isOpen) {
+			isOpen = newStoreValue;
+		}
+	};
 
 	/**
 	 * Sets trigger actions and attributes (ARIA) for access by `Trigger` component


### PR DESCRIPTION
This updates `LayerControlGroup`, so it now accepts a `mutuallyExclusive` prop (addressing https://github.com/Greater-London-Authority/ldn-viz-tools/issues/800).

It also fixes regressions to the `LayerControl` caused by changes to the `Popover` component, and adds an `isOpen` prop to the `Popover` so that it can be externally opened/closed in the same way as the modal (this enables the `ColorPicker` to close itself when a color is selected).