### PR TITLE
A11y: improve sr accessibility in CheckboxGroup and LayerControlGroup

### DIFF
--- a/.changeset/slimy-snakes-drum.md
+++ b/.changeset/slimy-snakes-drum.md
@@ -1,0 +1,11 @@
+---
+'@ldn-viz/ui': minor
+---
+
+Refactored `LayerControlGroup`, `CheckboxGroup` and `Checkbox` components for accessibility.
+
+`LayerControlGroup` and `CheckboxGroup` now have:
+
+- `id` and `role="group"` attributes on the div that wraps around the `LayerControl` or `Checkbox` inputs
+- `ariaLabel` prop to describe the purpose of the components to screen reader users
+- `<ul>` element surrounding the options, with each option nested in an `<li>` element so screen reader users know the options are connected

--- a/packages/ui/src/lib/checkBox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkBox/Checkbox.svelte
@@ -14,7 +14,7 @@
 
 <script lang="ts">
 	import Overlay from '../overlay/Overlay.svelte';
-
+	import Trigger from '../overlay/Trigger.svelte';
 	/**
 	 * The `<Checkbox>` component provides a checkbox control as a Boolean input.
 	 * It creates an `<input type="checkbox">`HTML element ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox)), but enhances this with the ability to easily change the checkbox color, and add tooltips providing explanatory text.
@@ -107,7 +107,13 @@
 		<slot name="hint" />
 	{/if}
 	{#if hint}
-		<Overlay {hintLabel}>
+		<Overlay>
+			<Trigger
+				slot="trigger"
+				size="xs"
+				{hintLabel}
+				ariaLabel={!hintLabel && label ? label : null}
+			/>
 			{hint}
 		</Overlay>
 	{/if}

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
@@ -25,10 +25,12 @@
 		{ id: 'underground', name: 'underground', label: 'Underground stations', color: '#9E0059' },
 		{ id: 'taxi', name: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
 	];
+
+	let ariaLabel = 'Select transport methods';
 </script>
 
 <Template let:args>
-	<CheckboxGroup options={optionsForGroup} bind:selectedOptions {...args} />
+	<CheckboxGroup options={optionsForGroup} bind:selectedOptions {...args} {ariaLabel} />
 	<p class="mt-4 text-color-text-secondary">
 		selectedOptions: {JSON.stringify(selectedOptions)}
 	</p>
@@ -37,7 +39,12 @@
 <Story name="Default" source />
 
 <Story name="with title">
-	<CheckboxGroup options={optionsForGroup} bind:selectedOptions label="Transport method" />
+	<CheckboxGroup
+		options={optionsForGroup}
+		bind:selectedOptions
+		label="Transport method"
+		{ariaLabel}
+	/>
 	<p class="mt-4 text-color-text-secondary">
 		selectedOptions: {JSON.stringify(selectedOptions)}
 	</p>
@@ -49,6 +56,7 @@
 		bind:selectedOptions
 		label="Transport method"
 		hint="contextual hint text"
+		{ariaLabel}
 	/>
 	<p class="mt-4 text-color-text-secondary">
 		selectedOptions: {JSON.stringify(selectedOptions)}
@@ -62,6 +70,7 @@
 		bind:selectedOptions
 		label="Transport method"
 		description="Pick you prefered method of transport - taxis are currently not available"
+		{ariaLabel}
 	/>
 	<p class="mt-4 text-color-text-secondary">
 		selectedOptions: {JSON.stringify(selectedOptions)}
@@ -69,7 +78,7 @@
 </Story>
 
 <Story name="disabled buttons">
-	<CheckboxGroup options={optionsForGroup} bind:selectedOptions buttonsHidden />
+	<CheckboxGroup options={optionsForGroup} bind:selectedOptions buttonsHidden {ariaLabel} />
 	<p class="mt-4 text-color-text-secondary">
 		selectedOptions: {JSON.stringify(selectedOptions)}
 	</p>
@@ -79,7 +88,7 @@
 	<Button on:click={() => (selectedOptions = ['bus', 'train'])}>Select bus and train!</Button>
 
 	<div class="my-4">
-		<CheckboxGroup options={optionsForGroup} bind:selectedOptions buttonsHidden />
+		<CheckboxGroup options={optionsForGroup} bind:selectedOptions buttonsHidden {ariaLabel} />
 	</div>
 	<p class="mt-4 text-color-text-secondary">
 		selectedOptions: {JSON.stringify(selectedOptions)}
@@ -95,6 +104,7 @@
 		hint="Contextual Hint"
 		description="This is a description"
 		disabled
+		{ariaLabel}
 	/>
 	<p class="mt-4 text-color-text-secondary">
 		selectedOptions: {JSON.stringify(selectedOptions)}
@@ -110,6 +120,7 @@
 		hint="Contextual Hint"
 		description="Deselect all to see an error state!"
 		error={!selectedOptions.length ? 'You must select an option' : undefined}
+		{ariaLabel}
 	/>
 	<p class="mt-4 text-color-text-secondary">
 		selectedOptions: {JSON.stringify(selectedOptions)}

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -21,6 +21,11 @@
 	export let label = '';
 
 	/**
+	 * Enables screen reader to describe group
+	 */
+	export let ariaLabel = '';
+
+	/**
 	 * Text that appears below the `<input>` element, in smaller font than the `label`.
 	 */
 	export let description = '';
@@ -151,7 +156,7 @@
 	{optional}
 >
 	<slot name="hint" slot="hint" />
-	<div class="flex flex-col space-y-1">
+	<div {id} role="group" aria-label={ariaLabel} class="flex flex-col space-y-1">
 		{#if !buttonsHidden}
 			<!--
 			form="" should prevent this checkbox from being included in form
@@ -169,19 +174,21 @@
 			/>
 		{/if}
 
-		<div class={`flex flex-col space-y-1 ${buttonsHidden ? '' : 'pl-5'}`}>
+		<ul class={`flex flex-col space-y-1 ${buttonsHidden ? '' : 'pl-5'}`}>
 			{#each options as option (option.id)}
-				<Checkbox
-					id={option.id}
-					name={option.name}
-					label={option.label}
-					color={option.color}
-					disabled={option.disabled || disabled}
-					hint={option.hint}
-					hintLabel={option.hintLabel}
-					bind:checked={selectionState[option.id]}
-				/>
+				<li>
+					<Checkbox
+						id={option.id}
+						name={option.name}
+						label={option.label}
+						color={option.color}
+						disabled={option.disabled || disabled}
+						hint={option.hint}
+						hintLabel={option.hintLabel}
+						bind:checked={selectionState[option.id]}
+					/>
+				</li>
 			{/each}
-		</div>
+		</ul>
 	</div>
 </InputWrapper>

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -21,7 +21,7 @@
 	export let label = '';
 
 	/**
-	 * Enables screen reader to describe group
+	 * Accessible name of group to be read by screen reader.
 	 */
 	export let ariaLabel = '';
 

--- a/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
@@ -82,10 +82,12 @@
 			size: 1
 		}
 	};
+
+	let ariaLabel = 'Customise layers';
 </script>
 
 <Template let:args>
-	<LayerControlGroup bind:options={optionsForGroup} bind:state={state1} {...args} />
+	<LayerControlGroup bind:options={optionsForGroup} bind:state={state1} {...args} {ariaLabel} />
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
 </Template>
 
@@ -98,6 +100,7 @@
 		disableOpacityControl
 		disableSizeControl
 		label="Layer Control Group"
+		{ariaLabel}
 	/>
 
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
@@ -111,6 +114,7 @@
 		disableSizeControl
 		label="Layer Control Group"
 		hint="Turn the layers of the map on and off"
+		{ariaLabel}
 	/>
 
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
@@ -125,6 +129,7 @@
 		label="Layer Control Group"
 		hint="Turn the layers of the map on and off"
 		description="Transport layers - Taxis disabled"
+		{ariaLabel}
 	/>
 
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
@@ -136,13 +141,14 @@
 		bind:state={state1}
 		disableOpacityControl
 		disableSizeControl
+		{ariaLabel}
 	/>
 
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
 </Story>
 
 <Story name="Disable controls size and opacity controls for some layers">
-	<LayerControlGroup bind:options={optionsForGroup2} bind:state={state2} />
+	<LayerControlGroup bind:options={optionsForGroup2} bind:state={state2} {ariaLabel} />
 	<pre class="mt-4 text-xs">{JSON.stringify(state2, null, 2)}</pre>
 </Story>
 
@@ -153,6 +159,7 @@
 			bind:state={state1}
 			disableOpacityControl
 			disableSizeControl
+			{ariaLabel}
 		/>
 	</div>
 </Story>
@@ -167,13 +174,20 @@ For example, choropleth layers would cover each other.
 		bind:state={state1}
 		mutuallyExclusive
 		name="mutually-exclusive-layers"
+		{ariaLabel}
 	/>
 
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
 </Story>
 
 <Story name="Disabled (global)">
-	<LayerControlGroup bind:options={optionsForGroup} bind:state={state1} disabled name="Disabled" />
+	<LayerControlGroup
+		bind:options={optionsForGroup}
+		bind:state={state1}
+		disabled
+		name="Disabled"
+		{ariaLabel}
+	/>
 
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
 </Story>
@@ -188,6 +202,7 @@ For example, choropleth layers would cover each other.
 		error={Object.values(state1).every((layer) => layer.visible === false)
 			? 'You must select an option'
 			: undefined}
+		{ariaLabel}
 	/>
 
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>

--- a/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
@@ -23,6 +23,11 @@
 	export let label = '';
 
 	/**
+	 * Enables screen reader to describe group
+	 */
+	export let ariaLabel = '';
+
+	/**
 	 * Text that appears below the `<input>` element, in smaller font than the `label`.
 	 */
 	export let description = '';
@@ -209,25 +214,27 @@
 	{optional}
 >
 	<slot name="hint" slot="hint" />
-	<div class="flex flex-col space-y-1">
+	<div {id} role="group" aria-label={ariaLabel} class="flex flex-col space-y-1">
 		{#if mutuallyExclusive}
 			{#if !buttonsHidden}
 				<Button {disabled} variant="text" class="!px-0" on:click={clearRadioButtons}>Clear</Button>
 			{/if}
 
-			<div class={'flex flex-col space-y-1'}>
+			<ul class={'flex flex-col space-y-1'}>
 				{#each options as option}
-					<LayerControl
-						label={option.label}
-						{name}
-						bind:state={state[option.id]}
-						optionId={option.id}
-						disabled={option.disabled || disabled}
-						bind:selectedOptionId
-						mutuallyExclusive
-					/>
+					<li>
+						<LayerControl
+							label={option.label}
+							{name}
+							bind:state={state[option.id]}
+							optionId={option.id}
+							disabled={option.disabled || disabled}
+							bind:selectedOptionId
+							mutuallyExclusive
+						/>
+					</li>
 				{/each}
-			</div>
+			</ul>
 		{:else}
 			{#if !buttonsHidden}
 				<!--
@@ -245,20 +252,22 @@
 				/>
 			{/if}
 
-			<div class={`flex flex-col space-y-1 ${buttonsHidden ? '' : 'pl-5'}`}>
+			<ul class={`flex flex-col space-y-1 ${buttonsHidden ? '' : 'pl-5'}`}>
 				{#each options as option (option.id)}
-					<LayerControl
-						label={option.label}
-						disabled={option.disabled || disabled}
-						hint={option.hint}
-						disableColorControl={disableColorControl || option.disableColorControl}
-						disableOpacityControl={disableOpacityControl || option.disableOpacityControl}
-						disableSizeControl={disableSizeControl || option.disableSizeControl}
-						bind:state={state[option.id]}
-						{controlsInUse}
-					/>
+					<li>
+						<LayerControl
+							label={option.label}
+							disabled={option.disabled || disabled}
+							hint={option.hint}
+							disableColorControl={disableColorControl || option.disableColorControl}
+							disableOpacityControl={disableOpacityControl || option.disableOpacityControl}
+							disableSizeControl={disableSizeControl || option.disableSizeControl}
+							bind:state={state[option.id]}
+							{controlsInUse}
+						/>
+					</li>
 				{/each}
-			</div>
+			</ul>
 		{/if}
 	</div>
 </InputWrapper>


### PR DESCRIPTION
**What does this change?**
I've updated the `LayerControlGroup` and `CheckboxGroup` components to use semantic html for better screen reader accessibility. I've also updated `Checkbox` to improve screen reader accessibility for tooltips inside checkbox components.

**Why?**
Improving screen reader accessibility

**How?**
`LayerControlGroup` and `CheckboxGroup` now have:

- `id` and `role="group"` attributes on the div that wraps around the `LayerControl` or `Checkbox` inputs
- `ariaLabel` prop to describe the purpose of the LayerControlGroup/CheckboxGroup to screen reader users
- `<ul>` element surrounding the options, with each option nested in an `<li>` element so screen reader users know the options are connected and how many there are

`Checkbox` now explicitly nests a `Trigger` component in the `Overlay` with an `ariaLabel` in cases where `hintLabel` doesn't exist.

**Related issues**: Closes #935 

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
