### PR TITLE
changed defaultArea to use fillOpacity instead of opacity

### DIFF
--- a/.changeset/gold-deers-end.md
+++ b/.changeset/gold-deers-end.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/charts': minor
+---
+
+CHANGED: defaultArea plot fragment uses fillOpacity instead of opacity for consistency with other plot fragments

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -114,6 +114,43 @@
 			)
 		]
 	};
+
+	// Spec and data for area example
+	$: areaData = demoMonthlyTimeseriesLong.filter((d) => d.Variable == 'Variable A');
+	$: areaSpec = {
+		x: { insetLeft: 80, insetRight: 20, type: 'utc' },
+		marks: [
+			Plot.gridX({ interval: '2 years' }),
+			Plot.gridY(),
+			Plot.axisX({ label: 'Year', interval: '1 year' }),
+			Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+			Plot.ruleY([0]),
+			Plot.areaY(areaData, {
+				x: 'Month',
+				y: 'Value'
+			}),
+			Plot.line(areaData, {
+				x: 'Month',
+				y: 'Value',
+				z: 'Variable',
+				stroke: $currentTheme.color.data.primary,
+				tip: true
+			})
+		]
+	};
+
+	// Spec for area (with custom fillOpacity) example
+	$: areaOpacitySpec = {
+		...areaSpec,
+		marks: [
+			...areaSpec.marks,
+			Plot.areaY(areaData, {
+				x: 'Month',
+				y: 'Value',
+				fillOpacity: 0.8
+			})
+		]
+	};
 </script>
 
 <Template let:args>
@@ -180,85 +217,85 @@
 </Story>
 
 <!--
-```html
-<script>
-	import { Plot, plotTheme } from '@ldn-viz/charts';
-	import demoMonthlyTimeseriesLong from '../../data/demoMonthlyTimeseriesLong.json'; // import or load your data
-	import { format } from 'd3'; // for formatting numbers in the chart	
-
-	const formatLow = format(',.0f'); // for lower than 10000, format commas and not dp
-	const formatHigh = format(',.4~s'); // for 10000 and above, format commas and SI numbering (M & K)
-
-	$: multiLineData = demoMonthlyTimeseriesLong; // using demo data directly, without parsing
-	$: multiLineSpec = {
-		x: { insetLeft: 80, insetRight: 20, type: 'utc' },
-		color: {
-			legend: true,
-			type: 'ordinal',
-			range: [
-				$currentTheme.color.data.primary,
-				$currentTheme.color.data.secondary,
-				$currentTheme.color.data.tertiary
-			]
-		},
-		marks: [
-			Plot.gridX({ interval: '2 years' }),
-			Plot.gridY(),
-			Plot.axisX({ interval: '1 year' }),
-			Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
-			Plot.ruleY([0]),
-			Plot.line(multiLineData, {
-				x: 'Month',
-				y: 'Value',
-				z: 'Variable',
-				stroke: 'Variable'
-			}),
-
-			Plot.ruleX(
-				multiLineData,
-				Plot.pointerX({ x: 'Month', stroke: $currentTheme.color.chart.label })
-			),
-			Plot.point(
-				multiLineData,
-				Plot.pointer({ x: 'Month', y: 'Value', z: 'Variable', stroke: 'Variable' })
-			),
-			Plot.tip(
-				multiLineData,
-				Plot.pointer({
-					x: 'Month',
-					y: 'Value',
-					z: 'Variable',
-					channels: {
-						Variable: 'Variable',
-						Month: { value: 'Month', label: 'Date' },
-						Value: { value: 'Value', label: 'GBP' }
-					},
-					format: {
-						Variable: true,
-						Month: true,
-						Value: (d) => '£' + formatHigh(d),
-						x: false,
-						y: false
-					}
-				})
-			)
-		]
-	};
-</script>
-
-<ObservablePlot
-	spec={multiLineSpec}
-	data={multiLineData}
-	title={'In London, all variable values have fallen steadily since 2017, with Variable A experiencing the most significant fall'}
-	subTitle={'London monthly estimated variable values (GBP), January 2015 to March 2024'}
-	alt={'Line chart of London variable values'}
-	byline={'GLA City Intelligence'}
-	source={'LDN Viz Tools Demo Data'}
-	note={'Data for demonstration only'}
-	chartDescription={"The line chart shows monthly time series data for Variable A, B and C, measured in GBP (Pounds Sterling). The x axis ranges in months from January 2015 to March 2024. The y axis ranges from £0 to £60,000. All variable values have fallen steadily since around 2017, but Variable A has fallen the most. Variable A's highest value was £61,816 in February 2015, its lowest value was £11,667 in July 2023, (a change of around -£50,149) and its mean average value was £30,758. Variable B and C follow a similar fall, with a mean average of £27,545 and £23,681 respectively."}
-/>
-```
--->
+	```html
+	<script>
+		import { Plot, plotTheme } from '@ldn-viz/charts';
+		import demoMonthlyTimeseriesLong from '../../data/demoMonthlyTimeseriesLong.json'; // import or load your data
+		import { format } from 'd3'; // for formatting numbers in the chart	
+		
+		const formatLow = format(',.0f'); // for lower than 10000, format commas and not dp
+		const formatHigh = format(',.4~s'); // for 10000 and above, format commas and SI numbering (M & K)
+		
+		$: multiLineData = demoMonthlyTimeseriesLong; // using demo data directly, without parsing
+		$: multiLineSpec = {
+			x: { insetLeft: 80, insetRight: 20, type: 'utc' },
+			color: {
+				legend: true,
+				type: 'ordinal',
+				range: [
+					$currentTheme.color.data.primary,
+					$currentTheme.color.data.secondary,
+					$currentTheme.color.data.tertiary
+					]
+				},
+				marks: [
+					Plot.gridX({ interval: '2 years' }),
+					Plot.gridY(),
+					Plot.axisX({ interval: '1 year' }),
+					Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+					Plot.ruleY([0]),
+					Plot.line(multiLineData, {
+						x: 'Month',
+						y: 'Value',
+						z: 'Variable',
+						stroke: 'Variable'
+					}),
+					
+					Plot.ruleX(
+						multiLineData,
+						Plot.pointerX({ x: 'Month', stroke: $currentTheme.color.chart.label })
+						),
+						Plot.point(
+							multiLineData,
+							Plot.pointer({ x: 'Month', y: 'Value', z: 'Variable', stroke: 'Variable' })
+							),
+							Plot.tip(
+								multiLineData,
+								Plot.pointer({
+									x: 'Month',
+									y: 'Value',
+									z: 'Variable',
+									channels: {
+										Variable: 'Variable',
+										Month: { value: 'Month', label: 'Date' },
+										Value: { value: 'Value', label: 'GBP' }
+									},
+									format: {
+										Variable: true,
+										Month: true,
+										Value: (d) => '£' + formatHigh(d),
+										x: false,
+										y: false
+									}
+								})
+								)
+								]
+							};
+						</script>
+						
+						<ObservablePlot
+						spec={multiLineSpec}
+						data={multiLineData}
+						title={'In London, all variable values have fallen steadily since 2017, with Variable A experiencing the most significant fall'}
+						subTitle={'London monthly estimated variable values (GBP), January 2015 to March 2024'}
+						alt={'Line chart of London variable values'}
+						byline={'GLA City Intelligence'}
+						source={'LDN Viz Tools Demo Data'}
+						note={'Data for demonstration only'}
+						chartDescription={"The line chart shows monthly time series data for Variable A, B and C, measured in GBP (Pounds Sterling). The x axis ranges in months from January 2015 to March 2024. The y axis ranges from £0 to £60,000. All variable values have fallen steadily since around 2017, but Variable A has fallen the most. Variable A's highest value was £61,816 in February 2015, its lowest value was £11,667 in July 2023, (a change of around -£50,149) and its mean average value was £30,758. Variable B and C follow a similar fall, with a mean average of £27,545 and £23,681 respectively."}
+						/>
+						```
+					-->
 
 <Story name="Multiple lines (inc custom tool tips)" source>
 	<ObservablePlot
@@ -271,5 +308,142 @@
 		source={'LDN Viz Tools Demo Data'}
 		note={'Data for demonstration only'}
 		chartDescription={"The line chart shows monthly time series data for Variable A, B and C, measured in GBP (Pounds Sterling). The x axis ranges in months from January 2015 to March 2024. The y axis ranges from £0 to £60,000. All variable values have fallen steadily since around 2017, but Variable A has fallen the most. Variable A's highest value was £61,816 in February 2015, its lowest value was £11,667 in July 2023, (a change of around -£50,149) and its mean average value was £30,758. Variable B and C follow a similar fall, with a mean average of £27,545 and £23,681 respectively."}
+	/>
+</Story>
+
+<!--
+	```html
+	<script>
+		import { Plot, plotTheme } from '@ldn-viz/charts';
+		import demoMonthlyTimeseriesLong from '../../data/demoMonthlyTimeseriesLong.json'; // import or load your data
+		import { format } from 'd3'; // for formatting numbers in the chart	
+	
+		const formatLow = format(',.0f'); // for lower than 10000, format commas and not dp
+		const formatHigh = format(',.4~s'); // for 10000 and above, format commas and SI numbering (M & K)
+	
+		$: areaData = demoMonthlyTimeseriesLong.filter((d) => d.Variable == 'Variable A');
+		$: areaSpec = {
+			x: { insetLeft: 80, insetRight: 20, type: 'utc' },
+			marks: [
+				Plot.gridX({ interval: '2 years' }),
+				Plot.gridY(),
+				Plot.axisX({ label: 'Year', interval: '1 year' }),
+				Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+				Plot.ruleY([0]),
+				Plot.areaY(areaData, {
+					x: 'Month',
+					y: 'Value'
+				}),
+				Plot.line(areaData, {
+					x: 'Month',
+					y: 'Value',
+					z: 'Variable',
+					stroke: $currentTheme.color.data.primary,
+					tip: true
+				})
+			]
+		};
+		
+	</script>
+	
+	<ObservablePlot
+			spec={areaSpec}
+			data={areaData}
+			title={"In London, Variable A's value has fallen steadily since 2017"}
+			subTitle={"London monthly estimated variable value (GBP), January 2015 to March 2024"}
+			alt={"Area chart of London's variable A values"}
+			byline={"GLA City Intelligence"}
+			source={"LDN Viz Tools Demo Data"}
+			note={"Data for demonstration only"}
+			chartDescription={"The area chart shows monthly time series data for Variable A, measured in GBP (Pounds Sterling). The x axis ranges in months from January 2015 to March 2024. The y axis ranges from £0 to £60,000. Variable A's has fallen steadily since around 2017. Variable A's highest value was £61,816 in February 2015, its lowest value was £11,667 in July 2023, (a change of around -£50,149) and its mean average value was £30,758"}
+	/>
+	```
+-->
+
+<Story name="Area chart" source>
+	<ObservablePlot
+		spec={areaSpec}
+		data={areaData}
+		title={"In London, Variable A's value has fallen steadily since 2017"}
+		subTitle={'London monthly estimated variable value (GBP), January 2015 to March 2024'}
+		alt={"Area chart of London's variable A values"}
+		byline={'GLA City Intelligence'}
+		source={'LDN Viz Tools Demo Data'}
+		note={'Data for demonstration only'}
+		chartDescription={"The area chart shows monthly time series data for Variable A, measured in GBP (Pounds Sterling). The x axis ranges in months from January 2015 to March 2024. The y axis ranges from £0 to £60,000. Variable A's has fallen steadily since around 2017. Variable A's highest value was £61,816 in February 2015, its lowest value was £11,667 in July 2023, (a change of around -£50,149) and its mean average value was £30,758"}
+	/>
+</Story>
+
+<!--
+	```html
+	<script>
+		import { Plot, plotTheme } from '@ldn-viz/charts';
+		import demoMonthlyTimeseriesLong from '../../data/demoMonthlyTimeseriesLong.json'; // import or load your data
+		import { format } from 'd3'; // for formatting numbers in the chart	
+	
+		const formatLow = format(',.0f'); // for lower than 10000, format commas and not dp
+		const formatHigh = format(',.4~s'); // for 10000 and above, format commas and SI numbering (M & K)
+	
+		$: areaData = demoMonthlyTimeseriesLong.filter((d) => d.Variable == 'Variable A');
+		$: areaSpec = {
+			x: { insetLeft: 80, insetRight: 20, type: 'utc' },
+			marks: [
+				Plot.gridX({ interval: '2 years' }),
+				Plot.gridY(),
+				Plot.axisX({ label: 'Year', interval: '1 year' }),
+				Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+				Plot.ruleY([0]),
+				Plot.areaY(areaData, {
+					x: 'Month',
+					y: 'Value'
+				}),
+				Plot.line(areaData, {
+					x: 'Month',
+					y: 'Value',
+					z: 'Variable',
+					stroke: $currentTheme.color.data.primary,
+					tip: true
+				})
+			]
+		};
+		
+		$: areaOpacitySpec = {
+			...areaSpec,
+			marks: [
+				...areaSpec.marks,
+				Plot.areaY(areaData, {
+					x: 'Month',
+					y: 'Value',
+					fillOpacity: 0.8
+				})
+			]
+		};
+	</script>
+	
+	<ObservablePlot
+			spec={areaOpacitySpec}
+			data={areaData}
+			title={"In London, Variable A's value has fallen steadily since 2017"}
+			subTitle={"London monthly estimated variable value (GBP), January 2015 to March 2024"}
+			alt={"Area chart of London's variable A values"}
+			byline={"GLA City Intelligence"}
+			source={"LDN Viz Tools Demo Data"}
+			note={"Data for demonstration only"}
+			chartDescription={"The area chart shows monthly time series data for Variable A, measured in GBP (Pounds Sterling). The x axis ranges in months from January 2015 to March 2024. The y axis ranges from £0 to £60,000. Variable A's has fallen steadily since around 2017. Variable A's highest value was £61,816 in February 2015, its lowest value was £11,667 in July 2023, (a change of around -£50,149) and its mean average value was £30,758"}
+	/>
+	```
+-->
+
+<Story name="Area chart with custom fill opacity" source>
+	<ObservablePlot
+		spec={areaOpacitySpec}
+		data={areaData}
+		title={"In London, Variable A's value has fallen steadily since 2017"}
+		subTitle={'London monthly estimated variable value (GBP), January 2015 to March 2024'}
+		alt={"Area chart of London's variable A values"}
+		byline={'GLA City Intelligence'}
+		source={'LDN Viz Tools Demo Data'}
+		note={'Data for demonstration only'}
+		chartDescription={"The area chart shows monthly time series data for Variable A, measured in GBP (Pounds Sterling). The x axis ranges in months from January 2015 to March 2024. The y axis ranges from £0 to £60,000. Variable A's has fallen steadily since around 2017. Variable A's highest value was £61,816 in February 2015, its lowest value was £11,667 in July 2023, (a change of around -£50,149) and its mean average value was £30,758"}
 	/>
 </Story>

--- a/packages/charts/src/lib/examples/LineChart.stories.svelte
+++ b/packages/charts/src/lib/examples/LineChart.stories.svelte
@@ -24,7 +24,7 @@
 [ ] X & Y threshold line (and annotation)
 [ ] Range highlight 
 [x] X axis label, Y axis label
-[ ] area chart, as simple addition to line? (not stacked)
+[x] area chart, as simple addition to line? (not stacked)
 [ ] non zero baseline (small change)
 -->
 

--- a/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
+++ b/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
@@ -143,7 +143,7 @@ const defaultArea = () => ({
 	stroke: get(currentTheme).color.data.primary,
 	strokeWidth: 0,
 	fill: get(currentTheme).color.data.primary,
-	opacity: 0.2
+	fillOpacity: 0.2
 });
 
 const defaultRule = () => ({


### PR DESCRIPTION
**What does this change?**
defaultArea plot fragment now sets a default `fillOpacity` instead of `opacity`. This makes it consistent with the other plot fragments.

**Does this introduce new dependencies?**
Potentially may affect existing area charts using `opacity`

**How is it tested?**
Storybook

**How is it documented?**
[Storybook](https://dev.ldn-gis.co.uk/storybook-update-plot-fragments/?path=/docs/charts-example-charts-linechart--documentation)

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
