### PR TITLE
Ally: Popover screen reader accessibility

### DIFF
--- a/.changeset/big-ladybugs-decide.md
+++ b/.changeset/big-ladybugs-decide.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: `Popover` component is now accessible to screen readers

--- a/packages/ui/src/lib/popover/Popover.stories.svelte
+++ b/packages/ui/src/lib/popover/Popover.stories.svelte
@@ -9,6 +9,7 @@
 
 <script lang="ts">
 	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import Button from '../button/Button.svelte';
 	import Trigger from '../overlay/Trigger.svelte';
 </script>
 
@@ -48,5 +49,16 @@
 		<svelte:fragment slot="title">Metric note</svelte:fragment>
 
 		<svelte:fragment>Some text explaining this metric...</svelte:fragment>
+	</Popover>
+</Story>
+
+<!-- When the popover opens with `defaultOpenFocus` set to true, it will focus on the first interactive element in the popover. If the popover starts with an interactive element, set to `true`, else omit. -->
+<Story name="Using defaultOpenFocus" source>
+	<Popover defaultOpenFocus>
+		<Trigger slot="trigger" />
+		<div class="space-y-2">
+			<Button emphasis="secondary" size="sm" href="/">A button</Button>
+			<p>starts this content, so it should receive focus.</p>
+		</div>
 	</Popover>
 </Story>

--- a/packages/ui/src/lib/popover/Popover.svelte
+++ b/packages/ui/src/lib/popover/Popover.svelte
@@ -16,8 +16,9 @@
 	import { Icon } from '@steeze-ui/svelte-icon';
 
 	import { setContext } from 'svelte';
-	import Button from '../button/Button.svelte';
 	import { writable } from 'svelte/store';
+	import Button from '../button/Button.svelte';
+	import { randomId } from '../utils/randomId';
 
 	/**
 	 * Boolean that determines whether the Popover is currently open.
@@ -26,13 +27,29 @@
 
 	const isOpenStore = writable(isOpen);
 
+	/**
+	 * Value set as the `id` attribute of the title, for use in describing the popover by screen reader (defaults to randomly generated value).
+	 */
+	export let popoverTitleId = randomId();
+
+	/**
+	 * Value set as the `id` attribute of the content, to enable open focus to target the contents (defaults to randomly generated value).
+	 */
+	export let popoverContentId = randomId();
+
+	/**
+	 * In cases where the first element of the popover is interactive (e.g. button, link), set to true. Else defaults to false, to allow focus on the contents container.
+	 */
+	export let defaultOpenFocus: boolean = false;
+
 	const {
 		elements: { trigger, content, arrow, close },
 		states: { open }
 	} = createPopover({
 		forceVisible: true,
 		open: isOpenStore,
-		positioning: { placement: 'top' }
+		positioning: { placement: 'top' },
+		openFocus: defaultOpenFocus ? null : `#${popoverContentId}`
 	});
 
 	$: toggledExternally(isOpen);
@@ -64,18 +81,19 @@
 		use:content
 		transition:fade={{ duration: 100 }}
 		class="z-50 w-60 bg-color-container-level-1 p-4 shadow"
+		aria-labelledby={popoverTitleId}
 	>
 		<div {...$arrow} use:arrow />
 
 		<div class="text-sm flex flex-col space-y-2 text-color-text-primary">
 			{#if $$slots.title}
-				<p class="font-medium">
+				<p class="font-medium" id={popoverTitleId}>
 					<!-- Optional title for the popover -->
 					<slot name="title" />
 				</p>
 			{/if}
 
-			<div>
+			<div id={popoverContentId} tabindex="-1">
 				<!-- Main content of the popover-->
 				<slot />
 			</div>


### PR DESCRIPTION
**What does this change?**
- Popover now has openFocus set to content, to enable screen reader accessibility
- Also created optional `defaultOpenFocus` prop.
   - This is useful for cases where the first element in the popover is interactive, as the default behaviour of focusing the first interactive element is appropriate.
   - Otherwise, it is set to false, for the majority of cases where the first interactive element is the close button, which would skip over the entire contents of the popover

**Related issues**:
Fixes #751
Relates #834

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**
Yes

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
