### PR TITLE
make list of geocoder search suggestions scrollable

### DIFF
--- a/.changeset/geocoder-suggestions-scroll.md
+++ b/.changeset/geocoder-suggestions-scroll.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: set `overflow-y: scroll` on list of geocoder suggestions and limit height to enable scrolling if `maxSuggestions` is set to a large value

--- a/packages/ui/src/lib/geolocation/GeocoderSuggestionList.svelte
+++ b/packages/ui/src/lib/geolocation/GeocoderSuggestionList.svelte
@@ -43,7 +43,7 @@
 </script>
 
 <ul
-	class="absolute top-11 left-0 bg-color-input-background text-color-text-primary text-sm w-full shadow-lg z-40"
+	class="absolute top-11 left-0 bg-color-input-background text-color-text-primary text-sm w-full shadow-lg z-40 overflow-y-scroll max-height-[60vh]"
 >
 	{#if suggestions.length === 0}
 		<li class="w-full px-2.5 py-1.5">


### PR DESCRIPTION
This is necessary if we're using a search API that returns a large number of results, and want to display more than 10 or so (as is the case for address search in the LBSM map).

I'm not sure of the best value to apply for the `max-height`.