### PR TITLE
add fragments for map layer styling

### DIFF
--- a/packages/maps/src/lib/themes/MapStyling.stories.svelte
+++ b/packages/maps/src/lib/themes/MapStyling.stories.svelte
@@ -1,0 +1,167 @@
+<script context="module">
+  import { mapStyles } from './mapStyleFragments';
+  import MapDeckOverlay from '../mapDeckOverlay/MapDeckOverlay.svelte';
+
+  export const meta = {
+    title: 'Maps/MapStyling',
+    component: mapStyles
+  };
+</script>
+
+<script lang="ts">
+  import { MVTLayer } from '@deck.gl/geo-layers/typed';
+
+  import { Story } from '@storybook/addon-svelte-csf';
+
+  import { Checkbox, colorTokenNameToRGBArray, currentTheme } from '@ldn-viz/ui';
+  import Map from '../map/Map.svelte';
+  import { appendOSKeyToUrl } from '../map/util';
+  //import { mapStyles } from './mapStyleFragments';
+  import { GeoJsonLayer } from '@deck.gl/layers/typed';
+
+  const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
+
+  const TILE_BASE_URL = 'https://d1lfm2zniswzpu.cloudfront.net';
+
+  const getBoroughLayer = () => {
+    return new MVTLayer({
+      id: 'boroughLayer',
+      data: `${TILE_BASE_URL}/boroughs/{z}/{x}/{y}.mvt`,
+
+      filled: true,
+      getFillColor: () => [0, 0, 0, 0],
+      opacity: 1,
+
+      ...mapStyles.border.primary($currentTheme)
+    });
+  };
+
+  const getWardsLayer = () => {
+    return new MVTLayer({
+      id: 'wardLayer',
+      data: `${TILE_BASE_URL}/wards-2022-clipped/{z}/{x}/{y}.mvt`,
+
+      filled: true,
+      getFillColor: () => [0, 0, 0, 0],
+      opacity: 1,
+
+      ...mapStyles.border.secondary($currentTheme)
+    });
+  };
+
+  const getLSOALayer = () => {
+    return new MVTLayer({
+      id: 'lsoaLayer',
+      data: `${TILE_BASE_URL}/loac-2021/{z}/{x}/{y}.mvt`,
+
+      filled: true,
+      getFillColor: () => [0, 0, 0, 0],
+      opacity: 1,
+
+      ...mapStyles.border.tertiary($currentTheme)
+    });
+  };
+
+  const getOpportunityAreas = () =>
+    new GeoJsonLayer({
+      id: 'opportunityAreasAdoptedThin',
+      geometryType: 'polygon',
+      data: 'https://gis2.london.gov.uk/server/rest/services/apps/opportunity_areas_webmap/MapServer/20/query?where=objectid+%3E%3D+0&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Foot&returnGeometry=true&returnTrueCurves=false&returnIdsOnly=false&returnCountOnly=false&returnZ=false&returnM=false&returnDistinctValues=false&returnExtentOnly=false&featureEncoding=esriDefault&f=geojson',
+
+      getFillColor: colorTokenNameToRGBArray('data.primary', $currentTheme),
+
+      ...mapStyles.outlines.thin($currentTheme)
+    });
+
+  const getOpportunityAreasThick = () =>
+    new GeoJsonLayer({
+      id: 'opportunityAreasAdoptedThicj',
+      geometryType: 'polygon',
+      data: 'https://gis2.london.gov.uk/server/rest/services/apps/opportunity_areas_webmap/MapServer/20/query?where=objectid+%3E%3D+0&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Foot&returnGeometry=true&returnTrueCurves=false&returnIdsOnly=false&returnCountOnly=false&returnZ=false&returnM=false&returnDistinctValues=false&returnExtentOnly=false&featureEncoding=esriDefault&f=geojson',
+
+      getFillColor: colorTokenNameToRGBArray('data.primary', $currentTheme),
+
+      ...mapStyles.outlines.thick($currentTheme)
+    });
+
+
+  let showBoroughs = true;
+  let showWards = true;
+  let showLSOAs = true;
+
+  let layers: any[] = [];
+  $: {
+    layers = [];
+    if (showBoroughs) {
+      layers.push(getBoroughLayer());
+    }
+    if (showWards) {
+      layers.push(getWardsLayer());
+    }
+    if (showLSOAs) {
+      layers.push(getLSOALayer());
+    }
+  }
+
+
+  /************************************/
+
+  let showOpportunityAreasThin = false;
+  let showOpportunityAreasThick = false;
+
+  let layers2: any[] = [];
+  $: {
+    layers2 = [];
+    if (showOpportunityAreasThin) {
+      layers2.push(getOpportunityAreas());
+    }
+    if (showOpportunityAreasThick) {
+      layers2.push(getOpportunityAreasThick());
+
+    }
+  }
+
+
+</script>
+
+
+<!--
+ `mapStyles.border` defines line styles for the boundaries of political and statistical geographies (boroughs, wards, MSOAs, LSOAs, etc.).
+ -->
+
+<Story name="Hierarchy of political/statistical geographies">
+  <Checkbox label="Show boroughs (primary)" bind:checked={showBoroughs} />
+  <Checkbox label="Show wards (secondary)" bind:checked={showWards} />
+  <Checkbox label="Show LSOAs (tertiary)" bind:checked={showLSOAs} />
+
+
+  <div class="relative w-[100dvw] h-[100dvh]">
+    <Map
+      options={{
+				transformRequest: appendOSKeyToUrl(OS_KEY)
+			}}
+    >
+      <MapDeckOverlay {layers} />
+    </Map>
+  </div>
+</Story>
+
+
+<!--
+`mapstyles.outlines` defines line styles for the outlines of filled areas.
+-->
+<Story name="Outlines filled areas">
+  <Checkbox label="Show polygons (thin outlines)" bind:checked={showOpportunityAreasThin} />
+  <Checkbox label="Show polygons (thick outlines)" bind:checked={showOpportunityAreasThick} />
+
+
+  <div class="relative w-[100dvw] h-[100dvh]">
+    <Map
+      options={{
+				transformRequest: appendOSKeyToUrl(OS_KEY)
+			}}
+    >
+      <MapDeckOverlay layers={layers2} />
+    </Map>
+  </div>
+</Story>

--- a/packages/maps/src/lib/themes/MapStyling.stories.svelte
+++ b/packages/maps/src/lib/themes/MapStyling.stories.svelte
@@ -1,176 +1,147 @@
 <script context="module">
-  import { mapStyles } from './mapStyleFragments';
-  import MapDeckOverlay from '../mapDeckOverlay/MapDeckOverlay.svelte';
+	import { mapStyles } from './mapStyleFragments';
+	import MapDeckOverlay from '../mapDeckOverlay/MapDeckOverlay.svelte';
 
-  export const meta = {
-    title: 'Maps/MapStyling',
-    component: mapStyles
-  };
+	export const meta = {
+		title: 'Maps/MapStyling',
+		component: mapStyles
+	};
 </script>
 
 <script lang="ts">
-  import { MVTLayer } from '@deck.gl/geo-layers/typed';
+	import { MVTLayer } from '@deck.gl/geo-layers/typed';
 
-  import { Story } from '@storybook/addon-svelte-csf';
+	import { Story } from '@storybook/addon-svelte-csf';
 
-  import { Checkbox, colorTokenNameToRGBArray, currentTheme } from '@ldn-viz/ui';
-  import Map from '../map/Map.svelte';
-  import { appendOSKeyToUrl } from '../map/util';
-  //import { mapStyles } from './mapStyleFragments';
-  import { GeoJsonLayer } from '@deck.gl/layers/typed';
+	import { Checkbox, colorTokenNameToRGBArray, currentTheme } from '@ldn-viz/ui';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
+	//import { mapStyles } from './mapStyleFragments';
+	import { GeoJsonLayer } from '@deck.gl/layers/typed';
 
-  const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
+	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
 
-  const TILE_BASE_URL = 'https://d1lfm2zniswzpu.cloudfront.net';
+	const TILE_BASE_URL = 'https://d1lfm2zniswzpu.cloudfront.net';
 
-  const getBoroughLayer = () => {
-    return new MVTLayer({
-      id: 'boroughLayer',
-      data: `${TILE_BASE_URL}/boroughs/{z}/{x}/{y}.mvt`,
+	const getBoroughLayer = () => {
+		return new MVTLayer({
+			id: 'boroughLayer',
+			data: `${TILE_BASE_URL}/boroughs/{z}/{x}/{y}.mvt`,
 
-      ...mapStyles.fill.transparent,
-      ...mapStyles.border.primary($currentTheme)
-    });
-  };
+			...mapStyles.fill.transparent,
+			...mapStyles.border.primary($currentTheme)
+		});
+	};
 
-  const getWardsLayer = () => {
-    return new MVTLayer({
-      id: 'wardLayer',
-      data: `${TILE_BASE_URL}/wards-2022-clipped/{z}/{x}/{y}.mvt`,
-      ...mapStyles.fill.transparent,
-      ...mapStyles.border.secondary($currentTheme)
-    });
-  };
+	const getWardsLayer = () => {
+		return new MVTLayer({
+			id: 'wardLayer',
+			data: `${TILE_BASE_URL}/wards-2022-clipped/{z}/{x}/{y}.mvt`,
+			...mapStyles.fill.transparent,
+			...mapStyles.border.secondary($currentTheme)
+		});
+	};
 
-  const getLSOALayer = () => {
-    return new MVTLayer({
-      id: 'lsoaLayer',
-      data: `${TILE_BASE_URL}/loac-2021/{z}/{x}/{y}.mvt`,
-      ...mapStyles.fill.transparent,
-      ...mapStyles.border.tertiary($currentTheme)
-    });
-  };
+	const getLSOALayer = () => {
+		return new MVTLayer({
+			id: 'lsoaLayer',
+			data: `${TILE_BASE_URL}/loac-2021/{z}/{x}/{y}.mvt`,
+			...mapStyles.fill.transparent,
+			...mapStyles.border.tertiary($currentTheme)
+		});
+	};
 
-  const getOpportunityAreas = () =>
-    new GeoJsonLayer({
-      id: 'opportunityAreasAdoptedThin',
-      geometryType: 'polygon',
-      data: 'https://gis2.london.gov.uk/server/rest/services/apps/opportunity_areas_webmap/MapServer/20/query?where=objectid+%3E%3D+0&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Foot&returnGeometry=true&returnTrueCurves=false&returnIdsOnly=false&returnCountOnly=false&returnZ=false&returnM=false&returnDistinctValues=false&returnExtentOnly=false&featureEncoding=esriDefault&f=geojson',
+	const getOpportunityAreas = () =>
+		new GeoJsonLayer({
+			id: 'opportunityAreasAdoptedThin',
+			geometryType: 'polygon',
+			data: 'https://gis2.london.gov.uk/server/rest/services/apps/opportunity_areas_webmap/MapServer/20/query?where=objectid+%3E%3D+0&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Foot&returnGeometry=true&returnTrueCurves=false&returnIdsOnly=false&returnCountOnly=false&returnZ=false&returnM=false&returnDistinctValues=false&returnExtentOnly=false&featureEncoding=esriDefault&f=geojson',
 
-      getFillColor: colorTokenNameToRGBArray('data.primary', $currentTheme),
+			getFillColor: colorTokenNameToRGBArray('data.primary', $currentTheme),
 
-      ...mapStyles.outlines.thin($currentTheme)
-    });
+			...mapStyles.outlines.thin($currentTheme)
+		});
 
-  const getOpportunityAreasThick = () =>
-    new GeoJsonLayer({
-      id: 'opportunityAreasAdoptedThicj',
-      geometryType: 'polygon',
-      data: 'https://gis2.london.gov.uk/server/rest/services/apps/opportunity_areas_webmap/MapServer/20/query?where=objectid+%3E%3D+0&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Foot&returnGeometry=true&returnTrueCurves=false&returnIdsOnly=false&returnCountOnly=false&returnZ=false&returnM=false&returnDistinctValues=false&returnExtentOnly=false&featureEncoding=esriDefault&f=geojson',
+	const getOpportunityAreasThick = () =>
+		new GeoJsonLayer({
+			id: 'opportunityAreasAdoptedThicj',
+			geometryType: 'polygon',
+			data: 'https://gis2.london.gov.uk/server/rest/services/apps/opportunity_areas_webmap/MapServer/20/query?where=objectid+%3E%3D+0&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Foot&returnGeometry=true&returnTrueCurves=false&returnIdsOnly=false&returnCountOnly=false&returnZ=false&returnM=false&returnDistinctValues=false&returnExtentOnly=false&featureEncoding=esriDefault&f=geojson',
 
-      getFillColor: colorTokenNameToRGBArray('data.primary', $currentTheme),
+			getFillColor: colorTokenNameToRGBArray('data.primary', $currentTheme),
 
-      ...mapStyles.outlines.thick($currentTheme)
-    });
+			...mapStyles.outlines.thick($currentTheme)
+		});
 
+	let showBoroughs = true;
+	let showWards = true;
+	let showLSOAs = true;
 
-  let showBoroughs = true;
-  let showWards = true;
-  let showLSOAs = true;
+	let layers: any[] = [];
+	$: {
+		layers = [];
+		if (showBoroughs) {
+			layers.push(getBoroughLayer());
+		}
+		if (showWards) {
+			layers.push(getWardsLayer());
+		}
+		if (showLSOAs) {
+			layers.push(getLSOALayer());
+		}
+	}
 
-  let layers: any[] = [];
-  $: {
-    layers = [];
-    if (showBoroughs) {
-      layers.push(getBoroughLayer());
-    }
-    if (showWards) {
-      layers.push(getWardsLayer());
-    }
-    if (showLSOAs) {
-      layers.push(getLSOALayer());
-    }
-  }
+	/************************************/
 
+	let showOpportunityAreasThin = false;
+	let showOpportunityAreasThick = false;
 
-  /************************************/
-
-  let showOpportunityAreasThin = false;
-  let showOpportunityAreasThick = false;
-
-  let layers2: any[] = [];
-  $: {
-    layers2 = [];
-    if (showOpportunityAreasThin) {
-      layers2.push(getOpportunityAreas());
-    }
-    if (showOpportunityAreasThick) {
-      layers2.push(getOpportunityAreasThick());
-
-    }
-  }
-
-
+	let layers2: any[] = [];
+	$: {
+		layers2 = [];
+		if (showOpportunityAreasThin) {
+			layers2.push(getOpportunityAreas());
+		}
+		if (showOpportunityAreasThick) {
+			layers2.push(getOpportunityAreasThick());
+		}
+	}
 </script>
-
 
 <!--
  `mapStyles.border` defines line styles for the boundaries of political and statistical geographies (boroughs, wards, MSOAs, LSOAs, etc.).
  -->
 
 <Story name="Hierarchy of political/statistical geographies">
-  <Checkbox label="Show boroughs (primary)" bind:checked={showBoroughs} />
-  <Checkbox label="Show wards (secondary)" bind:checked={showWards} />
-  <Checkbox label="Show LSOAs (tertiary)" bind:checked={showLSOAs} />
+	<Checkbox label="Show boroughs (primary)" bind:checked={showBoroughs} />
+	<Checkbox label="Show wards (secondary)" bind:checked={showWards} />
+	<Checkbox label="Show LSOAs (tertiary)" bind:checked={showLSOAs} />
 
-
-  <div class="relative w-[100dvw] h-[100dvh]">
-    <Map
-      options={{
+	<div class="relative w-[100dvw] h-[100dvh]">
+		<Map
+			options={{
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
-    >
-      <MapDeckOverlay {layers} />
-    </Map>
-  </div>
+		>
+			<MapDeckOverlay {layers} />
+		</Map>
+	</div>
 </Story>
-
 
 <!--
 `mapstyles.outlines` defines line styles for the outlines of filled areas.
 -->
 <Story name="Outlines filled areas">
-  <Checkbox label="Show polygons (thin outlines)" bind:checked={showOpportunityAreasThin} />
-  <Checkbox label="Show polygons (thick outlines)" bind:checked={showOpportunityAreasThick} />
+	<Checkbox label="Show polygons (thin outlines)" bind:checked={showOpportunityAreasThin} />
+	<Checkbox label="Show polygons (thick outlines)" bind:checked={showOpportunityAreasThick} />
 
-
-  <div class="relative w-[100dvw] h-[100dvh]">
-    <Map
-      options={{
+	<div class="relative w-[100dvw] h-[100dvh]">
+		<Map
+			options={{
 				transformRequest: appendOSKeyToUrl(OS_KEY)
 			}}
-    >
-      <MapDeckOverlay layers={layers2} />
-    </Map>
-  </div>
-</Story>
-
-
-<!--
-`mapstyles.fill` defines fill styles.
--->
-<Story name="Outlines filled areas">
-  <Checkbox label="Show polygons (thin outlines)" bind:checked={showOpportunityAreasThin} />
-  <Checkbox label="Show polygons (thick outlines)" bind:checked={showOpportunityAreasThick} />
-
-
-  <div class="relative w-[100dvw] h-[100dvh]">
-    <Map
-      options={{
-				transformRequest: appendOSKeyToUrl(OS_KEY)
-			}}
-    >
-      <MapDeckOverlay layers={layers2} />
-    </Map>
-  </div>
+		>
+			<MapDeckOverlay layers={layers2} />
+		</Map>
+	</div>
 </Story>

--- a/packages/maps/src/lib/themes/MapStyling.stories.svelte
+++ b/packages/maps/src/lib/themes/MapStyling.stories.svelte
@@ -28,10 +28,7 @@
       id: 'boroughLayer',
       data: `${TILE_BASE_URL}/boroughs/{z}/{x}/{y}.mvt`,
 
-      filled: true,
-      getFillColor: () => [0, 0, 0, 0],
-      opacity: 1,
-
+      ...mapStyles.fill.transparent,
       ...mapStyles.border.primary($currentTheme)
     });
   };
@@ -40,11 +37,7 @@
     return new MVTLayer({
       id: 'wardLayer',
       data: `${TILE_BASE_URL}/wards-2022-clipped/{z}/{x}/{y}.mvt`,
-
-      filled: true,
-      getFillColor: () => [0, 0, 0, 0],
-      opacity: 1,
-
+      ...mapStyles.fill.transparent,
       ...mapStyles.border.secondary($currentTheme)
     });
   };
@@ -53,11 +46,7 @@
     return new MVTLayer({
       id: 'lsoaLayer',
       data: `${TILE_BASE_URL}/loac-2021/{z}/{x}/{y}.mvt`,
-
-      filled: true,
-      getFillColor: () => [0, 0, 0, 0],
-      opacity: 1,
-
+      ...mapStyles.fill.transparent,
       ...mapStyles.border.tertiary($currentTheme)
     });
   };
@@ -149,6 +138,26 @@
 
 <!--
 `mapstyles.outlines` defines line styles for the outlines of filled areas.
+-->
+<Story name="Outlines filled areas">
+  <Checkbox label="Show polygons (thin outlines)" bind:checked={showOpportunityAreasThin} />
+  <Checkbox label="Show polygons (thick outlines)" bind:checked={showOpportunityAreasThick} />
+
+
+  <div class="relative w-[100dvw] h-[100dvh]">
+    <Map
+      options={{
+				transformRequest: appendOSKeyToUrl(OS_KEY)
+			}}
+    >
+      <MapDeckOverlay layers={layers2} />
+    </Map>
+  </div>
+</Story>
+
+
+<!--
+`mapstyles.fill` defines fill styles.
 -->
 <Story name="Outlines filled areas">
   <Checkbox label="Show polygons (thin outlines)" bind:checked={showOpportunityAreasThin} />

--- a/packages/maps/src/lib/themes/mapStyleFragments.ts
+++ b/packages/maps/src/lib/themes/mapStyleFragments.ts
@@ -1,0 +1,55 @@
+import { colorTokenNameToRGBArray } from '@ldn-viz/ui';
+
+/**
+ * Foo
+ *
+ * @component
+ */
+
+export const mapStyles = {
+
+  border: {
+
+    // was colors.core.grey['800'] in some maps
+    primary: (currentThemeVal) => ({
+      stroked: true,
+      getLineColor: colorTokenNameToRGBArray('container.inverse.level-0', currentThemeVal),
+      lineWidthScale: 10,
+      lineWidthMinPixels: 4
+    }),
+
+    // was colors.core.grey['600'] in some maps
+    secondary: (currentThemeVal) => ({
+      stroked: true,
+      getLineColor: colorTokenNameToRGBArray('container.inverse.level-2', currentThemeVal),
+      lineWidthScale: 5,
+      lineWidthMinPixels: 2
+
+
+    }),
+
+    // was colors.core.grey['500'] in some maps
+    tertiary: (currentThemeVal) => ({
+      stroked: true,
+      getLineColor: colorTokenNameToRGBArray('container.inverse.level-3', currentThemeVal),
+      lineWidthScale: 2,
+      lineWidthMinPixels: 1
+    })
+  },
+
+  outlines: {
+    thin: (currentThemeVal) => ({
+      stroked: true,
+      getLineColor: colorTokenNameToRGBArray('text.inverse.primary', currentThemeVal),
+      lineWidthScale: 1,
+      lineWidthMinPixels: 0
+    }),
+
+    thick: (currentThemeVal) => ({
+      stroked: true,
+      getLineColor: colorTokenNameToRGBArray('text.inverse.primary', currentThemeVal),
+      lineWidthScale: 2,
+      lineWidthMinPixels: 1
+    })
+  }
+};

--- a/packages/maps/src/lib/themes/mapStyleFragments.ts
+++ b/packages/maps/src/lib/themes/mapStyleFragments.ts
@@ -51,5 +51,12 @@ export const mapStyles = {
       lineWidthScale: 2,
       lineWidthMinPixels: 1
     })
+  },
+
+  fill: {
+    transparent: {
+      filled: true,
+      getFillColor: [0, 0, 0, 0]
+    }
   }
 };

--- a/packages/maps/src/lib/themes/mapStyleFragments.ts
+++ b/packages/maps/src/lib/themes/mapStyleFragments.ts
@@ -7,56 +7,52 @@ import { colorTokenNameToRGBArray } from '@ldn-viz/ui';
  */
 
 export const mapStyles = {
+	border: {
+		// was git s['800'] in some maps
+		primary: (currentThemeVal) => ({
+			stroked: true,
+			getLineColor: colorTokenNameToRGBArray('container.inverse.level-0', currentThemeVal),
+			lineWidthScale: 10,
+			lineWidthMinPixels: 4
+		}),
 
-  border: {
+		// was colors.core.grey['600'] in some maps
+		secondary: (currentThemeVal) => ({
+			stroked: true,
+			getLineColor: colorTokenNameToRGBArray('container.inverse.level-2', currentThemeVal),
+			lineWidthScale: 5,
+			lineWidthMinPixels: 2
+		}),
 
-    // was colors.core.grey['800'] in some maps
-    primary: (currentThemeVal) => ({
-      stroked: true,
-      getLineColor: colorTokenNameToRGBArray('container.inverse.level-0', currentThemeVal),
-      lineWidthScale: 10,
-      lineWidthMinPixels: 4
-    }),
+		// was colors.core.grey['500'] in some maps
+		tertiary: (currentThemeVal) => ({
+			stroked: true,
+			getLineColor: colorTokenNameToRGBArray('container.inverse.level-3', currentThemeVal),
+			lineWidthScale: 2,
+			lineWidthMinPixels: 1
+		})
+	},
 
-    // was colors.core.grey['600'] in some maps
-    secondary: (currentThemeVal) => ({
-      stroked: true,
-      getLineColor: colorTokenNameToRGBArray('container.inverse.level-2', currentThemeVal),
-      lineWidthScale: 5,
-      lineWidthMinPixels: 2
+	outlines: {
+		thin: (currentThemeVal) => ({
+			stroked: true,
+			getLineColor: colorTokenNameToRGBArray('text.inverse.primary', currentThemeVal),
+			lineWidthScale: 1,
+			lineWidthMinPixels: 0
+		}),
 
+		thick: (currentThemeVal) => ({
+			stroked: true,
+			getLineColor: colorTokenNameToRGBArray('text.inverse.primary', currentThemeVal),
+			lineWidthScale: 2,
+			lineWidthMinPixels: 1
+		})
+	},
 
-    }),
-
-    // was colors.core.grey['500'] in some maps
-    tertiary: (currentThemeVal) => ({
-      stroked: true,
-      getLineColor: colorTokenNameToRGBArray('container.inverse.level-3', currentThemeVal),
-      lineWidthScale: 2,
-      lineWidthMinPixels: 1
-    })
-  },
-
-  outlines: {
-    thin: (currentThemeVal) => ({
-      stroked: true,
-      getLineColor: colorTokenNameToRGBArray('text.inverse.primary', currentThemeVal),
-      lineWidthScale: 1,
-      lineWidthMinPixels: 0
-    }),
-
-    thick: (currentThemeVal) => ({
-      stroked: true,
-      getLineColor: colorTokenNameToRGBArray('text.inverse.primary', currentThemeVal),
-      lineWidthScale: 2,
-      lineWidthMinPixels: 1
-    })
-  },
-
-  fill: {
-    transparent: {
-      filled: true,
-      getFillColor: [0, 0, 0, 0]
-    }
-  }
+	fill: {
+		transparent: {
+			filled: true,
+			getFillColor: [0, 0, 0, 0]
+		}
+	}
 };


### PR DESCRIPTION
This starts to add fragments of styling that can be applied to deck.gl layers (similar to how we have fragments that can be applied to observable plot plots).

The values used will need review by @ChrisKnightLDN and @mikeldn as we haven't been consistent with what we've used across projects so far (e.g., one used the sequence `colors.core.grey.800`, `colors.core.grey.600`, `colors.core.grey.500` for border colors; another used `[0, 0, 0]`, and `[54, 69, 79]`). There should probably be semantic tokens created to be used by these fragments.

