### PR TITLE
Add default plot fragments

### DIFF
--- a/.changeset/twenty-dancers-talk.md
+++ b/.changeset/twenty-dancers-talk.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/charts': minor
+---
+
+ADDED: defaultRect and defaultBar plot fragments; CHANGED: plot function now also checks for options.facet to apply defaultSizeFacet fragment

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -33,6 +33,7 @@
 		"@ldn-viz/ui": "*",
 		"@ldn-viz/utils": "*",
 		"@observablehq/plot": "^0.6.16",
+		"@tidyjs/tidy": "^2.5.2",
 		"layercake": "^8.1.1"
 	},
 	"devDependencies": {

--- a/packages/charts/src/lib/examples/BarChart.stories.svelte
+++ b/packages/charts/src/lib/examples/BarChart.stories.svelte
@@ -36,8 +36,6 @@
 	// Spec and data for single variable bar example (default)
 	$: singleVariableData = demoData.filter((d) => d.Variable == 'Variable A');
 	$: barData = aggregateData(singleVariableData);
-	$: averaged = tidy(demoData, groupBy('Variable', summarize({ Average: mean('Value') })));
-	$: console.log(averaged);
 	let barSpec: any;
 	$: if ($currentTheme) {
 		barSpec = {
@@ -57,6 +55,7 @@
 		};
 	}
 
+	// Spec and data for multi variable stacked bar example
 	$: stackedBarData = aggregateData(demoData);
 	$: stackedBarSpec = {
 		x: { insetLeft: 80, interval: 'year', label: 'Year' },
@@ -84,6 +83,7 @@
 		]
 	};
 
+	// Spec and data for multi variable stacked rect example
 	$: rectData = demoData;
 	$: rectSpec = {
 		x: { insetLeft: 80, interval: 'year', label: 'Year' },
@@ -117,6 +117,7 @@
 		]
 	};
 
+	// Spec and data for multi variable faceted rect example
 	$: facetedRectData = demoData;
 	$: facetedRectSpec = {
 		x: { insetLeft: 80, interval: 'year', label: 'Year' },

--- a/packages/charts/src/lib/examples/BarChart.stories.svelte
+++ b/packages/charts/src/lib/examples/BarChart.stories.svelte
@@ -1,0 +1,451 @@
+<script context="module">
+	import ObservablePlot from '../observablePlot/ObservablePlot.svelte';
+
+	/** This is an example `BarChart` chart using default plot styles.
+	 *
+	 * By default, charts (and their inner details) are hidden from screen readers to improve the accessibility experience. Instead, it's crtitical we use a descriptive `title`, `subTitle`, `alt`, `chartDescription` and surrounding document text, so all users understand what the chart shows and gain the same insight. We should also link to the data where possible.
+	 */
+
+	export const meta = {
+		title: 'Charts/Example Charts/BarChart'
+	};
+</script>
+
+<script lang="ts">
+	import { currentTheme } from '@ldn-viz/ui';
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import { groupBy, map, mean, summarize, tidy } from '@tidyjs/tidy';
+	import { format } from 'd3';
+	import demoData from '../../data/demoMonthlyTimeseriesLong.json';
+	import { Plot } from '../observablePlotFragments/plot';
+
+	//const formatLow = format(',.0f'); // for lower than 10000, format commas and not dp
+	const formatHigh = format(',.4~s'); // for 10000 and above, format commas and SI numbering (M & K)
+
+	const aggregateData = (data: any[]) => {
+		return tidy(
+			data,
+			map((d) => ({
+				...d,
+				Year: d.Month.slice(0, 4)
+			})),
+			groupBy(['Year', 'Variable'], summarize({ Average: mean('Value') }))
+		);
+	};
+
+	// Spec and data for single variable bar example (default)
+	$: singleVariableData = demoData.filter((d) => d.Variable == 'Variable A');
+	$: barData = aggregateData(singleVariableData);
+	$: averaged = tidy(demoData, groupBy('Variable', summarize({ Average: mean('Value') })));
+	$: console.log(averaged);
+	let barSpec: any;
+	$: if ($currentTheme) {
+		barSpec = {
+			x: { insetLeft: 80, interval: 'year', label: 'Year' },
+			marks: [
+				Plot.gridX({ interval: '2 years' }),
+				Plot.gridY(),
+				Plot.axisX({ label: 'Year', interval: '2 years' }),
+				Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+				Plot.barY(barData, {
+					x: (d) => new Date(d.Year),
+					y: 'Average',
+					tip: true
+				}),
+				Plot.ruleY([0])
+			]
+		};
+	}
+
+	$: stackedBarData = aggregateData(demoData);
+	$: stackedBarSpec = {
+		x: { insetLeft: 80, interval: 'year', label: 'Year' },
+		color: {
+			legend: true,
+			type: 'ordinal',
+			range: [
+				$currentTheme.color.data.primary,
+				$currentTheme.color.data.secondary,
+				$currentTheme.color.data.tertiary
+			]
+		},
+		marks: [
+			Plot.gridX({ interval: '2 years' }),
+			Plot.gridY(),
+			Plot.axisX({ label: 'Year', interval: '2 years' }),
+			Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+			Plot.barY(stackedBarData, {
+				x: (d) => new Date(d.Year),
+				y: 'Average',
+				fill: 'Variable',
+				tip: true
+			}),
+			Plot.ruleY([0])
+		]
+	};
+
+	$: rectData = demoData;
+	$: rectSpec = {
+		x: { insetLeft: 80, interval: 'year', label: 'Year' },
+		color: {
+			legend: true,
+			type: 'ordinal',
+			range: [
+				$currentTheme.color.data.primary,
+				$currentTheme.color.data.secondary,
+				$currentTheme.color.data.tertiary
+			]
+		},
+		marks: [
+			Plot.gridX({ interval: '2 years' }),
+			Plot.gridY(),
+			Plot.axisX({ label: 'Year', interval: '2 years' }),
+			Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+			Plot.rectY(
+				rectData,
+				Plot.binX(
+					{ y: 'mean' },
+					{
+						x: (d) => new Date(d.Month),
+						y: 'Value',
+						fill: 'Variable',
+						tip: true
+					}
+				)
+			),
+			Plot.ruleY([0])
+		]
+	};
+
+	$: facetedRectData = demoData;
+	$: facetedRectSpec = {
+		x: { insetLeft: 80, interval: 'year', label: 'Year' },
+		color: {
+			legend: true,
+			type: 'ordinal',
+			range: [
+				$currentTheme.color.data.primary,
+				$currentTheme.color.data.secondary,
+				$currentTheme.color.data.tertiary
+			]
+		},
+		facet: { label: null },
+		marks: [
+			Plot.gridX({ interval: '2 years' }),
+			Plot.gridY(),
+			Plot.axisX({ label: 'Year', interval: '2 years' }),
+			Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+			Plot.rectY(
+				facetedRectData,
+				Plot.binX(
+					{ y: 'mean' },
+					{
+						x: (d) => new Date(d.Month),
+						y: 'Value',
+						fill: 'Variable',
+						fy: 'Variable',
+						tip: { format: { fy: false } }
+					}
+				)
+			),
+			Plot.ruleY([0])
+		]
+	};
+</script>
+
+<Template let:args>
+	<ObservablePlot {...args} />
+</Template>
+
+<!--
+```html
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import { groupBy, map, mean, summarize, tidy } from '@tidyjs/tidy';
+	import { format } from 'd3';
+	import demoData from '../../data/demoMonthlyTimeseriesLong.json';
+	import { Plot } from '../observablePlotFragments/plot';
+
+	//const formatLow = format(',.0f'); // for lower than 10000, format commas and not dp
+	const formatHigh = format(',.4~s'); // for 10000 and above, format commas and SI numbering (M & K)
+
+	const aggregateData = (data: any[]) => {
+		return tidy(
+			data,
+			map((d) => ({
+				...d,
+				Year: d.Month.slice(0, 4)
+			})),
+			groupBy('Year', summarize({ Average: mean('Value') }))
+		);
+	};
+
+	// Spec and data for single variable bar example (default)
+	$: singleVariableData = demoData.filter((d) => d.Variable == 'Variable A');
+	$: barData = aggregateData(singleVariableData);
+	$: barSpec = {
+		x: { insetLeft: 80, interval: 'year', label: 'Year' },
+		marks: [
+			Plot.gridX({ interval: '2 years' }),
+			Plot.gridY(),
+			Plot.axisX({ label: 'Year', interval: '2 years' }),
+			Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+			Plot.barY(barData, {
+				x: (d) => new Date(d.Year),
+				y: 'Average',
+				tip: true
+			}),
+			Plot.ruleY([0])
+		]
+	};
+
+	<ObservablePlot
+		spec={barSpec}
+		data={barData}
+		title={"In London, Variable A's average value has fallen steadily since 2015"}
+		subTitle={'London average yearly estimated variable value (GBP), 2015 to March 2024'}
+		alt={"Bar chart of London's variable A average values"}
+		byline={'GLA City Intelligence'}
+		source={'LDN Viz Tools Demo Data'}
+		note={'Data for demonstration only'}
+		chartDescription={"The bar chart shows yearly time series data for Variable A, measured in GBP (Pounds Sterling). The x axis ranges in years from 2015 to 2024. The y axis ranges from £0 to £40,000. Variable A's average value has fallen steadily since 2015. Variable A's highest average value was £43,472 in 2015, its lowest average value was £19,786 in 2024, (a change of around -£19,742) and its mean average value was £30,758."}
+	/>
+```
+-->
+
+<Story name="Default" source>
+	<ObservablePlot
+		spec={barSpec}
+		data={barData}
+		title={"In London, Variable A's average value has fallen steadily since 2015"}
+		subTitle={'London average yearly estimated variable value (GBP), 2015 to March 2024'}
+		alt={"Bar chart of London's variable A average values"}
+		byline={'GLA City Intelligence'}
+		source={'LDN Viz Tools Demo Data'}
+		note={'Data for demonstration only'}
+		chartDescription={"The bar chart shows yearly time series data for Variable A, measured in GBP (Pounds Sterling). The x axis ranges in years from 2015 to 2024. The y axis ranges from £0 to £40,000. Variable A's average value has fallen steadily since 2015. Variable A's highest average value was £43,472 in 2015, its lowest average value was £19,786 in 2024, (a change of around -£19,742) and its mean average value was £30,758."}
+	/>
+</Story>
+
+<!--
+```html
+	import { currentTheme } from '@ldn-viz/ui';
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import { groupBy, map, mean, summarize, tidy } from '@tidyjs/tidy';
+	import { format } from 'd3';
+	import demoData from '../../data/demoMonthlyTimeseriesLong.json';
+	import { Plot } from '../observablePlotFragments/plot';
+
+	//const formatLow = format(',.0f'); // for lower than 10000, format commas and not dp
+	const formatHigh = format(',.4~s'); // for 10000 and above, format commas and SI numbering (M & K)
+
+	const aggregateData = (data: any[]) => {
+		return tidy(
+			data,
+			map((d) => ({
+				...d,
+				Year: d.Month.slice(0, 4)
+			})),
+			groupBy(['Year', 'Variable'], summarize({ Average: mean('Value') }))
+		);
+	};
+
+	$: stackedBarData = aggregateData(demoData);
+	$: stackedBarSpec = {
+		x: { insetLeft: 80, interval: 'year', label: 'Year' },
+		color: {
+			legend: true,
+			type: 'ordinal',
+			range: [
+				$currentTheme.color.data.primary,
+				$currentTheme.color.data.secondary,
+				$currentTheme.color.data.tertiary
+			]
+		},
+		marks: [
+			Plot.gridX({ interval: '2 years' }),
+			Plot.gridY(),
+			Plot.axisX({ label: 'Year', interval: '2 years' }),
+			Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+			Plot.barY(stackedBarData, {
+				x: (d) => new Date(d.Year),
+				y: 'Average',
+				fill: 'Variable',
+				tip: true
+			}),
+			Plot.ruleY([0])
+		]
+	};
+
+	<ObservablePlot
+		spec={stackedBarSpec}
+		data={stackedBarData}
+		title={'In London, all variable values have fallen steadily since 2016, with Variable A experiencing the most significant fall'}
+		subTitle={'London average yearly estimated variable value (GBP), 2015 to March 2024'}
+		alt={'Bar chart of London variable average values'}
+		byline={'GLA City Intelligence'}
+		source={'LDN Viz Tools Demo Data'}
+		note={'Data for demonstration only'}
+		chartDescription={"The bar chart shows yearly time series data for Variable A, B and C, measured in GBP (Pounds Sterling). The x axis ranges in years from 2015 to 2024. The y axis ranges from £0 to £100,000. All variable values have fallen steadily since around 2017, but Variable A has fallen the most. Variable A's highest average value was £43,472 in 2015, its lowest average value was £19,786 in 2024, (a change of around -£19,742) and its mean average value was £30,758. Variable B and C follow a similar fall, with a mean average of £27,545 and £23,681 respectively."}
+	/>
+```
+-->
+
+<Story name="Stacked bar chart" source>
+	<ObservablePlot
+		spec={stackedBarSpec}
+		data={stackedBarData}
+		title={'In London, all variable values have fallen steadily since 2016, with Variable A experiencing the most significant fall'}
+		subTitle={'London average yearly estimated variable value (GBP), 2015 to March 2024'}
+		alt={'Bar chart of London variable average values'}
+		byline={'GLA City Intelligence'}
+		source={'LDN Viz Tools Demo Data'}
+		note={'Data for demonstration only'}
+		chartDescription={"The bar chart shows yearly time series data for Variable A, B and C, measured in GBP (Pounds Sterling). The x axis ranges in years from 2015 to 2024. The y axis ranges from £0 to £100,000. All variable values have fallen steadily since around 2017, but Variable A has fallen the most. Variable A's highest average value was £43,472 in 2015, its lowest average value was £19,786 in 2024, (a change of around -£19,742) and its mean average value was £30,758. Variable B and C follow a similar fall, with a mean average of £27,545 and £23,681 respectively."}
+	/>
+</Story>
+
+<!--
+```html
+	import { currentTheme } from '@ldn-viz/ui';
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import { format } from 'd3';
+	import demoData from '../../data/demoMonthlyTimeseriesLong.json';
+	import { Plot } from '../observablePlotFragments/plot';
+
+	//const formatLow = format(',.0f'); // for lower than 10000, format commas and not dp
+	const formatHigh = format(',.4~s'); // for 10000 and above, format commas and SI numbering (M & K)
+
+	$: rectData = demoData;
+	$: rectSpec = {
+		x: { insetLeft: 80, interval: 'year', label: 'Year' },
+		color: {
+			legend: true,
+			type: 'ordinal',
+			range: [
+				$currentTheme.color.data.primary,
+				$currentTheme.color.data.secondary,
+				$currentTheme.color.data.tertiary
+			]
+		},
+		marks: [
+			Plot.gridX({ interval: '2 years' }),
+			Plot.gridY(),
+			Plot.axisX({ label: 'Year', interval: '2 years' }),
+			Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+			Plot.rectY(
+				rectData,
+				Plot.binX(
+					{ y: 'mean' },
+					{
+						x: (d) => new Date(d.Month),
+						y: 'Value',
+						fill: 'Variable',
+						tip: true
+					}
+				)
+			),
+			Plot.ruleY([0])
+		]
+	};
+
+	<ObservablePlot
+		spec={rectSpec}
+		data={rectData}
+		title={'In London, all variable values have fallen steadily since 2016, with Variable A experiencing the most significant fall'}
+		subTitle={'London average yearly estimated variable value (GBP), 2015 to March 2024'}
+		alt={'Histogram chart of London variable average values'}
+		byline={'GLA City Intelligence'}
+		source={'LDN Viz Tools Demo Data'}
+		note={'Data for demonstration only'}
+		chartDescription={"The histogram chart shows yearly time series data for Variable A, B and C, measured in GBP (Pounds Sterling). The x axis ranges in years from 2015 to 2024. The y axis ranges from £0 to £100,000. All variable values have fallen steadily since around 2017, but Variable A has fallen the most. Variable A's highest average value was £43,472 in 2015, its lowest average value was £19,786 in 2024, (a change of around -£19,742) and its mean average value was £30,758. Variable B and C follow a similar fall, with a mean average of £27,545 and £23,681 respectively."}
+	/>
+```
+-->
+
+<Story name="Rect chart" source>
+	<ObservablePlot
+		spec={rectSpec}
+		data={rectData}
+		title={'In London, all variable values have fallen steadily since 2016, with Variable A experiencing the most significant fall'}
+		subTitle={'London average yearly estimated variable value (GBP), 2015 to March 2024'}
+		alt={'Histogram chart of London variable average values'}
+		byline={'GLA City Intelligence'}
+		source={'LDN Viz Tools Demo Data'}
+		note={'Data for demonstration only'}
+		chartDescription={"The histogram chart shows yearly time series data for Variable A, B and C, measured in GBP (Pounds Sterling). The x axis ranges in years from 2015 to 2024. The y axis ranges from £0 to £100,000. All variable values have fallen steadily since around 2017, but Variable A has fallen the most. Variable A's highest average value was £43,472 in 2015, its lowest average value was £19,786 in 2024, (a change of around -£19,742) and its mean average value was £30,758. Variable B and C follow a similar fall, with a mean average of £27,545 and £23,681 respectively."}
+	/>
+</Story>
+
+<!--
+```html
+	import { currentTheme } from '@ldn-viz/ui';
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import { format } from 'd3';
+	import demoData from '../../data/demoMonthlyTimeseriesLong.json';
+	import { Plot } from '../observablePlotFragments/plot';
+
+	//const formatLow = format(',.0f'); // for lower than 10000, format commas and not dp
+	const formatHigh = format(',.4~s'); // for 10000 and above, format commas and SI numbering (M & K)
+
+	$: facetedRectData = demoData;
+	$: facetedRectSpec = {
+		x: { insetLeft: 80, interval: 'year', label: 'Year' },
+		color: {
+			legend: true,
+			type: 'ordinal',
+			range: [
+				$currentTheme.color.data.primary,
+				$currentTheme.color.data.secondary,
+				$currentTheme.color.data.tertiary
+			]
+		},
+		facet: { label: null },
+		marks: [
+			Plot.gridX({ interval: '2 years' }),
+			Plot.gridY(),
+			Plot.axisX({ label: 'Year', interval: '2 years' }),
+			Plot.axisY({ label: '', tickFormat: (d) => '£' + formatHigh(d) }),
+			Plot.rectY(
+				facetedRectData,
+				Plot.binX(
+					{ y: 'mean' },
+					{
+						x: (d) => new Date(d.Month),
+						y: 'Value',
+						fill: 'Variable',
+						fy: 'Variable',
+						tip: { format: { fy: false } }
+					}
+				)
+			),
+			Plot.ruleY([0])
+		]
+	};
+
+	<ObservablePlot
+		spec={facetedRectSpec}
+		data={facetedRectData}
+		title={'In London, all variable values have fallen steadily since 2016, with Variable A experiencing the most significant fall'}
+		subTitle={'London average yearly estimated variable value (GBP), 2015 to March 2024'}
+		alt={'Three histogram charts of London variable average values split by variable'}
+		byline={'GLA City Intelligence'}
+		source={'LDN Viz Tools Demo Data'}
+		note={'Data for demonstration only'}
+		chartDescription={"The histogram chart shows yearly time series data for Variable A, B and C, measured in GBP (Pounds Sterling). The x axis ranges in years from 2015 to 2024. The y axes ranges from £0 to £40,000. All variable values have fallen steadily since around 2017, but Variable A has fallen the most. Variable A's highest average value was £43,472 in 2015, its lowest average value was £19,786 in 2024, (a change of around -£19,742) and its mean average value was £30,758. Variable B and C follow a similar fall. Variable B's highest average value was £36,942 in 2016, its lowest average value was £17,614 in 2024, (a change of around -£19,328) and its mean average value was £27,545. Variable C's highest average value was £30,714 in 2016, its lowest average value was £16,840 in 2023, (a change of around -£13,874) and its mean average value was £23,681."}
+	/>
+```
+-->
+
+<Story name="Faceted rect chart" source>
+	<ObservablePlot
+		spec={facetedRectSpec}
+		data={facetedRectData}
+		title={'In London, all variable values have fallen steadily since 2016, with Variable A experiencing the most significant fall'}
+		subTitle={'London average yearly estimated variable value (GBP), 2015 to March 2024'}
+		alt={'Three histogram charts of London variable average values split by variable'}
+		byline={'GLA City Intelligence'}
+		source={'LDN Viz Tools Demo Data'}
+		note={'Data for demonstration only'}
+		chartDescription={"The histogram chart shows yearly time series data for Variable A, B and C, measured in GBP (Pounds Sterling). The x axis ranges in years from 2015 to 2024. The y axes ranges from £0 to £40,000. All variable values have fallen steadily since around 2017, but Variable A has fallen the most. Variable A's highest average value was £43,472 in 2015, its lowest average value was £19,786 in 2024, (a change of around -£19,742) and its mean average value was £30,758. Variable B and C follow a similar fall. Variable B's highest average value was £36,942 in 2016, its lowest average value was £17,614 in 2024, (a change of around -£19,328) and its mean average value was £27,545. Variable C's highest average value was £30,714 in 2016, its lowest average value was £16,840 in 2023, (a change of around -£13,874) and its mean average value was £23,681."}
+	/>
+</Story>

--- a/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
+++ b/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
@@ -184,6 +184,16 @@ const defaultAnnotationRange = () => ({
 	opacity: 0.1
 });
 
+const defaultRect = () => ({
+	fill: get(currentTheme).color.data.primary,
+	stroke: get(currentTheme).color.chart.background
+});
+
+const defaultBar = () => ({
+	fill: get(currentTheme).color.data.primary,
+	stroke: get(currentTheme).color.chart.background
+});
+
 /**
  * One limitation of Observable Plot is that  things that we would like to be channels are options.
  * The documentation states:

--- a/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
+++ b/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
@@ -27,7 +27,9 @@ export const defaultPlotStyleFunctions: DefaultPlotStyleFunctions = {
 	defaultTip: () => defaultTip(),
 	defaultAnnotationTip: () => defaultAnnotationTip(),
 	defaultAnnotationText: () => defaultAnnotationText(),
-	defaultAnnotationRange: () => defaultAnnotationRange()
+	defaultAnnotationRange: () => defaultAnnotationRange(),
+	defaultBar: () => defaultBar(),
+	defaultRect: () => defaultRect()
 };
 
 export const getDefaultPlotStyles = () => {

--- a/packages/charts/src/lib/observablePlotFragments/plot.ts
+++ b/packages/charts/src/lib/observablePlotFragments/plot.ts
@@ -4,6 +4,8 @@ import type {
 	AreaYOptions,
 	AxisXOptions,
 	AxisYOptions,
+	BarXOptions,
+	BarYOptions,
 	Data,
 	DotOptions,
 	DotXOptions,
@@ -14,6 +16,9 @@ import type {
 	LineXOptions,
 	LineYOptions,
 	PlotOptions,
+	RectOptions,
+	RectXOptions,
+	RectYOptions,
 	RuleXOptions,
 	RuleYOptions,
 	TextOptions,
@@ -35,7 +40,7 @@ export const plot = (options: PlotOptions = {}) => {
 	const { style, color, x, y, height, marginTop, marginBottom, marginLeft, marginRight, ...rest } =
 		options;
 
-	const sizeDefault = options.fx || options.fy ? defaultSizeFacet : defaultSize;
+	const sizeDefault = options.fx || options.fy || options.facet ? defaultSizeFacet : defaultSize;
 	const defaultStyleString = Object.entries(defaultStyle)
 		.map(([k, v]) => `${k}:${v}`)
 		.join(';');
@@ -110,6 +115,12 @@ export const Plot = {
 		args.length > 1
 			? ObservablePlot.axisY(args[0] as Data, { ...getDefault('defaultYaxis'), ...args[1] })
 			: ObservablePlot.axisY({ ...getDefault('defaultYAxis'), ...args[0] }),
+	barX: (data?: Data, options?: BarXOptions) => {
+		return ObservablePlot.barX(data, { ...getDefault('defaultBar'), ...options });
+	},
+	barY: (data?: Data, options?: BarYOptions) => {
+		return ObservablePlot.barY(data, { ...getDefault('defaultBar'), ...options });
+	},
 	dashedLine: (data?: Data, options?: LineOptions) => {
 		return ObservablePlot.line(data, { ...getDefault('defaultDashedLine'), ...options });
 	},
@@ -155,6 +166,15 @@ export const Plot = {
 	},
 	pointY: (data?: Data, options?: DotYOptions) => {
 		return ObservablePlot.dotY(data, { ...getDefault('defaultPoint'), ...options });
+	},
+	rect: (data?: Data, options?: RectOptions) => {
+		return ObservablePlot.rect(data, { ...getDefault('defaultRect'), ...options });
+	},
+	rectX: (data?: Data, options?: RectXOptions) => {
+		return ObservablePlot.rectX(data, { ...getDefault('defaultRect'), ...options });
+	},
+	rectY: (data?: Data, options?: RectYOptions) => {
+		return ObservablePlot.rectY(data, { ...getDefault('defaultRect'), ...options });
 	},
 	ruleX: (data?: Data, options?: RuleYOptions) => {
 		return ObservablePlot.ruleX(data, { ...getDefault('defaultRule'), ...options });


### PR DESCRIPTION
**What does this change?**
Added:
- defaultRect and defaultBar plot fragments (as per Mike's request in #882)
- documented use of these fragments

Changed:
- plot function now checks for `options.facet` as well as `options.fy/fx` to apply default facet styling

**Related issues**: Resolves #882 

**Does this introduce new dependencies?**
Yes, `@tidyjs/tidy`

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
Yes

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
