### PR TITLE
A11y: updated Sidebar to use an aside and ariaLabel props

### DIFF
--- a/.changeset/wicked-singers-own.md
+++ b/.changeset/wicked-singers-own.md
@@ -1,5 +1,5 @@
 ---
-'@ldn-viz/ui': minor
+'@ldn-viz/ui': major
 ---
 
 CHANGED: `Sidebar` is now an aside and takes `sidebarAriaLabel` and `tabsAriaLabel` optional props for better accessibility

--- a/.changeset/wicked-singers-own.md
+++ b/.changeset/wicked-singers-own.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: `Sidebar` is now an aside and takes `sidebarAriaLabel` and `tabsAriaLabel` optional props for better accessibility

--- a/packages/ui/src/lib/sidebar/Sidebar.stories.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.stories.svelte
@@ -633,3 +633,29 @@
 		</SidebarFooter>
 	</Sidebar>
 </Story>
+
+<Story name="With Tabs and custom ariaLabels" source>
+	<Sidebar {tabs} sidebarAriaLabel="Sidebar for viewing controls to filter main page content">
+		<SidebarHeader title="Main sidebar title" slot="header">
+			<svelte:fragment slot="subTitle">
+				<p>
+					Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui, nec
+					venenatis sapien. Etiam venenatis felis.
+				</p>
+			</svelte:fragment>
+		</SidebarHeader>
+		<!-- COMPONENT PASSED AS CONTENT IN TABS ARRAY WILL RENDER HERE-->
+		<SidebarFooter slot="footer">
+			<div class="flex justify-between">
+				<div class="w-[165px]"><LogoMayor /></div>
+				<div class="w-[165px]"><LogoCIU /></div>
+			</div>
+			<svelte:fragment slot="menu">
+				<ul class="flex space-x-2">
+					<li>View Cookie settings</li>
+					<li>Privacy Policy</li>
+				</ul>
+			</svelte:fragment>
+		</SidebarFooter>
+	</Sidebar>
+</Story>

--- a/packages/ui/src/lib/sidebar/Sidebar.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.svelte
@@ -65,9 +65,14 @@
 	$: component = tabs.find((tab) => tab.id === selectedValue)?.content;
 
 	/**
+	 * Aria label to describe purpose of sidebar
+	 */
+	export let sidebarAriaLabel: string = 'Sidebar with information and controls';
+
+	/**
 	 * Aria label applied to tabs list
 	 */
-	export let ariaLabel: string = 'Switch sidebar panel';
+	export let tabsAriaLabel: string = 'Switch sidebar panel';
 
 	/**
 	 * Randomly generated id for sidebar container. Used by `SidebarToggle` to tell screen readers what the toggle controls.
@@ -98,7 +103,7 @@
 	{#if tabs.length}
 		<div class={classNames('absolute bg-color-container-level-0', tabPlacementClasses)}>
 			<!-- A `<SidebarTabList>`, if the sidebar has tabs-->
-			<SidebarTabList {tabs} {ariaLabel} bind:selectedValue />
+			<SidebarTabList {tabs} ariaLabel={tabsAriaLabel} bind:selectedValue />
 		</div>
 	{:else if $sidebarAlwaysOpen !== 'true'}
 		<div class={classNames('absolute', togglePlacementClasses)}>
@@ -107,8 +112,9 @@
 	{/if}
 
 	{#if $sidebarIsOpen}
-		<div
+		<aside
 			id={sidebarId}
+			aria-label={sidebarAriaLabel}
 			class={classNames('flex', heightClasses)}
 			transition:slide={{ duration: 300, axis: transitionAxis[placement] }}
 		>
@@ -167,6 +173,6 @@
 					</div>
 				{/if}
 			</div>
-		</div>
+		</aside>
 	{/if}
 </div>


### PR DESCRIPTION
**What does this change?**

The main content of `Sidebar` is now wrapped in an `<aside>` rather than a `<div>` for better screen reader navigation between main content and sidebar.

`Sidebar` now takes two `ariaLabel` props:
- `sidebarAriaLabel` to tell screen reader users what the sidebar is for
- `tabsAriaLabel` to tell screen reader users what the tabsList is for (renamed from `ariaLabel` to accommodate the need for a sidebar ariaLabel.

This is to address the last bits of accessibility updates needed for the sidebar as outlined in #755.

**Related issues**: Resolves #755 

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
