### PR TITLE
tables: improve ARIA

### DIFF
--- a/.changeset/table-aria.md
+++ b/.changeset/table-aria.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/tables': minor
+---
+
+CHANGED: improve ARIA for table component

--- a/packages/tables/src/lib/core/renderers/Header.svelte
+++ b/packages/tables/src/lib/core/renderers/Header.svelte
@@ -46,13 +46,7 @@
 	$$restProps;
 </script>
 
-<div
-	on:click={toggle}
-	on:keypress={toggle}
-	role="cell"
-	tabindex={0}
-	class="font-bold py-0.5 w-full h-full"
->
+<div on:click={toggle} on:keypress={toggle} tabindex={0} class="font-bold py-0.5 w-full h-full">
 	<div class={classNames('flex items-center select-none', alignmentClass)}>
 		{#if superscriptText}
 			<div class="text-left">

--- a/packages/tables/src/lib/core/renderers/Header.svelte
+++ b/packages/tables/src/lib/core/renderers/Header.svelte
@@ -46,10 +46,11 @@
 	$$restProps;
 </script>
 
-<div on:click={toggle} on:keypress={toggle} tabindex={0} class="font-bold py-0.5 w-full h-full">
+<div class="font-bold py-0.5 w-full h-full">
 	<svelte:element
 		this={allowSorting ? 'button' : 'div'}
 		class={classNames('flex items-center select-none', alignmentClass)}
+		on:click={allowSorting ? toggle : undefined}
 	>
 		{#if superscriptText}
 			<div class="text-left">

--- a/packages/tables/src/lib/core/renderers/Header.svelte
+++ b/packages/tables/src/lib/core/renderers/Header.svelte
@@ -47,7 +47,10 @@
 </script>
 
 <div on:click={toggle} on:keypress={toggle} tabindex={0} class="font-bold py-0.5 w-full h-full">
-	<div class={classNames('flex items-center select-none', alignmentClass)}>
+	<svelte:element
+		this={allowSorting ? 'button' : 'div'}
+		class={classNames('flex items-center select-none', alignmentClass)}
+	>
 		{#if superscriptText}
 			<div class="text-left">
 				<span class="font-normal text-xs">{superscriptText}</span><br />
@@ -68,7 +71,7 @@
 				aria-hidden="true"
 			/>
 		{/if}
-	</div>
+	</svelte:element>
 </div>
 
 <style>

--- a/packages/tables/src/lib/table/Table.svelte
+++ b/packages/tables/src/lib/table/Table.svelte
@@ -239,6 +239,7 @@
 				class="table-auto text-sm w-full text-color-text-primary"
 				slot="table"
 				bind:clientWidth={tableWidth}
+				role="table"
 			>
 				<TableHeader {tableSpec} {table} {data} {allowSorting} {tableWidth} />
 

--- a/packages/tables/src/lib/table/Table.svelte
+++ b/packages/tables/src/lib/table/Table.svelte
@@ -244,7 +244,7 @@
 				<TableHeader {tableSpec} {table} {data} {allowSorting} {tableWidth} />
 
 				{#if paginate}
-					<div style:width={tableWidth} class:striped={zebraStripe}>
+					<div style:width={tableWidth} class:striped={zebraStripe} role="rowgroup">
 						{#each visualRows as visualRow, i}
 							{#if i > (page - 1) * pageSize + 1 && i <= page * pageSize + 1}
 								<RowRenderer spec={visualRow} {table} />
@@ -256,13 +256,14 @@
 						style:height={`${height - 100}px`}
 						style:width={tableWidth}
 						class:stripedVirtual={zebraStripe}
+						role="rowgroup"
 					>
 						<VirtualScroll data={visualRows} key="uniqueKey" let:data>
 							<RowRenderer spec={data} {table} />
 						</VirtualScroll>
 					</div>
 				{:else}
-					<div style:width={tableWidth} class:striped={zebraStripe}>
+					<div style:width={tableWidth} class:striped={zebraStripe} role="rowgroup">
 						{#each visualRows as visualRow}
 							<RowRenderer spec={visualRow} {table} />
 						{/each}

--- a/packages/tables/src/lib/table/TableHeader.svelte
+++ b/packages/tables/src/lib/table/TableHeader.svelte
@@ -35,6 +35,7 @@
 <div
 	class={classNames(topRuleClass, bottomRuleClass, 'border-color-ui-border-primary py-2')}
 	style:width={tableWidth}
+	role="rowgroup"
 >
 	{#if tableSpec.colGroups && tableSpec.colGroups.some((c) => c.label)}
 		<ColumnGroupHeadingRow {table} />

--- a/packages/tables/src/lib/table/TableHeader.svelte
+++ b/packages/tables/src/lib/table/TableHeader.svelte
@@ -51,7 +51,9 @@
 		<ColumnSummariesRow {table} {data} />
 	{/if}
 
-	<AxisRow {table} />
+	{#if table.columnSpec.some((c) => c.cell.axisRenderer)}
+		<AxisRow {table} />
+	{/if}
 
 	{#if tableSpec.colGroups}
 		<ColumnGroupHeadingRuleRow {table} />

--- a/packages/tables/src/lib/table/rows/DataRow.svelte
+++ b/packages/tables/src/lib/table/rows/DataRow.svelte
@@ -13,7 +13,7 @@
 		{#each table.columnSpec as col, i}
 			{#if !table.visibleFields || table.visibleFields.includes(col.short_label)}
 				<!-- <td>{row[col.short_label]}</td> -->
-				<div style:width={col.computedWidth + 'px'} class="was-td">
+				<div style:width={col.computedWidth + 'px'} class="was-td" role="cell">
 					{#if col.cell && col.cell.renderer}
 						<DataCell href={col.href} {row}>
 							<svelte:component

--- a/packages/tables/src/lib/table/rows/Scaffolding.svelte
+++ b/packages/tables/src/lib/table/rows/Scaffolding.svelte
@@ -12,7 +12,7 @@
 
 <!-- items-center - came from DataRow -->
 <!-- controlRows added an m-2 -->
-<div class="flex was-tr items-stretch">
+<div class="flex was-tr items-stretch" role="row">
 	<!-- controls for expanding/collapsing groups -->
 	<slot name="groupControl">
 		{#each table.groupingFields || [] as _field}

--- a/packages/tables/src/lib/table/rows/headerRows/AxisRow.svelte
+++ b/packages/tables/src/lib/table/rows/headerRows/AxisRow.svelte
@@ -7,24 +7,22 @@
 
 <Scaffolding {table}>
 	<svelte:fragment slot="dataColumns">
-		{#if table.columnSpec.some((c) => c.cell.axisRenderer)}
-			{#each table.columnSpec as col, i}
-				{#if !table.visibleFields || table.visibleFields.includes(col.short_label)}
-					<div style:width={col.computedWidth + 'px'} class="was-td">
-						{#if col.cell && col.cell.axisRenderer}
-							<svelte:component
-								this={col.cell.axisRenderer}
-								colorScale={table.scales[col.short_label]}
-								posScale={table.posScales[col.short_label]}
-								extent={table.extents[col.short_label]}
-								{...col.cell}
-								width={col.computedWidth}
-							/>
-						{/if}
-					</div>
-				{/if}
-				<ColGroupSpacer {table} {i} />
-			{/each}
-		{/if}
+		{#each table.columnSpec as col, i}
+			{#if !table.visibleFields || table.visibleFields.includes(col.short_label)}
+				<div style:width={col.computedWidth + 'px'} class="was-td">
+					{#if col.cell && col.cell.axisRenderer}
+						<svelte:component
+							this={col.cell.axisRenderer}
+							colorScale={table.scales[col.short_label]}
+							posScale={table.posScales[col.short_label]}
+							extent={table.extents[col.short_label]}
+							{...col.cell}
+							width={col.computedWidth}
+						/>
+					{/if}
+				</div>
+			{/if}
+			<ColGroupSpacer {table} {i} />
+		{/each}
 	</svelte:fragment>
 </Scaffolding>

--- a/packages/tables/src/lib/table/rows/headerRows/AxisRow.svelte
+++ b/packages/tables/src/lib/table/rows/headerRows/AxisRow.svelte
@@ -7,22 +7,24 @@
 
 <Scaffolding {table}>
 	<svelte:fragment slot="dataColumns">
-		{#each table.columnSpec as col, i}
-			{#if !table.visibleFields || table.visibleFields.includes(col.short_label)}
-				<div style:width={col.computedWidth + 'px'} class="was-td">
-					{#if col.cell && col.cell.axisRenderer}
-						<svelte:component
-							this={col.cell.axisRenderer}
-							colorScale={table.scales[col.short_label]}
-							posScale={table.posScales[col.short_label]}
-							extent={table.extents[col.short_label]}
-							{...col.cell}
-							width={col.computedWidth}
-						/>
-					{/if}
-				</div>
-			{/if}
-			<ColGroupSpacer {table} {i} />
-		{/each}
+		{#if table.columnSpec.some((c) => c.cell.axisRenderer)}
+			{#each table.columnSpec as col, i}
+				{#if !table.visibleFields || table.visibleFields.includes(col.short_label)}
+					<div style:width={col.computedWidth + 'px'} class="was-td">
+						{#if col.cell && col.cell.axisRenderer}
+							<svelte:component
+								this={col.cell.axisRenderer}
+								colorScale={table.scales[col.short_label]}
+								posScale={table.posScales[col.short_label]}
+								extent={table.extents[col.short_label]}
+								{...col.cell}
+								width={col.computedWidth}
+							/>
+						{/if}
+					</div>
+				{/if}
+				<ColGroupSpacer {table} {i} />
+			{/each}
+		{/if}
 	</svelte:fragment>
 </Scaffolding>

--- a/packages/tables/src/lib/table/rows/headerRows/ColumnHeadingRow.svelte
+++ b/packages/tables/src/lib/table/rows/headerRows/ColumnHeadingRow.svelte
@@ -42,12 +42,19 @@
 	<svelte:fragment slot="dataColumns">
 		{#each table.columnSpec as col, i}
 			{#if !table.visibleFields || table.visibleFields.includes(col.short_label)}
-				<div class="flex was-th" role="columnheader" style:width={col.computedWidth + 'px'}>
+				{@const colIsSortable = allowSorting && col.sortable !== false}
+				{@const order = table.rowOrderSpec.find((f) => f.field === col.short_label)?.direction}
+
+				<div
+					class="flex was-th"
+					role="columnheader"
+					style:width={col.computedWidth + 'px'}
+					aria-sort={colIsSortable ? order : ''}
+				>
 					<Header
 						label={col.label ?? col.short_label}
-						order={table.rowOrderSpec.find((f) => f.field === col.short_label)?.direction}
-						toggle={() =>
-							allowSorting && col.sortable !== false && table.toggleSort(col.short_label)}
+						{order}
+						toggle={() => colIsSortable && table.toggleSort(col.short_label)}
 						allowSorting={allowSorting && col.sortable !== false}
 						alignHeader={col.alignHeader}
 						superscriptText={col.superscriptText}


### PR DESCRIPTION
This improves the ARIA for the table component.

For the [basic example table](https://dev.ldn-gis.co.uk/storybook-table-aria/?path=/story/tables-components-table--default), Vocie Assitant allows navigation with Control-Option-[up/down/left/right] and correctly describes cell contents, e.g.:

* "First Name Margharet. Column 1 of 3" - when shifting between columns
* "Row 14 of 21: Margharet" - when shifting between rows
