### PR TITLE
A11y: add aria-expanded to sidebar

### DIFF
--- a/.changeset/lemon-balloons-report.md
+++ b/.changeset/lemon-balloons-report.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: `SidebarToggle` now has `aria-expanded` and `aria-controls` attributes for screen reader accessibility. `Sidebar` has a `sidebarId` for use by `SidebarToggle`.

--- a/packages/ui/src/lib/sidebar/Sidebar.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.svelte
@@ -13,6 +13,7 @@
 	import { type Writable } from 'svelte/store';
 	import { slide } from 'svelte/transition';
 	import { classNames } from '../utils/classNames';
+	import { randomId } from '../utils/randomId';
 	import TabPanel from './../tabs/TabPanel.svelte';
 	import type { Tab } from './../tabs/types';
 	import SidebarTabList from './elements/sidebarTabs/SidebarTabList.svelte';
@@ -68,6 +69,11 @@
 	 */
 	export let ariaLabel: string = 'Switch sidebar panel';
 
+	/**
+	 * Randomly generated id for sidebar container. Used by `SidebarToggle` to tell screen readers what the toggle controls.
+	 */
+	export let sidebarId: string = randomId();
+
 	const sidebarPlacementFromContext = getContext<Writable<PlacementType>>('sidebarPlacement');
 	const sidebarIsOpen = getContext<Writable<boolean>>('sidebarIsOpen');
 	const sidebarAlwaysOpen = getContext<Writable<'true' | 'false'>>('sidebarAlwaysOpen');
@@ -96,12 +102,13 @@
 		</div>
 	{:else if $sidebarAlwaysOpen !== 'true'}
 		<div class={classNames('absolute', togglePlacementClasses)}>
-			<SidebarToggle />
+			<SidebarToggle {sidebarId} />
 		</div>
 	{/if}
 
 	{#if $sidebarIsOpen}
 		<div
+			id={sidebarId}
 			class={classNames('flex', heightClasses)}
 			transition:slide={{ duration: 300, axis: transitionAxis[placement] }}
 		>

--- a/packages/ui/src/lib/sidebar/elements/sidebarToggle/SidebarToggle.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarToggle/SidebarToggle.svelte
@@ -11,6 +11,9 @@
 	import Button from '../../../button/Button.svelte';
 	import { classNames } from '../../../utils/classNames';
 
+	// `id` for sidebar container, to point to for screen readers
+	export let sidebarId: string;
+
 	const sidebarIsOpen = getContext<Writable<boolean>>('sidebarIsOpen');
 	$: isOpen = $sidebarIsOpen;
 
@@ -30,6 +33,7 @@
 		emphasis="secondary"
 		class={sidebarToggleClasses}
 		on:click={toggleOpen}
+		actionProps={{ 'aria-controls': sidebarId, 'aria-expanded': isOpen }}
 	>
 		{#if isOpen === false}
 			{#if $$slots.icon === true}


### PR DESCRIPTION
**What does this change?**
- `SidebarToggle` now has `aria-expanded` and `aria-controls` attributes for better screen reader accessibility, so users can identify when the sidebar is expanded or closed.
- `Sidebar` has a default `sidebarId` that can be changed externally, for `SidebarToggle` to identify the sidebar container that the button controls.

**Why?**
Fix accessibility issues identified in external audit

**How?**
`SidebarToggle` has the following props:
- `aria-expanded = isOpen`
- `aria-controls = sidebarId`

`Sidebar` has `sidebarId` variable which is passed into `SidebarToggle` and assigned to div container wrapping around sidebar contents.

**Related issues**: Closes #914

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**
Yes

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
