### PR TITLE
fix token refresh

### DIFF
--- a/.changeset/fix-token-refresh.md
+++ b/.changeset/fix-token-refresh.md
@@ -1,5 +1,5 @@
 ---
-'@ldn-viz/ui': minor
+'@ldn-viz/ui': patch
 ---
 
 FIXED: fixed refresh of OAuth tokens by `HandleRedirectFromAuth`

--- a/.changeset/fix-token-refresh.md
+++ b/.changeset/fix-token-refresh.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: fixed refresh of OAuth tokens by `HandleRedirectFromAuth`

--- a/packages/ui/src/lib/auth/HandleRedirectFromAuth.svelte
+++ b/packages/ui/src/lib/auth/HandleRedirectFromAuth.svelte
@@ -32,7 +32,7 @@
 				// schedule to re-run
 				// Store the new access token in local storage or session storage
 
-				setTimeout(() => refreshAccessToken(), data.expires_in * 1000 * 0.8);
+				setTimeout(() => refreshAccessToken(oauth_config), data.expires_in * 1000 * 0.8);
 			})
 			.catch((error) => {
 				console.error('Error refreshing access token:', error);
@@ -75,7 +75,7 @@
 					accessToken.set(data.access_token);
 					refreshToken.set(data.refresh_token);
 
-					setTimeout(() => refreshAccessToken(), data.expires_in * 1000 * 0.8);
+					setTimeout(() => refreshAccessToken(oauth_config), data.expires_in * 1000 * 0.8);
 
 					const tokenObj = parseJwt(data.access_token);
 					userName.set(tokenObj.preferred_username);


### PR DESCRIPTION
Refreshing access tokens was broken due to a mistake when re-factoring to extract the auth components from the initial demo app into re-suable components that accept a config object.