### PR TITLE
A11y: updated LayerControl and LayerControlGroup to apply name to checkboxes

### DIFF
--- a/.changeset/brown-glasses-shop.md
+++ b/.changeset/brown-glasses-shop.md
@@ -2,8 +2,8 @@
 '@ldn-viz/ui': minor
 ---
 
-CHANGED: `CheckboxGroup`, `LayerControl` and `LayerControlGroup` components for better accessibility
+CHANGED: `CheckboxGroup`, `LayerControl` and `LayerControlGroup` components
 
 - `LayerControlGroup` now passes `name` into `LayerControl`
 - `LayerControl` now passes `name` into `Checkbox`, in addition to `Radio`
-- `LayerControlGroup` and `CheckboxGroup` now have an `aria-controls` attribute on the checkbox that toggles all controls, with a value equal to the ids for all controls
+- For accessibility: `LayerControlGroup` and `CheckboxGroup` now have an `aria-controls` attribute on the checkbox that toggles all controls, with a value equal to the ids for all controls

--- a/.changeset/brown-glasses-shop.md
+++ b/.changeset/brown-glasses-shop.md
@@ -2,7 +2,8 @@
 '@ldn-viz/ui': minor
 ---
 
-CHANGED: applied `name` attribute to `Checkbox` components within `LayerControl` and `LayerControlGroup` for better accessibility
+CHANGED: `CheckboxGroup`, `LayerControl` and `LayerControlGroup` componenents for better accessibility
 
 - `LayerControlGroup` now passes `name` into `LayerControl`
 - `LayerControl` now passes `name` into `Checkbox`, in addition to `Radio`
+- `LayerControlGroup` and `CheckboxGroup` now have an `aria-controls` attribute on the checkbox that toggles all controls, with a value equal to the ids for all controls

--- a/.changeset/brown-glasses-shop.md
+++ b/.changeset/brown-glasses-shop.md
@@ -1,0 +1,8 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: applied `name` attribute to `Checkbox` components within `LayerControl` and `LayerControlGroup` for better accessibility
+
+- `LayerControlGroup` now passes `name` into `LayerControl`
+- `LayerControl` now passes `name` into `Checkbox`, in addition to `Radio`

--- a/.changeset/brown-glasses-shop.md
+++ b/.changeset/brown-glasses-shop.md
@@ -2,7 +2,7 @@
 '@ldn-viz/ui': minor
 ---
 
-CHANGED: `CheckboxGroup`, `LayerControl` and `LayerControlGroup` componenents for better accessibility
+CHANGED: `CheckboxGroup`, `LayerControl` and `LayerControlGroup` components for better accessibility
 
 - `LayerControlGroup` now passes `name` into `LayerControl`
 - `LayerControl` now passes `name` into `Checkbox`, in addition to `Radio`

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.svelte
@@ -140,6 +140,8 @@
 			clearAll();
 		}
 	};
+
+	let optionIds = options.map((o) => o.id).join(' ');
 </script>
 
 <InputWrapper
@@ -169,6 +171,7 @@
 				color="#3787D2"
 				checked={allCheckboxesCheckedOrDisabled}
 				indeterminate={!allCheckboxesCheckedOrDisabled && !noCheckboxesChecked}
+				aria-controls={optionIds}
 				on:change={toggleAll}
 				{disabled}
 			/>

--- a/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
@@ -10,28 +10,25 @@
 
 <script lang="ts">
 	let optionsForGroup = [
-		{ id: 'bus', name: 'transport', label: 'Bus stops' },
+		{ id: 'bus', label: 'Bus stops' },
 		{
 			id: 'train',
-			name: 'transport',
 			label: 'Train stations',
 			hint: 'Excluding underground stations'
 		},
-		{ id: 'underground', name: 'transport', label: 'Underground stations' },
-		{ id: 'taxi', name: 'transport', label: 'Taxi ranks', disabled: true }
+		{ id: 'underground', label: 'Underground stations' },
+		{ id: 'taxi', label: 'Taxi ranks', disabled: true }
 	];
 
 	let optionsForGroup2 = [
-		{ id: 'bus', name: 'transport', label: 'Bus stops' },
+		{ id: 'bus', label: 'Bus stops' },
 		{
 			id: 'train',
-			name: 'transport',
 			label: 'Train stations',
 			hint: 'Excluding underground stations'
 		},
 		{
 			id: 'underground',
-			name: 'transport',
 			label: 'Underground stations',
 			disableOpacityControl: true,
 			disableSizeControl: true

--- a/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
@@ -10,25 +10,28 @@
 
 <script lang="ts">
 	let optionsForGroup = [
-		{ id: 'bus', label: 'Bus stops' },
+		{ id: 'bus', name: 'transport', label: 'Bus stops' },
 		{
 			id: 'train',
+			name: 'transport',
 			label: 'Train stations',
 			hint: 'Excluding underground stations'
 		},
-		{ id: 'underground', label: 'Underground stations' },
-		{ id: 'taxi', label: 'Taxi ranks', disabled: true }
+		{ id: 'underground', name: 'transport', label: 'Underground stations' },
+		{ id: 'taxi', name: 'transport', label: 'Taxi ranks', disabled: true }
 	];
 
 	let optionsForGroup2 = [
-		{ id: 'bus', label: 'Bus stops' },
+		{ id: 'bus', name: 'transport', label: 'Bus stops' },
 		{
 			id: 'train',
+			name: 'transport',
 			label: 'Train stations',
 			hint: 'Excluding underground stations'
 		},
 		{
 			id: 'underground',
+			name: 'transport',
 			label: 'Underground stations',
 			disableOpacityControl: true,
 			disableSizeControl: true

--- a/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
@@ -49,7 +49,7 @@
 <Story name="Default" source />
 
 <Story name="With Label" source>
-	<LayerControl bind:state label="Borough" name="label" />
+	<LayerControl bind:state label="Borough" />
 </Story>
 
 <Story name="With Label and hint" source>
@@ -57,20 +57,19 @@
 		bind:state
 		label="Borough"
 		hint="Boundaries of each of Greater London's 32 boroughs"
-		name="label and hint"
 	/>
 </Story>
 
 <Story name="Hide color control" source>
-	<LayerControl bind:state label="Borough" disableColorControl name="hide color" />
+	<LayerControl bind:state label="Borough" disableColorControl />
 </Story>
 
 <Story name="Hide opacity control" source>
-	<LayerControl bind:state label="Borough" disableOpacityControl name="hide opacity" />
+	<LayerControl bind:state label="Borough" disableOpacityControl />
 </Story>
 
 <Story name="Hide size control" source>
-	<LayerControl bind:state label="Borough" disableSizeControl name="hide size" />
+	<LayerControl bind:state label="Borough" disableSizeControl />
 </Story>
 
 <Story name="Checkbox only" source>
@@ -80,20 +79,14 @@
 		disableOpacityControl
 		disableColorControl
 		disableSizeControl
-		name="checkbox only"
 	/>
 </Story>
 
 <Story name="Multiple control instances" source>
 	<div class="space-y-1">
-		<LayerControl bind:state={layerStates.boroughs} label="Borough" name="borough" />
-		<LayerControl
-			bind:state={layerStates.imd}
-			label="IMD"
-			hint="Index of Multiple Deprivation"
-			name="IMD"
-		/>
-		<LayerControl bind:state={layerStates.fuel_poverty} label="Fuel Poverty" name="fuel poverty" />
+		<LayerControl bind:state={layerStates.boroughs} label="Borough" />
+		<LayerControl bind:state={layerStates.imd} label="IMD" hint="Index of Multiple Deprivation" />
+		<LayerControl bind:state={layerStates.fuel_poverty} label="Fuel Poverty" />
 	</div>
 
 	<div class="mt-4 text-xs">
@@ -104,11 +97,15 @@
 </Story>
 
 <Story name="Disabled (Color)" source>
-	<LayerControl bind:state label="Borough" disableColorControl name="disabled color" />
+	<LayerControl bind:state label="Borough" disableColorControl />
 </Story>
 <Story name="Disabled (Opacity)" source>
-	<LayerControl bind:state label="Borough" disableOpacityControl name="disabled opacity" />
+	<LayerControl bind:state label="Borough" disableOpacityControl />
 </Story>
 <Story name="Disabled (Size)" source>
-	<LayerControl bind:state label="Borough" disableSizeControl name="disabled size" />
+	<LayerControl bind:state label="Borough" disableSizeControl />
+</Story>
+
+<Story name="With name prop" source>
+	<LayerControl bind:state label="Borough" name="borough" />
 </Story>

--- a/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
@@ -34,7 +34,7 @@
 
 <Template let:args>
 	<div class="w-96">
-		<LayerControl bind:state {...args} />
+		<LayerControl bind:state {...args} name="default" />
 	</div>
 	<pre class="mt-4 text-xs">{JSON.stringify(state, null, 2)}</pre>
 
@@ -49,7 +49,7 @@
 <Story name="Default" source />
 
 <Story name="With Label" source>
-	<LayerControl bind:state label="Borough" />
+	<LayerControl bind:state label="Borough" name="label" />
 </Story>
 
 <Story name="With Label and hint" source>
@@ -57,19 +57,20 @@
 		bind:state
 		label="Borough"
 		hint="Boundaries of each of Greater London's 32 boroughs"
+		name="label and hint"
 	/>
 </Story>
 
 <Story name="Hide color control" source>
-	<LayerControl bind:state label="Borough" disableColorControl />
+	<LayerControl bind:state label="Borough" disableColorControl name="hide color" />
 </Story>
 
 <Story name="Hide opacity control" source>
-	<LayerControl bind:state label="Borough" disableOpacityControl />
+	<LayerControl bind:state label="Borough" disableOpacityControl name="hide opacity" />
 </Story>
 
 <Story name="Hide size control" source>
-	<LayerControl bind:state label="Borough" disableSizeControl />
+	<LayerControl bind:state label="Borough" disableSizeControl name="hide size" />
 </Story>
 
 <Story name="Checkbox only" source>
@@ -79,14 +80,20 @@
 		disableOpacityControl
 		disableColorControl
 		disableSizeControl
+		name="checkbox only"
 	/>
 </Story>
 
 <Story name="Multiple control instances" source>
 	<div class="space-y-1">
-		<LayerControl bind:state={layerStates.boroughs} label="Borough" />
-		<LayerControl bind:state={layerStates.imd} label="IMD" hint="Index of Multiple Deprivation" />
-		<LayerControl bind:state={layerStates.fuel_poverty} label="Fuel Poverty" />
+		<LayerControl bind:state={layerStates.boroughs} label="Borough" name="borough" />
+		<LayerControl
+			bind:state={layerStates.imd}
+			label="IMD"
+			hint="Index of Multiple Deprivation"
+			name="IMD"
+		/>
+		<LayerControl bind:state={layerStates.fuel_poverty} label="Fuel Poverty" name="fuel poverty" />
 	</div>
 
 	<div class="mt-4 text-xs">
@@ -97,11 +104,11 @@
 </Story>
 
 <Story name="Disabled (Color)" source>
-	<LayerControl bind:state label="Borough" disableColorControl />
+	<LayerControl bind:state label="Borough" disableColorControl name="disabled color" />
 </Story>
 <Story name="Disabled (Opacity)" source>
-	<LayerControl bind:state label="Borough" disableOpacityControl />
+	<LayerControl bind:state label="Borough" disableOpacityControl name="disabled opacity" />
 </Story>
 <Story name="Disabled (Size)" source>
-	<LayerControl bind:state label="Borough" disableSizeControl />
+	<LayerControl bind:state label="Borough" disableSizeControl name="disabled size" />
 </Story>

--- a/packages/ui/src/lib/layerControl/LayerControl.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.svelte
@@ -91,7 +91,8 @@
 	export let optionId = randomId();
 
 	/**
-	 * Name of the radio button group  (used only if `mutuallyExclusive` is true)
+	 * Name of the radio/checkbox button group. If `mutuallyExclusive` is true,
+	 * this is required (should have the same value for all radio buttons in group).
 	 */
 	export let name = '';
 
@@ -114,7 +115,7 @@
 				{name}
 			/>
 		{:else}
-			<Checkbox bind:checked={state.visible} label="" {disabled} id={optionId} />
+			<Checkbox bind:checked={state.visible} label="" {disabled} id={optionId} {name} />
 		{/if}
 	</div>
 

--- a/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
@@ -74,6 +74,7 @@
 	 * Each element of this array defines the control for a layer, and is an object with the properties:
 	 * * `id` (string)
 	 * * `label` (string) - the text displayed next to the checkbox
+	 * * `name` (string, optional) - for use by radio or checkbox buttons
 	 * * `hint` (string, optional) - help text to be displayed in tooltip
 	 *
 	 * * `disableColorControl` (boolean) - if `true`, then the trigger to open the opacity control for this layer is not displayed
@@ -89,8 +90,8 @@
 	export let options: {
 		id: string;
 		label: string;
+		name?: string;
 		hint?: string;
-
 		disabled?: boolean;
 		disableColorControl?: boolean;
 		disableOpacityControl?: boolean;
@@ -138,6 +139,10 @@
 	export let showAllLabel = 'Show all';
 
 	export let mutuallyExclusive = false;
+
+	/**
+	 * Name of the radio button group (used only if `mutuallyExclusive` is true)
+	 */
 	export let name = '';
 
 	let allCheckboxesCheckedOrDisabled: boolean;
@@ -167,6 +172,8 @@
 			clearAll();
 		}
 	};
+
+	let optionIds = options.map((o) => o.id).join(' ');
 
 	let selectedOptionId: string | undefined; // only used by radioButtons, if mutuallyExclusive
 	const updateStateFromCheckbox = (selectedId: string | undefined) => {
@@ -247,6 +254,7 @@
 					label={showAllLabel}
 					checked={allCheckboxesCheckedOrDisabled}
 					indeterminate={!allCheckboxesCheckedOrDisabled && !noCheckboxesChecked}
+					aria-controls={optionIds}
 					on:change={toggleAll}
 					{disabled}
 				/>
@@ -257,6 +265,7 @@
 					<li>
 						<LayerControl
 							label={option.label}
+							name={option.name}
 							disabled={option.disabled || disabled}
 							hint={option.hint}
 							disableColorControl={disableColorControl || option.disableColorControl}


### PR DESCRIPTION
**What does this change?**
- `LayerControlGroup` now passes `name` into `LayerControl`
- `LayerControl` now passes `name` into `Checkbox`, in addition to `Radio`
- `LayerControlGroup` and `CheckboxGroup` now have an `aria-controls` attribute on the checkbox that toggles all controls, with a value equal to the ids for all controls

**Why?**
For better accessibility

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
