### PR TITLE
Refactored SidebarTab components for accessibility and correct styling

### DIFF
--- a/.changeset/thick-months-poke.md
+++ b/.changeset/thick-months-poke.md
@@ -1,0 +1,8 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: `SidebarTabList` accessibility and styling
+
+- applies orientation correctly for keyboard/screen reader accessibility when oriented horizontally
+- applies correct styling by accepting `placement` prop and wrapping around new `SidebarTabLabel` component (instead of using `TabLabel` component)

--- a/packages/ui/src/lib/sidebar/Sidebar.stories.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.stories.svelte
@@ -1,5 +1,5 @@
 <script context="module">
-	import { RelativeWrapper } from '../../../../../apps/docs';
+	import { RelativeWrapper, SidebarTopContext } from '../../../../../apps/docs';
 	import Sidebar from './Sidebar.svelte';
 
 	export const meta = {
@@ -31,7 +31,7 @@
 </script>
 
 <script lang="ts">
-	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import { Story, Template, type DecoratorReturnType } from '@storybook/addon-svelte-csf';
 	import { setContext } from 'svelte';
 	import { writable } from 'svelte/store';
 	import LogoCIU from '../logos/LogoCIU.svelte';
@@ -62,6 +62,8 @@
 		{ id: 'analysis', label: 'Analysis', icon: Map, content: Third },
 		{ id: 'layers', label: 'Layers', icon: MapPin, content: Fourth }
 	];
+
+	const horizontalContext = SidebarTopContext as unknown as DecoratorReturnType;
 </script>
 
 <Template let:args>
@@ -636,6 +638,32 @@
 
 <Story name="With Tabs and custom ariaLabels" source>
 	<Sidebar {tabs} sidebarAriaLabel="Sidebar for viewing controls to filter main page content">
+		<SidebarHeader title="Main sidebar title" slot="header">
+			<svelte:fragment slot="subTitle">
+				<p>
+					Maecenas ut libero vel nibh maximus feugiat non sed tortor. Sed in lacinia dui, nec
+					venenatis sapien. Etiam venenatis felis.
+				</p>
+			</svelte:fragment>
+		</SidebarHeader>
+		<!-- COMPONENT PASSED AS CONTENT IN TABS ARRAY WILL RENDER HERE-->
+		<SidebarFooter slot="footer">
+			<div class="flex justify-between">
+				<div class="w-[165px]"><LogoMayor /></div>
+				<div class="w-[165px]"><LogoCIU /></div>
+			</div>
+			<svelte:fragment slot="menu">
+				<ul class="flex space-x-2">
+					<li>View Cookie settings</li>
+					<li>Privacy Policy</li>
+				</ul>
+			</svelte:fragment>
+		</SidebarFooter>
+	</Sidebar>
+</Story>
+
+<Story name="Top Placement with tabs" source decorators={[() => horizontalContext]}>
+	<Sidebar {tabs}>
 		<SidebarHeader title="Main sidebar title" slot="header">
 			<svelte:fragment slot="subTitle">
 				<p>

--- a/packages/ui/src/lib/sidebar/Sidebar.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.svelte
@@ -103,7 +103,7 @@
 	{#if tabs.length}
 		<div class={classNames('absolute bg-color-container-level-0', tabPlacementClasses)}>
 			<!-- A `<SidebarTabList>`, if the sidebar has tabs-->
-			<SidebarTabList {tabs} ariaLabel={tabsAriaLabel} bind:selectedValue />
+			<SidebarTabList {tabs} {placement} ariaLabel={tabsAriaLabel} bind:selectedValue />
 		</div>
 	{:else if $sidebarAlwaysOpen !== 'true'}
 		<div class={classNames('absolute', togglePlacementClasses)}>

--- a/packages/ui/src/lib/sidebar/elements/sidebarTabs/SidebarTabLabel.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarTabs/SidebarTabLabel.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import type { Tab } from '../../../tabs/types';
+	import { classNames } from '../../../utils/classNames';
+
+	/**
+	 * Unique identifier that is used to set the value of `selectedValue` for the parent `TabList` when this item is selected.
+	 * Also connects SidebarTabLabel to relevant TabPanel
+	 */
+	export let tabId: Tab['id'];
+
+	export let handleSelect;
+
+	const { selectedValue } = getContext<{
+		selectedValue: Writable<string>;
+	}>('sidebarTabContext');
+
+	$: isSelected = tabId === $selectedValue;
+
+	$: sidebarTabLabelClasses = classNames(
+		'bg-color-container-level-0 text-color-text-primary hover:bg-color-input-background-hover',
+		'focus:ring-inset focus:ring-offset-2 focus:ring-offset-color-action-primary-focussed focus:ring-2 focus:outline-none focus:ring-color-ui-background-primary',
+		'text-xs w-20 h-20 p-2 flex flex-col items-center justify-center text-center'
+	);
+</script>
+
+<button
+	on:click={() => handleSelect(tabId)}
+	id={tabId}
+	role="tab"
+	aria-controls={`${tabId}-panel`}
+	aria-selected={isSelected}
+	tabindex={isSelected ? 0 : -1}
+	class={classNames(
+		sidebarTabLabelClasses,
+		isSelected ? '!bg-color-input-background-active !text-color-static-white cursor-default' : ''
+	)}
+>
+	<!-- contents of the tab label (name and/or icon) -->
+	<slot />
+</button>

--- a/packages/ui/src/lib/sidebar/elements/sidebarTabs/SidebarTabsList.stories.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarTabs/SidebarTabsList.stories.svelte
@@ -11,8 +11,7 @@
 </script>
 
 <script lang="ts">
-	import { SidebarTopContext } from '@ldn-viz/docs';
-	import { Story, Template, type DecoratorReturnType } from '@storybook/addon-svelte-csf';
+	import { Story, Template } from '@storybook/addon-svelte-csf';
 
 	import { Map as MapIcon, Square3Stack3d } from '@steeze-ui/heroicons';
 
@@ -28,8 +27,6 @@
 		{ id: 'averages', label: 'Averages', icon: Square3Stack3d, content: NonIdealState },
 		{ id: 'histograms', label: 'Histograms', icon: MapIcon, content: NonIdealState }
 	];
-
-	const horizontalContext = SidebarTopContext as unknown as DecoratorReturnType;
 </script>
 
 <Template let:args>
@@ -38,8 +35,8 @@
 
 <Story name="Default" source args={{ tabs: tabs }} />
 
-<Story name="Horizontal with Icons" decorators={[() => horizontalContext]}>
-	<SidebarTabList {tabs} bind:selectedValue />
+<Story name="Horizontal with Icons">
+	<SidebarTabList {tabs} placement="top" bind:selectedValue />
 </Story>
 
 <!-- A custom event can be passed to onChange -->

--- a/packages/ui/src/lib/sidebar/sidebarUtils.ts
+++ b/packages/ui/src/lib/sidebar/sidebarUtils.ts
@@ -31,7 +31,6 @@ export const tabLayoutOverride: PlacementLookup = {
 	bottom: '!w-auto !flex !flex-row !space-y-0 !pb-0 !float-left'
 };
 
-export const tabThemeOverride = '[&>button]:bg-color-container-level-0 [&>button]:no-underline';
 // The width and height classes are a bit complex to accommodate absolutely positioned nav trigger elements...
 export const widthLookup: WidthLookup = {
 	standard: {


### PR DESCRIPTION
**What does this change?**
`SidebarTabList` now:
- applies orientation correctly for keyboard/screen reader accessibility when oriented horizontally
- accepts `placement` prop from `Sidebar` and wraps around new `SidebarTabLabel` component (instead of using `TabLabel` component) to apply correct styling

**Why?**
Previously, `SidebarTabList` wasn't applying `orientation` correctly because it caused incorrect styling. However, this created issues for accessibility because keyboard navigation and screen reader `aria-orientation` were not working correctly.

**How?**
A new `SidebarTabLabel` is styled correctly for sidebars and avoids polluting the `TabLabel` component with sidebar-specific styling requirements. Now `orientation` can safely be passed into `SidebarTabList` for accessibility without causing unexpected styling issues.

**Related issues**: Resolves #950 

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook:
- [Top Placement with tabs](https://dev.ldn-gis.co.uk/storybook-sidebar-tabs/?path=/story/ui-components-layout-and-themes-sidebar--top-placement-with-tabs)
- [Horizontal with Icons](https://dev.ldn-gis.co.uk/storybook-sidebar-tabs/?path=/story/ui-components-layout-and-themes-sidebar-elements-sidebartabs--horizontal-with-icons)

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
