### PR TITLE
update theme using storybook controls

### DIFF
--- a/apps/docs/.storybook/preview.ts
+++ b/apps/docs/.storybook/preview.ts
@@ -3,6 +3,7 @@ import type { Preview } from '@storybook/svelte';
 import { docs } from './ciuStorybookTheme';
 
 import { prefersDarkMode } from '@ldn-viz/ui';
+import { get } from 'svelte/store';
 import '../src/app.postcss';
 import { withThemeByClassNameStore } from './withThemeByClassNameStore';
 
@@ -90,7 +91,7 @@ const preview: Preview = {
 			themes: {
 				light: '',
 				dark: 'dark',
-				system: prefersDarkMode ? 'dark' : 'light'
+				system: get(prefersDarkMode) ? 'dark' : 'light'
 			},
 			defaultTheme: getLocalStorage()
 		})

--- a/apps/docs/.storybook/preview.ts
+++ b/apps/docs/.storybook/preview.ts
@@ -2,6 +2,7 @@
 import type { Preview } from '@storybook/svelte';
 import { docs } from './ciuStorybookTheme';
 
+import { prefersDarkMode } from '@ldn-viz/ui';
 import '../src/app.postcss';
 import { withThemeByClassNameStore } from './withThemeByClassNameStore';
 
@@ -88,7 +89,8 @@ const preview: Preview = {
 		withThemeByClassNameStore({
 			themes: {
 				light: '',
-				dark: 'dark'
+				dark: 'dark',
+				system: prefersDarkMode ? 'dark' : 'light'
 			},
 			defaultTheme: getLocalStorage()
 		})

--- a/apps/docs/.storybook/withThemeByClassNameStore.ts
+++ b/apps/docs/.storybook/withThemeByClassNameStore.ts
@@ -3,6 +3,7 @@ import type { DecoratorFunction, Renderer } from '@storybook/types';
 
 import { userThemeSelectionStore } from '@ldn-viz/ui';
 import { DecoratorHelpers } from '@storybook/addon-themes';
+import { get } from 'svelte/store';
 
 const { initializeThemeState, pluckThemeFromContext } = DecoratorHelpers;
 
@@ -47,6 +48,8 @@ export const withThemeByClassNameStore = <TRenderer extends Renderer = any>({
 
 			const newThemeClasses = classStringToArray(themes[selectedThemeName]);
 			userThemeSelectionStore.set(selectedThemeName);
+
+			globalThis.localStorage?.setItem('theme', selectedThemeName);
 
 			if (newThemeClasses.length > 0) {
 				parentElement.classList.add(...newThemeClasses);

--- a/apps/docs/.storybook/withThemeByClassNameStore.ts
+++ b/apps/docs/.storybook/withThemeByClassNameStore.ts
@@ -49,8 +49,6 @@ export const withThemeByClassNameStore = <TRenderer extends Renderer = any>({
 			const newThemeClasses = classStringToArray(themes[selectedThemeName]);
 			userThemeSelectionStore.set(selectedThemeName);
 
-			globalThis.localStorage?.setItem('theme', selectedThemeName);
-
 			if (newThemeClasses.length > 0) {
 				parentElement.classList.add(...newThemeClasses);
 			}

--- a/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
@@ -15,7 +15,7 @@
 
 	let layerStates = {
 		boroughs: {
-			colorName: 'data.categorical.yellow',
+			colorName: 'data.primary',
 			visible: true,
 			opacity: 1.0
 		},
@@ -35,11 +35,6 @@
 </script>
 
 <Template let:args>
-	<Theme />
-	<div class="mb-4">
-		<ThemeSwitcher />
-	</div>
-
 	<div class="w-96">
 		<LayerControl bind:state {...args} />
 	</div>


### PR DESCRIPTION
**What does this change?**
Upadtes the theme switching in storybook to both honor system settings and update the universal theme store (more closely aligning 'our theme' used in components to the storybook theme switcher)

**Why?**
Theme switching in sb was a) buggy if set to system and b) did not update the theme store used for our component theme variables

**How?**
Updated storybook decorator

**Related issues**:
#853 

**Does this introduce new dependencies?**
no

**How is it tested?**
sb 

**How is it documented?**
n/a

**Are light and dark themes considered?**
yes
**Is it complete?**

- [ ] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
