### PR TITLE
Ally: fixed accessibility issues in Toast component

### DIFF
--- a/.changeset/chatty-carrots-search.md
+++ b/.changeset/chatty-carrots-search.md
@@ -2,4 +2,4 @@
 '@ldn-viz/ui': minor
 ---
 
-FIXED `Toast` component accessibility
+FIXED: changed ARIA role of `Toast` from `dialog` to `alert`

--- a/.changeset/chatty-carrots-search.md
+++ b/.changeset/chatty-carrots-search.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED `Toast` component accessibility

--- a/packages/ui/src/lib/toaster/Toast.svelte
+++ b/packages/ui/src/lib/toaster/Toast.svelte
@@ -27,7 +27,7 @@
 </script>
 
 <div
-	role="dialog"
+	role="alert"
 	id={message.id}
 	class="shadow-lg text-color-text-primary"
 	out:fade={{ duration: 100 }}


### PR DESCRIPTION
**What does this change?**
- Applied correct role to Toast component so screen reader can identify it and read out the contents when it pops up.

**Why?**
Accessibility

**How?**
Changed `role="dialog"` to `role="alert"`

**Related issues**:
Closes #760
Relates #367

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**
Yes

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
