### PR TITLE
A11y: Added ColorPicker tooltip, hover and active states

### DIFF
--- a/.changeset/two-meals-perform.md
+++ b/.changeset/two-meals-perform.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: `ColorPicker` now has tooltip, hover and active states

--- a/apps/docs/.storybook/withThemeByClassNameStore.ts
+++ b/apps/docs/.storybook/withThemeByClassNameStore.ts
@@ -47,6 +47,7 @@ export const withThemeByClassNameStore = <TRenderer extends Renderer = any>({
 
 			const newThemeClasses = classStringToArray(themes[selectedThemeName]);
 			userThemeSelectionStore.set(selectedThemeName);
+			localStorage.setItem('theme', selectedThemeName);
 
 			if (newThemeClasses.length > 0) {
 				parentElement.classList.add(...newThemeClasses);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14789,7 +14789,7 @@
     },
     "packages/ui": {
       "name": "@ldn-viz/ui",
-      "version": "19.0.0",
+      "version": "19.1.0",
       "license": "MIT",
       "dependencies": {
         "@ldn-viz/utils": "*",

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -10,7 +10,7 @@
 
 	export let label;
 
-	export let colorName = 'data.categorical.blue';
+	export let activeColorName = 'data.categorical.blue';
 
 	export let disabled = false;
 
@@ -45,14 +45,11 @@
 		return array.join(' ');
 	};
 
-	// add ring to currently selected colour
-	$: selectedClass = (colorOption: string) => {
-		return classNames(
-			colorName == colorOption
-				? 'ring-2 ring-offset-2 ring-color-ui-border-primary ring-offset-color-container-level-0'
-				: ''
-		);
-	};
+	const activeOptionClasses =
+		'ring-inset ring-2 ring-offset-2 ring-color-ui-background-secondary hover:ring-offset-color-ui-border-primary focus-visible:ring-offset-color-ui-border-primary';
+
+	const optionClasses =
+		'rounded-full bg-color-container-level-0 hover:ring-inset hover:ring-offset-2 hover:ring-offset-color-ui-border-secondary hover:ring-2 hover:ring-color-ui-background-secondary focus-visible:ring-offset-color-ui-border-secondary';
 </script>
 
 {#if disabled}
@@ -67,7 +64,7 @@
 		<Trigger slot="trigger" size="xs" ariaLabel="Click to open {label} layer colour picker">
 			<div
 				class="w-[22px] h-[22px] relative border rounded-full"
-				style:background={tokenNameToValue(colorName, $currentTheme)}
+				style:background={tokenNameToValue(activeColorName, $currentTheme)}
 			/>
 		</Trigger>
 
@@ -75,23 +72,24 @@
 
 		<span class="text-xs mb-2 inline-block">Click to assign a colour to this layer.</span>
 
-		<div class="flex flex-wrap gap-2">
+		<div class="flex flex-wrap gap-0.5">
 			{#each colorNames as colorOption}
 				<Tooltip>
 					<Trigger
 						slot="trigger"
-						size="xs"
+						variant="square"
+						size="sm"
+						class={classNames(
+							activeColorName === colorOption ? activeOptionClasses : '',
+							optionClasses
+						)}
 						on:click={() => {
-							colorName = colorOption;
+							activeColorName = colorOption;
 							isOpen = false;
 						}}
-						class={classNames(
-							'rounded-full hover:ring-2 hover:ring-offset-2 hover:ring-color-ui-border-primary hover:ring-offset-color-container-level-0',
-							selectedClass(colorOption)
-						)}
 					>
 						<div
-							class={classNames('w-6 h-6 rounded-full')}
+							class="w-6 h-6 rounded-full"
 							style:background={tokenNameToValue(colorOption, $currentTheme)}
 						/>
 					</Trigger>

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -46,7 +46,7 @@
 	};
 
 	const activeOptionClasses =
-		'ring-inset ring-2 ring-offset-2 ring-color-ui-background-secondary hover:ring-offset-color-ui-border-primary focus-visible:ring-offset-color-ui-border-primary';
+		'ring-inset ring-2 ring-offset-2 ring-color-ui-background-secondary ring-offset-color-ui-border-primary hover:ring-offset-color-ui-border-primary focus-visible:ring-offset-color-ui-border-primary';
 
 	const optionClasses =
 		'rounded-full bg-color-container-level-0 hover:ring-inset hover:ring-offset-2 hover:ring-offset-color-ui-border-secondary hover:ring-2 hover:ring-color-ui-background-secondary focus-visible:ring-offset-color-ui-border-secondary';

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -4,12 +4,13 @@
 
 	import { NoSymbol } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
-
 	import { currentTheme, tokenNameToValue } from '../theme/themeStore';
+	import Tooltip from '../tooltip/Tooltip.svelte';
+	import { classNames } from '../utils/classNames';
 
 	export let label;
 
-	export let colorName = 'data.primary';
+	export let colorName = 'data.categorical.blue';
 
 	export let disabled = false;
 
@@ -37,6 +38,19 @@
 	}
 
 	let isOpen = false;
+
+	const trimTokenName = (token: string) => {
+		const array = token.split('.');
+		array.shift();
+		return array.join(' ');
+	};
+
+	// add ring to currently selected colour
+	$: selectedClass = (colorOption: string) => {
+		return classNames(
+			colorName == colorOption ? 'ring-2 ring-offset-2 ring-color-text-primary' : ''
+		);
+	};
 </script>
 
 {#if disabled}
@@ -61,15 +75,27 @@
 
 		<div class="flex flex-wrap gap-2">
 			{#each colorNames as colorOption}
-				<button
-					class="w-6 h-6 rounded-full"
-					style:background={tokenNameToValue(colorOption, $currentTheme)}
-					aria-label="Color code: {colorOption}"
-					on:click={() => {
-						colorName = colorOption;
-						isOpen = false;
-					}}
-				/>
+				<Tooltip>
+					<Trigger
+						slot="trigger"
+						size="xs"
+						on:click={() => {
+							colorName = colorOption;
+							isOpen = false;
+						}}
+						class={classNames(
+							'rounded-full hover:ring-2 hover:ring-offset-2 hover:ring-color-text-primary',
+							selectedClass(colorOption)
+						)}
+					>
+						<div
+							class={classNames('w-6 h-6 rounded-full')}
+							style:background={tokenNameToValue(colorOption, $currentTheme)}
+						/>
+					</Trigger>
+					<span class="sr-only">Color code:</span>
+					{trimTokenName(colorOption)}
+				</Tooltip>
 			{/each}
 		</div>
 	</Popover>

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -46,10 +46,10 @@
 	};
 
 	const activeOptionClasses =
-		'ring-inset ring-2 ring-offset-2 ring-color-ui-background-secondary ring-offset-color-ui-border-primary hover:ring-offset-color-ui-border-primary focus-visible:ring-offset-color-ui-border-primary';
+		'ring-inset ring-2 ring-offset-2 ring-color-ui-background-primary ring-offset-color-ui-border-primary hover:ring-offset-color-ui-border-primary focus-visible:ring-offset-color-ui-border-primary';
 
 	const optionClasses =
-		'rounded-full bg-color-container-level-0 hover:bg-color-container-level-0 hover:ring-inset hover:ring-offset-2 hover:ring-offset-color-ui-border-secondary hover:ring-2 hover:ring-color-ui-background-secondary focus-visible:ring-offset-color-ui-border-secondary';
+		'rounded-full bg-color-container-level-0 hover:bg-color-container-level-0 hover:ring-inset hover:ring-offset-2 hover:ring-offset-color-ui-border-secondary hover:ring-2 hover:ring-color-ui-background-primary focus-visible:ring-offset-color-ui-border-secondary';
 </script>
 
 {#if disabled}

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -49,7 +49,7 @@
 	$: selectedClass = (colorOption: string) => {
 		return classNames(
 			colorName == colorOption
-				? 'ring-2 ring-offset-2 ring-color-text-primary ring-offset-color-container-level-0'
+				? 'ring-2 ring-offset-2 ring-color-ui-border-primary ring-offset-color-container-level-0'
 				: ''
 		);
 	};
@@ -86,7 +86,7 @@
 							isOpen = false;
 						}}
 						class={classNames(
-							'rounded-full hover:ring-2 hover:ring-offset-2 hover:ring-color-text-primary hover:ring-offset-color-container-level-0',
+							'rounded-full hover:ring-2 hover:ring-offset-2 hover:ring-color-ui-border-primary hover:ring-offset-color-container-level-0',
 							selectedClass(colorOption)
 						)}
 					>

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -49,7 +49,7 @@
 		'ring-inset ring-2 ring-offset-2 ring-color-ui-background-secondary ring-offset-color-ui-border-primary hover:ring-offset-color-ui-border-primary focus-visible:ring-offset-color-ui-border-primary';
 
 	const optionClasses =
-		'rounded-full bg-color-container-level-0 hover:ring-inset hover:ring-offset-2 hover:ring-offset-color-ui-border-secondary hover:ring-2 hover:ring-color-ui-background-secondary focus-visible:ring-offset-color-ui-border-secondary';
+		'rounded-full bg-color-container-level-0 hover:bg-color-container-level-0 hover:ring-inset hover:ring-offset-2 hover:ring-offset-color-ui-border-secondary hover:ring-2 hover:ring-color-ui-background-secondary focus-visible:ring-offset-color-ui-border-secondary';
 </script>
 
 {#if disabled}

--- a/packages/ui/src/lib/layerControl/ColorPicker.svelte
+++ b/packages/ui/src/lib/layerControl/ColorPicker.svelte
@@ -48,7 +48,9 @@
 	// add ring to currently selected colour
 	$: selectedClass = (colorOption: string) => {
 		return classNames(
-			colorName == colorOption ? 'ring-2 ring-offset-2 ring-color-text-primary' : ''
+			colorName == colorOption
+				? 'ring-2 ring-offset-2 ring-color-text-primary ring-offset-color-container-level-0'
+				: ''
 		);
 	};
 </script>
@@ -84,7 +86,7 @@
 							isOpen = false;
 						}}
 						class={classNames(
-							'rounded-full hover:ring-2 hover:ring-offset-2 hover:ring-color-text-primary',
+							'rounded-full hover:ring-2 hover:ring-offset-2 hover:ring-color-text-primary hover:ring-offset-color-container-level-0',
 							selectedClass(colorOption)
 						)}
 					>

--- a/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
@@ -14,7 +14,7 @@
 
 	let layerStates = {
 		boroughs: {
-			colorName: 'data.primary',
+			colorName: 'data.categorical.blue',
 			visible: true,
 			opacity: 1.0
 		},

--- a/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
@@ -44,11 +44,11 @@
 	</div>
 	<pre class="mt-4 text-xs">{JSON.stringify(state, null, 2)}</pre>
 
-	<p>
-		Color is: {tokenNameToValue(state.colorName, $currentTheme)} or [{colorTokenNameToRGBArray(
-			state.colorName,
-			$currentTheme
-		)}]
+	<p class="mt-4 text-sm">
+		Active Color is: <span style={`color: ${tokenNameToValue(state.colorName, $currentTheme)}`}>
+			{tokenNameToValue(state.colorName, $currentTheme)}
+		</span>
+		or [{colorTokenNameToRGBArray(state.colorName, $currentTheme)}]
 	</p>
 </Template>
 

--- a/packages/ui/src/lib/layerControl/LayerControl.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.svelte
@@ -127,7 +127,7 @@
 	{#if controlsInUse.includes('color')}
 		<ColorPicker
 			{colorNames}
-			bind:colorName={state.colorName}
+			bind:activeColorName={state.colorName}
 			disabled={disabled || disableColorControl}
 			{label}
 		/>

--- a/packages/ui/src/lib/overlay/Trigger.svelte
+++ b/packages/ui/src/lib/overlay/Trigger.svelte
@@ -44,7 +44,17 @@
 	const { action, actionProps } = getContext<TriggerFuncs>('triggerFuncs');
 </script>
 
-<Button {size} class={$$props.class} {variant} {emphasis} {slim} {ariaLabel} {action} {actionProps}>
+<Button
+	{size}
+	class={$$props.class}
+	{variant}
+	{emphasis}
+	{slim}
+	{ariaLabel}
+	{action}
+	{actionProps}
+	on:click
+>
 	<slot>
 		{hintLabel}
 

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -41,7 +41,8 @@
 		positioning: { placement },
 		openDelay: 0,
 		closeDelay: 0,
-		closeOnPointerDown: false
+		closeOnPointerDown: false,
+		disableHoverableContent: true
 	});
 
 	/**


### PR DESCRIPTION
**What does this change?**
`ColorPicker` now has the following:
- Each colour option has a tooltip with the name of the colour, for better accessibility
- When you hover over a colour, a ring appears
- Active colour (currently selected) has a ring around it 

**Why?**
Improve accessibility

**Related issues**: Resolves #961 

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
Yes

**Is it complete?**
Requires design review of focus state as this is currently not visible.

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
