### PR TITLE
enable full-width buttons and MultipleActionButtons

### DIFF
--- a/.changeset/full-width-button.md
+++ b/.changeset/full-width-button.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: allow `Button`/`MultipleActionButton`/`DataDownloadButton`/`ImageDownloadButton`

--- a/packages/ui/src/lib/button/Button.stories.svelte
+++ b/packages/ui/src/lib/button/Button.stories.svelte
@@ -14,7 +14,7 @@
 				control: { type: 'select' }
 			},
 			size: {
-				options: ['sm', 'md', 'lg'],
+				options: ['xs', 'sm', 'md', 'lg'],
 				control: { type: 'radio' }
 			},
 			type: {
@@ -133,7 +133,11 @@
 		layout: 'fullscreen'
 	}}
 >
-	<Button class="w-full">Custom classes applied</Button>
+	<div class="py-4 space-y-4">
+		<Button class="w-full">Custom classes applied</Button>
+
+		<Button fullWidth>fullWidth prop applied</Button>
+	</div>
 </Story>
 
 <Story name="With Icon">

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -13,7 +13,7 @@
 	export interface ButtonProps {
 		variant: 'brand' | 'square' | 'solid' | 'outline' | 'text';
 		emphasis: 'primary' | 'secondary' | 'caution' | 'positive' | 'negative';
-		size: 'xs' | 'sm' | 'md' | 'lg';
+		size: 'xs' | 'sm' | 'md' | 'lg' | 'full';
 		disabled: boolean;
 		href: string;
 		openInNewTab: boolean;
@@ -93,6 +93,11 @@
 	 * Value set as the `id` attribute of the `<svelte:element>` element (defaults to randomly generated value).
 	 */
 	export let id = randomId();
+
+	/**
+	 * If `true`, then button will fill full width of parent.
+	 */
+	export let fullWidth = false;
 
 	import { classNames } from '../utils/classNames';
 	import { randomId } from '../utils/randomId';
@@ -193,7 +198,7 @@
 	);
 </script>
 
-<div class="flex">
+<div class={classNames('flex', fullWidth ? 'w-full' : '')}>
 	<svelte:element
 		this={href ? 'a' : 'button'}
 		type={href ? undefined : type}
@@ -202,7 +207,7 @@
 		{href}
 		{disabled}
 		{title}
-		class={buttonClass}
+		class={classNames(buttonClass, fullWidth ? 'w-full' : '')}
 		aria-label={ariaLabel}
 		{id}
 		on:click

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -13,7 +13,7 @@
 	export interface ButtonProps {
 		variant: 'brand' | 'square' | 'solid' | 'outline' | 'text';
 		emphasis: 'primary' | 'secondary' | 'caution' | 'positive' | 'negative';
-		size: 'xs' | 'sm' | 'md' | 'lg' | 'full';
+		size: 'xs' | 'sm' | 'md' | 'lg';
 		disabled: boolean;
 		href: string;
 		openInNewTab: boolean;

--- a/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.stories.svelte
+++ b/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.stories.svelte
@@ -55,6 +55,10 @@
 	<DataDownloadButton {data} filename="download" />
 </Story>
 
+<Story name="Full width">
+	<DataDownloadButton {data} filename="download" fullWidth />
+</Story>
+
 <Story name="With Icon before label">
 	<DataDownloadButton {data} filename="download">
 		<Icon

--- a/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.svelte
+++ b/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.svelte
@@ -40,6 +40,11 @@
 	 */
 	export let columnMapping: undefined | { [oldName: string]: string } = undefined;
 
+	/**
+	 * If `true`, then button will fill full width of parent.
+	 */
+	export let fullWidth = false;
+
 	const enforceExtension = (name: string, extension: string) => {
 		return name.toLocaleLowerCase().endsWith(extension) ? name : `${name}${extension}`;
 	};
@@ -114,6 +119,7 @@
 	menuTitle="Select data format"
 	onClick={download}
 	{disabled}
+	{fullWidth}
 	{...$$restProps}
 >
 	<!-- contents of the button -->

--- a/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.stories.svelte
+++ b/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.stories.svelte
@@ -63,3 +63,9 @@
 		<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
 	</ImageDownloadButton>
 </Story>
+
+<Story name="Full width button">
+	<ImageDownloadButton {htmlNode} scaleFactor={2} fullWidth>
+		<Icon src={Camera} theme="mini" class="ml-2 w-5 h-5" aria-hidden="true" slot="afterLabel" />
+	</ImageDownloadButton>
+</Story>

--- a/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.svelte
+++ b/packages/ui/src/lib/imageDownloadButton/ImageDownloadButton.svelte
@@ -48,6 +48,11 @@
 	 */
 	export let scaleFactor = 2;
 
+	/**
+	 * If `true`, then button will fill full width of parent.
+	 */
+	export let fullWidth = false;
+
 	const downloadFromURL = (url: string) => {
 		const initialName = filename || 'image';
 
@@ -217,6 +222,7 @@
 	menuTitle="Select image format"
 	onClick={download}
 	{disabled}
+	{fullWidth}
 	{...$$restProps}
 >
 	<!-- contents of the button -->

--- a/packages/ui/src/lib/multipleActionButton/MultipleActionButton.svelte
+++ b/packages/ui/src/lib/multipleActionButton/MultipleActionButton.svelte
@@ -160,10 +160,7 @@
 
 	{#if $open}
 		<div
-			class={classNames(
-				'bg-color-container-level-1 z-40 p-2 shadow flex flex-col space-y-2',
-				fullWidth ? 'w-full' : 'max-w-sm'
-			)}
+			class="bg-color-container-level-1 z-40 max-w-sm p-2 shadow flex flex-col space-y-2"
 			use:$menu.action
 			{...$menu}
 			transition:fly={{ duration: 150, y: -10 }}

--- a/packages/ui/src/lib/multipleActionButton/MultipleActionButton.svelte
+++ b/packages/ui/src/lib/multipleActionButton/MultipleActionButton.svelte
@@ -19,6 +19,8 @@
 
 	import { Check, ChevronDown } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
+	import { classNames } from '../utils/classNames';
+
 	import type { ButtonProps } from '../button/Button.svelte';
 	import Button from '../button/Button.svelte';
 	import { randomId } from '../utils/randomId';
@@ -92,6 +94,11 @@
 	export let size: ButtonProps['size'] = 'md';
 
 	/**
+	 * If `true`, then button will fill full width of parent.
+	 */
+	export let fullWidth = false;
+
+	/**
 	 * If `true`, then the button cannot be interacted with (either by clicking, or by using the keyboard).
 	 */
 	export let disabled: ButtonProps['disabled'] = false;
@@ -101,7 +108,16 @@
 </script>
 
 {#if options.length === 1}
-	<Button on:click={() => onClick(state.id)} {variant} {emphasis} {size} {disabled} {title} {id}>
+	<Button
+		on:click={() => onClick(state.id)}
+		{variant}
+		{emphasis}
+		{size}
+		{disabled}
+		{title}
+		{id}
+		{fullWidth}
+	>
 		<div class="flex items-center">
 			<slot name="beforeLabel" />
 			{options[0].buttonLabel}
@@ -109,12 +125,13 @@
 		</div>
 	</Button>
 {:else}
-	<div class="flex items-center gap-0">
+	<div class={classNames('flex items-center gap-0 w-full', fullWidth ? 'w-full' : '')}>
 		<Button
 			on:click={() => onClick(state.id)}
 			{variant}
 			{emphasis}
 			{size}
+			{fullWidth}
 			{disabled}
 			{title}
 			{id}
@@ -143,7 +160,10 @@
 
 	{#if $open}
 		<div
-			class="bg-color-container-level-1 z-40 max-w-sm p-2 shadow flex flex-col space-y-2"
+			class={classNames(
+				'bg-color-container-level-1 z-40 p-2 shadow flex flex-col space-y-2',
+				fullWidth ? 'w-full' : 'max-w-sm'
+			)}
 			use:$menu.action
 			{...$menu}
 			transition:fly={{ duration: 150, y: -10 }}


### PR DESCRIPTION
**What does this change?**
This adds a prop that allows buttons and MultipleActionButtons to fill the width of their parent.

**Related issues**: 
https://github.com/Greater-London-Authority/ldn-viz-tools/issues/791

**Preview**: https://dev.ldn-gis.co.uk/storybook-full-width-buttons/?path=/docs/ui-components-buttons-datadownloadbutton--documentation

