### PR TITLE
don't set color scales to ordinal type as default

### DIFF
--- a/.changeset/observable-color-defaults.md
+++ b/.changeset/observable-color-defaults.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/charts': minor
+---
+
+CHANGED: observable plot fragments to no longer set color scales to `ordinal` by default

--- a/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
+++ b/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
@@ -64,8 +64,7 @@ const defaultSizeFacet = {
 const defaultColor = {
 	legend: true,
 	swatchSize: 16,
-	className: 'defaultColorLegendLabel',
-	type: 'ordinal'
+	className: 'defaultColorLegendLabel'
 };
 
 const defaultXScale = {


### PR DESCRIPTION
Observale Plot should determine the scale type automatically. Setting it to `ordinal` by default will mean that it will need to be explicitly set if a different scale type is required (otherwise, instead of being rendered as a nice interpretabl color-ramp, teh legend for a continuous color scale will be drawn as a large number of color chips, one per unique value in the data).