### PR TITLE
ColorPicker accepts custom colours

### DIFF
--- a/.changeset/itchy-rings-burn.md
+++ b/.changeset/itchy-rings-burn.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: `LayerControl`, `LayerControlGroup` and `ColorPicker` take an optional array of `colorNames` to allow customisation of color picker

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -13,7 +13,12 @@
 
 	export let disabled = false;
 
-	const colorNames = [
+	/**
+	 * Optional custom colours to choose from. If these don't exist, default to categoricalColors.
+	 */
+	export let colorNames;
+
+	const categoricalColors = [
 		'data.categorical.blue',
 		'data.categorical.darkpink',
 		'data.categorical.pink',
@@ -26,6 +31,10 @@
 		'data.neutral.0',
 		'data.neutral.1'
 	];
+
+	if (!colorNames.length) {
+		colorNames = categoricalColors;
+	}
 
 	let isOpen = false;
 </script>

--- a/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerContolGroup.stories.svelte
@@ -1,6 +1,7 @@
 <script context="module" lang="ts">
 	import { Story, Template } from '@storybook/addon-svelte-csf';
 	import LayerControlGroup from './LayerControlGroup.svelte';
+	import { colorNames } from './layerControlUtils';
 
 	export const meta = {
 		title: 'Ui/Components/Layer Controls/LayerControlGroup',
@@ -77,6 +78,26 @@
 		},
 		underground: {
 			colorName: 'data.categorical.darkpink',
+			visible: true,
+			opacity: 1.0,
+			size: 1
+		}
+	};
+	let state3 = {
+		bus: {
+			colorName: 'palette.blue.600',
+			visible: true,
+			opacity: 1.0,
+			size: 1
+		},
+		train: {
+			colorName: 'palette.green.600',
+			visible: true,
+			opacity: 1.0,
+			size: 1
+		},
+		underground: {
+			colorName: 'palette.darkpink.600',
 			visible: true,
 			opacity: 1.0,
 			size: 1
@@ -206,4 +227,10 @@ For example, choropleth layers would cover each other.
 	/>
 
 	<pre class="mt-4 text-xs">{JSON.stringify(state1, null, 2)}</pre>
+</Story>
+
+<!-- Note, this colour combination isn't accessible but is demonstrating potential for customising colours where necessary. -->
+<Story name="With custom colours" source>
+	<LayerControlGroup bind:options={optionsForGroup} bind:state={state3} {ariaLabel} {colorNames} />
+	<pre class="mt-4 text-xs">{JSON.stringify(state3, null, 2)}</pre>
 </Story>

--- a/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
@@ -10,6 +10,7 @@
 
 <script lang="ts">
 	import { colorTokenNameToRGBArray, currentTheme, tokenNameToValue } from '../theme/themeStore';
+	import { colorNames } from './layerControlUtils';
 
 	let layerStates = {
 		boroughs: {
@@ -24,6 +25,11 @@
 		},
 		fuel_poverty: {
 			colorName: 'data.categorical.orange',
+			visible: true,
+			opacity: 1.0
+		},
+		customColors: {
+			colorName: 'palette.blue.600',
 			visible: true,
 			opacity: 1.0
 		}
@@ -108,4 +114,9 @@
 
 <Story name="With name prop" source>
 	<LayerControl bind:state label="Borough" name="borough" />
+</Story>
+
+<!-- Note, this colour combination isn't accessible but is demonstrating potential for customising colours where necessary. -->
+<Story name="With custom colours" source>
+	<LayerControl bind:state={layerStates.customColors} label="Borough" {colorNames} />
 </Story>

--- a/packages/ui/src/lib/layerControl/LayerControl.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.svelte
@@ -29,6 +29,11 @@
 	export let disableSizeControl = false;
 
 	/**
+	 * Optional array of colour tokens for use by `ColorPicker`. Defaults to categorical colours.
+	 */
+	export let colorNames: string[] = [];
+
+	/**
 	 * the name of the layer
 	 */
 	export let label = '';
@@ -121,6 +126,7 @@
 
 	{#if controlsInUse.includes('color')}
 		<ColorPicker
+			{colorNames}
 			bind:colorName={state.colorName}
 			disabled={disabled || disableColorControl}
 			{label}

--- a/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControlGroup.svelte
@@ -134,6 +134,11 @@
 	export let disableSizeControl = false;
 
 	/**
+	 * Optional array of colour tokens for use by `ColorPicker`. Defaults to categorical colours.
+	 */
+	export let colorNames: string[] = [];
+
+	/**
 	 * Message to be displayed next to the checkbox that toggles the visibility of all layers.
 	 */
 	export let showAllLabel = 'Show all';
@@ -238,6 +243,7 @@
 							disabled={option.disabled || disabled}
 							bind:selectedOptionId
 							mutuallyExclusive
+							{colorNames}
 						/>
 					</li>
 				{/each}
@@ -274,6 +280,7 @@
 							disableSizeControl={disableSizeControl || option.disableSizeControl}
 							bind:state={state[option.id]}
 							{controlsInUse}
+							{colorNames}
 						/>
 					</li>
 				{/each}

--- a/packages/ui/src/lib/layerControl/layerControlUtils.ts
+++ b/packages/ui/src/lib/layerControl/layerControlUtils.ts
@@ -1,0 +1,11 @@
+export const colorNames = [
+	'palette.blue.600',
+	'palette.green.600',
+	'palette.yellow.600',
+	'palette.orange.600',
+	'palette.red.600',
+	'palette.pink.600',
+	'palette.darkpink.600',
+	'palette.purple.600',
+	'palette.turquoise.600'
+];


### PR DESCRIPTION
**What does this change?**
`LayerControlGroup`, `LayerControl` and `ColorPicker` accept a custom list of colour tokens, called `colorNames`.

**Why?**
This allows for use in maps where specific colours are required (e.g. requiring a light blue for water).

**How?**
`colorNames` is initialised as an empty array. If an array of token strings is passed in, it will show those colours. Otherwise, if it's empty, it will default to standard categorical colours, as normal.

![image](https://github.com/user-attachments/assets/b3be926b-02f8-4143-be9a-772d4859a047)

![image](https://github.com/user-attachments/assets/8a663532-e8ca-42dd-a914-886521dad1bd)

**Related issues**: Closes #959 

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
Yes (colorNames are token names, so change depending on the theme)

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
