### PR TITLE
maps: add MapArrow component

### DIFF
--- a/.changeset/map-arrow.md
+++ b/.changeset/map-arrow.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': minor
+---
+
+ADDED: `MapArrow` component allows arrow to be superimposed on map

--- a/.changeset/maps-bump.md
+++ b/.changeset/maps-bump.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': major
+---
+
+bumped major version due to `svelte5` tag being accidentally released as 7.4.1.

--- a/packages/maps/src/lib/index.js
+++ b/packages/maps/src/lib/index.js
@@ -32,6 +32,8 @@ export { default as MapMarkerStyledContainer } from './mapMarker/elements/mapMar
 
 export { default as MapPopover } from './mapPopover/MapPopover.svelte';
 
+export { default as MapArrow } from './mapArrow/MapArrow.svelte';
+
 // Layers
 export { default as MapLayerSource } from './mapLayerSource/MapLayerSource.svelte';
 export { default as GeoJSONMapLayerSource } from './mapLayerSource/adaptations/geojsonMapLayerSource/GeoJSONMapLayerSource.svelte';

--- a/packages/maps/src/lib/mapArrow/MapArrow.stories.svelte
+++ b/packages/maps/src/lib/mapArrow/MapArrow.stories.svelte
@@ -48,7 +48,6 @@
 				{options}
 				bind:selectedId={location}
 			></RadioButtonGroupSolid>
-			{JSON.stringify(selectedPosition)}
 		</div>
 
 		<Map

--- a/packages/maps/src/lib/mapArrow/MapArrow.stories.svelte
+++ b/packages/maps/src/lib/mapArrow/MapArrow.stories.svelte
@@ -1,0 +1,62 @@
+<script context="module">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import MapArrow from './MapArrow.svelte';
+
+	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
+
+	export const meta = {
+		title: 'Maps/Components/MapArrow/MapArrow',
+		component: MapArrow,
+		parameters: {
+			layout: 'full'
+		}
+	};
+</script>
+
+<script lang="ts">
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
+	import { RadioButtonGroupSolid } from '@ldn-viz/ui';
+
+	const options = [
+		{ id: 'nothing', label: 'Nothing' },
+		{ id: 'buckingham-palace', label: 'Buckingham Palace' },
+		{ id: 'parliament', label: 'Houses of Parliament' },
+		{ id: 'tower', label: 'Tower of London' }
+	];
+	let location = 'buckingham-palace';
+
+	const coords = {
+		nothing: undefined,
+		'buckingham-palace': { lat: 51.5014499, lng: -0.1434776 },
+		parliament: { lat: 51.4995045, lng: -0.1249316 },
+		tower: { lat: 51.5081449, lng: -0.0761326 }
+	};
+	$: selectedPosition = coords[location];
+</script>
+
+<Template let:args>
+	<MapArrow {...args} />
+</Template>
+
+<Story name="Fullscreen Button" let:args>
+	<div class="w-[100dvw] h-[100dvh] max-w-full">
+		<div class="text-color-text-primary space-y-4 m-2">
+			<RadioButtonGroupSolid
+				label="Point at"
+				name="What to point at"
+				{options}
+				bind:selectedId={location}
+			></RadioButtonGroupSolid>
+			{JSON.stringify(selectedPosition)}
+		</div>
+
+		<Map
+			options={{
+				transformRequest: appendOSKeyToUrl(OS_KEY)
+			}}
+		>
+			<MapArrow {...args} pointAt={selectedPosition} />
+		</Map>
+	</div>
+</Story>

--- a/packages/maps/src/lib/mapArrow/MapArrow.svelte
+++ b/packages/maps/src/lib/mapArrow/MapArrow.svelte
@@ -46,8 +46,6 @@
 	const mapStore: MapLibreStore = getContext('mapStore');
 	$: map = $mapStore;
 
-	$: console.log({ mapStore });
-
 	let pointPosPixels = { x: 0, y: 0 }; // what we're pointing at
 	let centerPosPixels = { x: 0, y: 0 }; // center of map
 
@@ -96,6 +94,7 @@
 		}
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 	$: pointAt && updatePos();
 </script>
 

--- a/packages/maps/src/lib/mapArrow/MapArrow.svelte
+++ b/packages/maps/src/lib/mapArrow/MapArrow.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+	/**
+	 * The `MapArrow` draws an arrow pointing at a location.
+	 * The arrow will adjust as the users pans or zooms.
+	 */
+
+	import { getContext, onDestroy } from 'svelte';
+
+	import type { Map as MaplibreglMap } from 'maplibre-gl';
+	import type { MapLibreStore } from '../map/types';
+
+	// export let map;
+
+	/**
+	 * Color of the arrow (both line and arrowhead), in any format that can be directly applied to an SVG element.
+	 */
+	export let color = 'red';
+
+	/**
+	 * Position that the arrow points at (a `Maplibre [LngLatLike](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/LngLatLike/) object.
+	 */
+	export let pointAt:
+		| { lat: number; lng: number }
+		| {
+				lat: number;
+				lon: number;
+		  }
+		| [number, number]
+		| undefined = undefined;
+
+	/**
+	 * Length of the arrow (in pixels).
+	 */
+	export let arrowLength = 200;
+
+	/**
+	 * Arrowhead size (in pixels).
+	 */
+	export let arrowheadSize = 20;
+
+	/**
+	 * Gap between the arrowhead and point (in pixels).
+	 */
+	export let gap = 30;
+
+	const mapStore: MapLibreStore = getContext('mapStore');
+	$: map = $mapStore;
+
+	$: console.log({ mapStore });
+
+	let pointPosPixels = { x: 0, y: 0 }; // what we're pointing at
+	let centerPosPixels = { x: 0, y: 0 }; // center of map
+
+	let arrowStartPos = { x: 0, y: 0 };
+	let arrowEndPos = { x: 0, y: 0 };
+
+	const updatePos = () => {
+		if (!map || !pointAt) {
+			return;
+		}
+		pointPosPixels = map.project(pointAt);
+		centerPosPixels = map.project(map.getCenter());
+
+		const d = Math.sqrt(
+			Math.pow(pointPosPixels.x - centerPosPixels.x, 2) +
+				Math.pow(pointPosPixels.y - centerPosPixels.y, 2)
+		);
+
+		arrowStartPos = {
+			x: pointPosPixels.x + ((centerPosPixels.x - pointPosPixels.x) * arrowLength) / d,
+			y: pointPosPixels.y + ((centerPosPixels.y - pointPosPixels.y) * arrowLength) / d
+		};
+
+		arrowEndPos = {
+			x: pointPosPixels.x + ((centerPosPixels.x - pointPosPixels.x) * gap) / d,
+			y: pointPosPixels.y + ((centerPosPixels.y - pointPosPixels.y) * gap) / d
+		};
+	};
+
+	const onMapLoad = (newMap: MaplibreglMap) => {
+		newMap.on('zoom', updatePos);
+		newMap.on('drag', updatePos);
+		updatePos();
+	};
+
+	onDestroy(() => {
+		if (map) {
+			map.off('zoom', updatePos);
+			map.off('drag', updatePos);
+		}
+	});
+
+	$: {
+		if (map) {
+			onMapLoad(map);
+		}
+	}
+
+	$: pointAt && updatePos();
+</script>
+
+<div class="h-full w-full pointer-events-none absolute z-50" style="top: 0">
+	<svg class="h-full w-full">
+		{#if map && pointAt}
+			<line
+				x1={arrowStartPos?.x ?? 0}
+				x2={arrowEndPos?.x ?? 0}
+				y1={arrowStartPos?.y ?? 0}
+				y2={arrowEndPos?.y ?? 0}
+				stroke={color}
+				marker-end="url(#arrowhead)"
+			/>
+
+			<defs>
+				<marker
+					markerWidth={arrowheadSize}
+					markerHeight={arrowheadSize}
+					refX={arrowheadSize / 2}
+					refY={arrowheadSize / 2}
+					viewBox={`0 0 ${arrowheadSize} ${arrowheadSize}`}
+					orient="auto"
+					id="arrowhead"
+				>
+					<polygon
+						points={`0,${arrowheadSize} 0,0 ${arrowheadSize},${arrowheadSize / 2}`}
+						fill={color}
+					></polygon>
+				</marker>
+			</defs>
+		{/if}
+	</svg>
+</div>


### PR DESCRIPTION
**What does this change?**

This adds a `MapArrow` component, to superimpose an arrow pointing at a point on a map.

**Why?**

On the Green Infrastructure map, individual hexes are small, so highlighting their boder is not enough to enable users to quickly find them: adding an arrow helps.

**Does this introduce new dependencies?**

No.


**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
