### PR TITLE
Toast: fixed css selector target

### DIFF
--- a/.changeset/lazy-bears-search.md
+++ b/.changeset/lazy-bears-search.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: CSS selector changed from 'dialog' to 'alert'

--- a/packages/ui/src/lib/toaster/Toast.svelte
+++ b/packages/ui/src/lib/toaster/Toast.svelte
@@ -52,7 +52,7 @@
 </div>
 
 <style>
-	div[role='dialog'] {
+	div[role='alert'] {
 		width: clamp(200px, 24rem, calc(100vw - 1rem));
 		/* 
 			Because order is an integer with no intermediate values the transition


### PR DESCRIPTION
**What does this change?**
`Toast` had an unused CSS selector after I changed the role from 'dialog' to 'alert'. I updated the CSS selector to 'alert' to fix this.

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
