### PR TITLE
Fixed: sidebar tabs now appear correctly when oriented horizontally

### DIFF
--- a/.changeset/sixty-bulldogs-scream.md
+++ b/.changeset/sixty-bulldogs-scream.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: Sidebar tabs orient correctly when horizontal

--- a/packages/ui/src/lib/sidebar/Sidebar.svelte
+++ b/packages/ui/src/lib/sidebar/Sidebar.svelte
@@ -103,7 +103,7 @@
 	{#if tabs.length}
 		<div class={classNames('absolute bg-color-container-level-0', tabPlacementClasses)}>
 			<!-- A `<SidebarTabList>`, if the sidebar has tabs-->
-			<SidebarTabList {tabs} ariaLabel={tabsAriaLabel} bind:selectedValue />
+			<SidebarTabList {tabs} {placement} ariaLabel={tabsAriaLabel} bind:selectedValue />
 		</div>
 	{:else if $sidebarAlwaysOpen !== 'true'}
 		<div class={classNames('absolute', togglePlacementClasses)}>

--- a/packages/ui/src/lib/sidebar/elements/sidebarTabs/SidebarTabList.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarTabs/SidebarTabList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { PlacementType } from '$lib/sidebar/types';
 	import { getContext } from 'svelte';
 	import { get, type Writable } from 'svelte/store';
 	import {
@@ -6,13 +7,9 @@
 		tabLayoutOverride,
 		tabThemeOverride
 	} from '../../../sidebar/sidebarUtils';
-	import type { PlacementType } from '../../../sidebar/types';
 	import TabList from '../../../tabs/TabList.svelte';
 	import type { Tab } from '../../../tabs/types';
 	import { classNames } from '../../../utils/classNames';
-
-	// Get the sidebar placement prop from context and use that to apply classes that make the tabs run horizontal or vertical
-	const sidebarPlacementFromContext = getContext<Writable<PlacementType>>('sidebarPlacement');
 
 	/**
 	 * List of tabs. An array, of which each entry is an object with the following properties:
@@ -30,13 +27,16 @@
 	export let selectedValue: Tab['id'] = tabs[0].id;
 
 	/**
+	 * Sidebar placement
+	 */
+	export let placement: PlacementType = 'right';
+
+	/**
 	 * orientation of the list of tabs
 	 */
 	let orientation: 'vertical' | 'horizontal';
 
-	$: orientation = ['top', 'bottom'].includes($sidebarPlacementFromContext)
-		? 'horizontal'
-		: 'vertical';
+	$: orientation = ['top', 'bottom'].includes(placement) ? 'horizontal' : 'vertical';
 
 	/**
 	 * Enables screen reader to describe purpose of tab list


### PR DESCRIPTION
**What does this change?**
Fixed style regression from #973 where sidebar tabs were not appearing correctly in horizontal orientation.

Before:
![image](https://github.com/user-attachments/assets/58edfd2c-479b-441b-b95e-2c28bbc9e284)

After:
![image](https://github.com/user-attachments/assets/e8662c28-3b08-4396-b8cb-38543a63fdc2)

**Why?**
Fix styling issue.

**How?**
`SidebarTabList` accepts a `placement` prop from `Sidebar` instead of getting `$sidebarPlacementFromContext` which sometimes doesn't exist.

**Related issues**:

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
