### PR TITLE
Searchbox api

### DIFF
--- a/.changeset/stupid-cougars-destroy.md
+++ b/.changeset/stupid-cougars-destroy.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': patch
+---
+
+Update geocoder from MapBox API to Searchbox API

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlGeocoder.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlGeocoder.svelte
@@ -5,19 +5,20 @@
 	 * @component
 	 */
 
-	import { getContext } from 'svelte';
-	import mapgl from 'maplibre-gl';
 	import { Geocoder, GeocoderSuggestionList } from '@ldn-viz/ui';
-	import { setFeature, clearFeature } from './map-layer';
+	import mapgl from 'maplibre-gl';
+	import { getContext } from 'svelte';
+	import { clearFeature, setFeature } from './map-layer';
 	import type { MapStore } from './map-types';
 
 	import type {
+		GeocoderAdapter,
 		Geolocation,
 		GeolocationNamed,
-		OnGeolocationSearchResult,
 		OnGeolocationSearchError,
-		GeocoderAdapter
+		OnGeolocationSearchResult
 	} from '@ldn-viz/ui';
+	import { MapGeocoderAdapterMapBox } from './MapGeocoderAdapterMapBox';
 
 	/**
 	 * An adapter for sourcing location suggestions. All data fetching and
@@ -67,12 +68,21 @@
 			return;
 		}
 
-		showClearButton = true;
-		setFeature('geocoder', $mapStore, mapgl, location, { zoom: zoomLevel });
+		adapter
+			.retrieve(location.id)
+			.then((updatedLocation) => {
+				console.log('Updated location:', updatedLocation);
 
-		if (onLocationSelected) {
-			onLocationSelected(location);
-		}
+				showClearButton = true;
+				setFeature('geocoder', $mapStore, mapgl, updatedLocation, { zoom: zoomLevel });
+
+				if (onLocationSelected) {
+					onLocationSelected(updatedLocation);
+				}
+			})
+			.catch((error) => {
+				console.error('Error retrieving location:', error);
+			});
 	};
 
 	let showClearButton = false;

--- a/packages/maps/src/lib/mapControlLocationSearch/MapGeocoderAdapterMapBox.ts
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapGeocoderAdapterMapBox.ts
@@ -6,30 +6,26 @@ import type {
 	GeolocationNamed
 } from '@ldn-viz/ui';
 
-type MapBoxFeature = {
-	id: string;
-	text: string; // name
-	place_name: string; // address
-	center: [number, number];
-	bbox?: [number, number, number, number]; // bounds
-	[otherOptions: string]: unknown;
-};
-
-type MapBoxFeatureCollection = {
-	features: MapBoxFeature[];
-	[otherOptions: string]: unknown;
-};
+interface RetrieveFeatureCollection {
+	features: Array<{
+		properties: {
+			mapbox_id: string;
+			name: string;
+			place_formatted: string;
+		};
+		geometry: {
+			coordinates: number[]; // e.g., [longitude, latitude]
+		};
+	}>;
+}
 
 type SearchBoxFeature = {
 	mapbox_id: string;
 	name: string; // name
 	place_formatted: string; // address
-	center: [number, number];
-	bbox?: [number, number, number, number]; // bounds
-	[otherOptions: string]: unknown;
 };
 
-type SearchBoxFeatureCollection = {
+type SuggestFeatureCollection = {
 	suggestions: SearchBoxFeature[];
 	[otherOptions: string]: unknown;
 };
@@ -61,7 +57,7 @@ export class MapGeocoderAdapterMapBox implements GeocoderAdapter {
 		console.log('Suggestion link: ' + url);
 		return fetch(url)
 			.then((res) => res.json())
-			.then(transformGeoJSONToNamedGeolocations);
+			.then(transformSuggestGeoJSONToNamedGeolocations);
 	}
 
 	retrieve(id: string) {
@@ -69,7 +65,7 @@ export class MapGeocoderAdapterMapBox implements GeocoderAdapter {
 		console.log('Retrieve link: ' + url);
 		return fetch(url)
 			.then((res) => res.json())
-			.then(transformGeoJSONToNamedGeolocations2);
+			.then(transformRetrieveGeoJSONToNamedGeolocations);
 	}
 
 	attribution() {
@@ -99,6 +95,7 @@ export class MapGeocoderAdapterMapBox implements GeocoderAdapter {
 	}
 }
 
+// Searchbox api 'suggest' endpoint to return a list of a suggestions based off of users input
 const buildSuggestionUrl = (
 	text: string,
 	token: string,
@@ -118,6 +115,7 @@ const buildSuggestionUrl = (
 	return `https://api.mapbox.com/search/searchbox/v1/suggest?q=${text}&${queryString}`;
 };
 
+// Searchbox api 'retrieve' endpoint to return the geometry of selected value from sugestion list
 const buildRetrieveUrl = (suggestionId: string, token: string, session_token: string): string => {
 	suggestionId = encodeURIComponent(suggestionId);
 	const queryString = new URLSearchParams({
@@ -128,24 +126,17 @@ const buildRetrieveUrl = (suggestionId: string, token: string, session_token: st
 	return `https://api.mapbox.com/search/searchbox/v1/retrieve/${suggestionId}?${queryString}`;
 };
 
-const transformGeoJSONToNamedGeolocations = (
-	geojson: SearchBoxFeatureCollection
-): GeolocationNamed[] => {
+const transformSuggestGeoJSONToNamedGeolocations = (geojson: SuggestFeatureCollection) => {
 	return geojson.suggestions.map((loc) => {
 		return {
 			id: loc.mapbox_id,
 			name: loc.name,
-			address: loc.place_formatted,
-			// loc.center isn't always the center of the bbox
-			center: [43, 57],
-			bounds: [43, 24, 56, 23]
+			address: loc.place_formatted
 		};
 	});
 };
 
-const transformGeoJSONToNamedGeolocations2 = (
-	geojson: MapBoxFeatureCollection
-): GeolocationNamed[] => {
+const transformRetrieveGeoJSONToNamedGeolocations = (geojson: RetrieveFeatureCollection) => {
 	// Return only the first transformed feature
 	const firstFeature = geojson.features[0];
 
@@ -156,29 +147,4 @@ const transformGeoJSONToNamedGeolocations2 = (
 		address: firstFeature.properties.place_formatted,
 		center: [firstFeature.geometry.coordinates[0], firstFeature.geometry.coordinates[1]]
 	};
-};
-
-const removeNameFromAddress = (address: string, name: string) => {
-	if (!address.startsWith(name)) {
-		return address;
-	}
-
-	address = address.slice(name.length).trim();
-
-	if (address.startsWith(',')) {
-		return address.slice(1).trim();
-	}
-
-	return address;
-};
-
-const calcBoundingBoxCenter = (
-	bbox: undefined | GeolocationBounds,
-	center: GeolocationCoords
-): GeolocationCoords => {
-	if (!bbox) {
-		return center;
-	}
-
-	return [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2];
 };

--- a/packages/maps/src/lib/mapControlLocationSearch/MapGeocoderAdapterMapBox.ts
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapGeocoderAdapterMapBox.ts
@@ -1,9 +1,9 @@
 import { GREATER_LONDON_BOUNDS_PADDED } from '@ldn-viz/maps';
 import type {
-	GeolocationCoords,
+	GeocoderAdapter,
 	GeolocationBounds,
-	GeolocationNamed,
-	GeocoderAdapter
+	GeolocationCoords,
+	GeolocationNamed
 } from '@ldn-viz/ui';
 
 type MapBoxFeature = {
@@ -20,6 +20,20 @@ type MapBoxFeatureCollection = {
 	[otherOptions: string]: unknown;
 };
 
+type SearchBoxFeature = {
+	mapbox_id: string;
+	name: string; // name
+	place_formatted: string; // address
+	center: [number, number];
+	bbox?: [number, number, number, number]; // bounds
+	[otherOptions: string]: unknown;
+};
+
+type SearchBoxFeatureCollection = {
+	suggestions: SearchBoxFeature[];
+	[otherOptions: string]: unknown;
+};
+
 // MapGeocoderAdapterMapBox adapter uses the MapBox API to source locations.
 //
 // Due to licensing this adapter can only be used within @ldn-viz maps and
@@ -27,19 +41,35 @@ type MapBoxFeatureCollection = {
 export class MapGeocoderAdapterMapBox implements GeocoderAdapter {
 	private _token: string = '';
 	private _resultCount: number = 5;
+	private _sessionToken: string = '';
+	static retrieveLocation: any;
 
 	constructor(token: string, resultCount = 5) {
 		this._token = token;
 		this.setResultCount(resultCount);
+		this.resetSessionToken(); // Initialize session token
+	}
+
+	private resetSessionToken() {
+		this._sessionToken = crypto.randomUUID(); // Generate a new session token
 	}
 
 	// GeocoderAdapter functions.
 
 	search(text: string) {
-		const url = buildUrl(text, this._token, this._resultCount);
+		const url = buildSuggestionUrl(text, this._token, this._resultCount, this._sessionToken);
+		console.log('Suggestion link: ' + url);
 		return fetch(url)
 			.then((res) => res.json())
 			.then(transformGeoJSONToNamedGeolocations);
+	}
+
+	retrieve(id: string) {
+		const url = buildRetrieveUrl(id, this._token, this._sessionToken);
+		console.log('Retrieve link: ' + url);
+		return fetch(url)
+			.then((res) => res.json())
+			.then(transformGeoJSONToNamedGeolocations2);
 	}
 
 	attribution() {
@@ -69,32 +99,63 @@ export class MapGeocoderAdapterMapBox implements GeocoderAdapter {
 	}
 }
 
-const buildUrl = (text: string, token: string, resultCount: number): string => {
+const buildSuggestionUrl = (
+	text: string,
+	token: string,
+	resultCount: number,
+	session_token: string
+): string => {
 	text = encodeURIComponent(text);
 
 	const queryString = new URLSearchParams({
 		access_token: token,
 		bbox: GREATER_LONDON_BOUNDS_PADDED.flat().toString(),
-		autocomplete: true.toString(),
-		limit: resultCount.toString()
+		//autocomplete: true.toString(),
+		limit: resultCount.toString(),
+		session_token: session_token
 	});
 
-	return `https://api.mapbox.com/geocoding/v5/mapbox.places/${text}.json?${queryString}`;
+	return `https://api.mapbox.com/search/searchbox/v1/suggest?q=${text}&${queryString}`;
+};
+
+const buildRetrieveUrl = (suggestionId: string, token: string, session_token: string): string => {
+	suggestionId = encodeURIComponent(suggestionId);
+	const queryString = new URLSearchParams({
+		access_token: token,
+		session_token: session_token
+	});
+
+	return `https://api.mapbox.com/search/searchbox/v1/retrieve/${suggestionId}?${queryString}`;
 };
 
 const transformGeoJSONToNamedGeolocations = (
-	geojson: MapBoxFeatureCollection
+	geojson: SearchBoxFeatureCollection
 ): GeolocationNamed[] => {
-	return geojson.features.map((loc) => {
+	return geojson.suggestions.map((loc) => {
 		return {
-			id: loc.id,
-			name: loc.text,
-			address: removeNameFromAddress(loc.place_name, loc.text),
+			id: loc.mapbox_id,
+			name: loc.name,
+			address: loc.place_formatted,
 			// loc.center isn't always the center of the bbox
-			center: calcBoundingBoxCenter(loc.bbox, loc.center),
-			bounds: loc.bbox
+			center: [43, 57],
+			bounds: [43, 24, 56, 23]
 		};
 	});
+};
+
+const transformGeoJSONToNamedGeolocations2 = (
+	geojson: MapBoxFeatureCollection
+): GeolocationNamed[] => {
+	// Return only the first transformed feature
+	const firstFeature = geojson.features[0];
+
+	// Transform and return the first feature only
+	return {
+		id: firstFeature.properties.mapbox_id,
+		name: firstFeature.properties.name,
+		address: firstFeature.properties.place_formatted,
+		center: [firstFeature.geometry.coordinates[0], firstFeature.geometry.coordinates[1]]
+	};
 };
 
 const removeNameFromAddress = (address: string, name: string) => {

--- a/packages/maps/src/lib/mapControlLocationSearch/map-layer.ts
+++ b/packages/maps/src/lib/mapControlLocationSearch/map-layer.ts
@@ -1,13 +1,13 @@
 import { GLIDE_ANIMATION_OPTIONS } from '@ldn-viz/maps';
-import type { GeolocationCoords, GeolocationBounds, Geolocation } from '@ldn-viz/ui';
+import type { Geolocation, GeolocationBounds, GeolocationCoords } from '@ldn-viz/ui';
 
 import type {
+	FlyToOptions,
+	GeoJSONSource,
+	LayerSpecification,
 	Map,
 	Marker,
-	GeoJSONSource,
-	SourceSpecification,
-	LayerSpecification,
-	FlyToOptions
+	SourceSpecification
 } from 'maplibre-gl';
 
 import type { FeatureCollection } from 'geojson';
@@ -78,6 +78,7 @@ export const setFeature = (
 
 	(map.getSource(sourceId) as GeoJSONSource)?.setData(
 		createFeatureCollection(location) as FeatureCollection
+		//createFeatureGeometryPoint(location)
 	);
 
 	addMarkerAndFlyToLocation(ref, map, mapgl, location, flyOptions);


### PR DESCRIPTION
**What does this change?**
Migrating from the searchbox api from the mapbox api

**Why?**
Mapbox API removed their points of interest dataset

**How?**
Search box api uses 2 separate endpoints. The suggestion endpoint which retrieves a list of possible place names (no geometry). This is followed by the retrieve endpoint which takes the selected place name from the suggestion list and returns the places coordinates. 

**Related issues**:
Billing - Currently the api is on 'Introductory Preview Pricing' which will change open 1st April. Billing is done per session and I don not believe we get alot of free sessions. Would be good to know how often the geocoder is used. 

**Does this introduce new dependencies?**
No 

**How is it tested?**
typing a location, selecting location, see if map pans to point

**How is it documented?**
Changeset and github 

**Are light and dark themes considered?**
NA 

**Is it complete?**
Mostly, there is a bit of repeated code and some problems with types. 

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
