### PR TITLE
Svelte 5: Switch component

### DIFF
--- a/packages/ui/src/lib/switch/Switch.stories.svelte
+++ b/packages/ui/src/lib/switch/Switch.stories.svelte
@@ -1,0 +1,64 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import Switch from './Switch.svelte';
+	import Button from '../button/Button.svelte';
+	import type { SwitchProps } from './types.js';
+
+	const { Story } = defineMeta({
+		title: 'Ui/Components/Switch',
+		component: Switch,
+		tags: ['autodocs'],
+		render: defaultTemplate,
+		argTypes: {
+			size: {
+				options: ['md', 'sm'],
+				control: { type: 'select' }
+			},
+			labelOn: {
+				options: ['left', 'right'],
+				control: { type: 'select' }
+			}
+		}
+	});
+
+	let checked = $state(false);
+	let disabled = $state(false);
+</script>
+
+{#snippet defaultTemplate(args: SwitchProps)}
+	<Switch {...args} bind:checked />
+	<p class="text-color-text-secondary pt-2">Is checked?: {checked}</p>
+{/snippet}
+
+<Story name="Default" />
+
+<Story name="With label" args={{ label: 'Enable something' }} />
+
+<Story name="Small" args={{ label: 'Enable something', size: 'sm' }} />
+
+<Story name="Label on left" args={{ label: 'Enable something', labelOn: 'left' }} />
+
+<Story name="Control whether disabled" args={{ label: 'Enable something' }}>
+	{#snippet template(args)}
+		<div class="flex flex-col space-y-4">
+			<div class="flex">
+				<Button onclick={() => (disabled = !disabled)}
+					>Click to {disabled ? 'enable' : 'disable'}
+				</Button>
+			</div>
+
+			<Switch {...args} bind:checked {disabled} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Externally change" args={{ label: 'Enable something' }}>
+	{#snippet template(args)}
+		<div class="flex flex-col space-y-4">
+			<div class="flex">
+				<Button onclick={() => (checked = !checked)}>Toggle</Button>
+			</div>
+			<Switch {...args} bind:checked />
+		</div>
+	{/snippet}
+</Story>

--- a/packages/ui/src/lib/switch/Switch.stories.svelte
+++ b/packages/ui/src/lib/switch/Switch.stories.svelte
@@ -42,12 +42,12 @@
 	{#snippet template(args)}
 		<div class="flex flex-col space-y-4">
 			<div class="flex">
-				<Button onclick={() => (disabled = !disabled)}
-					>Click to {disabled ? 'enable' : 'disable'}
+				<Button onclick={() => (disabled = !disabled)} aria-controls="disabled-control">
+					Click to {disabled ? 'enable' : 'disable'}
 				</Button>
 			</div>
 
-			<Switch {...args} bind:checked {disabled} />
+			<Switch {...args} bind:checked {disabled} id="disabled-control" />
 		</div>
 	{/snippet}
 </Story>
@@ -56,9 +56,11 @@
 	{#snippet template(args)}
 		<div class="flex flex-col space-y-4">
 			<div class="flex">
-				<Button onclick={() => (checked = !checked)}>Toggle</Button>
+				<Button onclick={() => (checked = !checked)} aria-controls="external-toggle">
+					Toggle {checked ? 'off' : 'on'}
+				</Button>
 			</div>
-			<Switch {...args} bind:checked />
+			<Switch {...args} bind:checked id="external-toggle" />
 		</div>
 	{/snippet}
 </Story>

--- a/packages/ui/src/lib/switch/Switch.stories.svelte
+++ b/packages/ui/src/lib/switch/Switch.stories.svelte
@@ -3,6 +3,7 @@
 	import Switch from './Switch.svelte';
 	import Button from '../button/Button.svelte';
 	import type { SwitchProps } from './types.js';
+	import { expect } from 'storybook/test';
 
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Switch',
@@ -18,6 +19,9 @@
 				options: ['left', 'right'],
 				control: { type: 'select' }
 			}
+		},
+		parameters: {
+			a11y: { test: 'error' }
 		}
 	});
 
@@ -30,7 +34,13 @@
 	<p class="text-color-text-secondary pt-2">Is checked?: {checked}</p>
 {/snippet}
 
-<Story name="Default" />
+<Story
+	name="Default"
+	play={async ({ canvas, userEvent }) => {
+		await userEvent.click(canvas.getByRole('switch'));
+		await expect(canvas.getByText('Is checked?: true')).toBeInTheDocument();
+	}}
+/>
 
 <Story name="With label" args={{ label: 'Enable something' }} />
 
@@ -38,7 +48,15 @@
 
 <Story name="Label on left" args={{ label: 'Enable something', labelOn: 'left' }} />
 
-<Story name="Control whether disabled" args={{ label: 'Enable something' }}>
+<Story
+	name="Control whether disabled"
+	args={{ label: 'Enable something' }}
+	play={async ({ canvas, userEvent }) => {
+		await userEvent.click(canvas.getByRole('button'));
+		await expect(canvas.getByRole('switch')).toHaveAttribute('disabled');
+		await expect(canvas.getByRole('button')).toHaveTextContent('Click to enable');
+	}}
+>
 	{#snippet template(args)}
 		<div class="flex flex-col space-y-4">
 			<div class="flex">
@@ -52,7 +70,17 @@
 	{/snippet}
 </Story>
 
-<Story name="Externally change" args={{ label: 'Enable something' }}>
+<Story
+	name="Externally change"
+	args={{ label: 'Enable something' }}
+	play={async ({ canvas, userEvent }) => {
+		await expect(canvas.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+		await expect(canvas.getByText('Toggle on')).toBeInTheDocument();
+		await userEvent.click(canvas.getByRole('button'));
+		await expect(canvas.getByText('Toggle off')).toBeInTheDocument();
+		await expect(canvas.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+	}}
+>
 	{#snippet template(args)}
 		<div class="flex flex-col space-y-4">
 			<div class="flex">

--- a/packages/ui/src/lib/switch/Switch.svelte
+++ b/packages/ui/src/lib/switch/Switch.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import { classNames } from '../utils/classNames.js';
+	import { randomId } from '../utils/randomId.js';
+	import { Label, Switch } from 'bits-ui';
+
+	interface Props {
+		/**
+		 * If `true`, the user will not be able to interact with the Switch to download data.
+		 */
+		disabled?: boolean;
+		/**
+		 * Value set as the `name` attribute of the hidden `<input>` element (optional, but required if providing value with a form submission)
+		 */
+		name?: string;
+		id?: any;
+		/**
+		 * Determines whether field is required.
+		 */
+		required?: boolean;
+		/**
+		 * Text displayed beside the switch.
+		 */
+		label?: string;
+		/**
+		 * Whether the checkbox is checked.
+		 */
+		checked?: boolean;
+		/**
+		 * The size of the switch.
+		 */
+		size?: 'md' | 'sm';
+		/**
+		 * Which side of the switch to display the label on.
+		 */
+		labelOn?: 'left' | 'right';
+	}
+
+	let {
+		disabled = false,
+		name = '',
+		id = randomId(),
+		required = false,
+		label = '',
+		checked = $bindable(false),
+		size = 'md',
+		labelOn = 'right'
+	}: Props = $props();
+
+	const switchRootClass = $derived(
+		classNames(
+			'bg-color-input-background-off data-[state=checked]:bg-color-input-background-on relative h-6 cursor-default rounded-full transition-colors',
+			size === 'md' ? 'h-[24px] w-[44px]' : 'h-[16px] w-[30px]'
+		)
+	);
+
+	// TODO replace color token with handle
+	const switchThumbClass = $derived(
+		classNames(
+			'thumb block rounded-full transition',
+			size === 'md' ? 'h-[22px] w-[22px]' : 'h-[14px] w-[14px]',
+			disabled ? 'bg-color-input-label-disabled' : 'bg-color-input-background'
+		)
+	);
+
+	// Does this need to be derived for the sake of the story? TO BE DISCUSSED
+	const labelClass = $derived(
+		classNames(
+			'form-label text-color-input-label leading-none',
+			labelOn === 'right' ? 'pl-2' : 'pr-2'
+		)
+	);
+
+	const translation = { md: '21px', sm: '15px' };
+
+	const translate = $derived(
+		checked ? `translate(${translation[size]}, 0px)` : 'translate(1px, 0px)'
+	);
+</script>
+
+<div class="flex items-center">
+	{#if labelOn === 'left'}
+		<Label.Root for={id} class={labelClass} id={`${id}-label`}>{label}</Label.Root>
+	{/if}
+
+	<Switch.Root class={switchRootClass} {id} {name} {required} {disabled} bind:checked>
+		<Switch.Thumb class={switchThumbClass} style="transform: {translate}" />
+	</Switch.Root>
+
+	{#if labelOn === 'right'}
+		<Label.Root for={id} class={labelClass} id={`${id}-label`}>{label}</Label.Root>
+	{/if}
+</div>

--- a/packages/ui/src/lib/switch/types.ts
+++ b/packages/ui/src/lib/switch/types.ts
@@ -1,0 +1,10 @@
+export type SwitchProps = {
+    disabled?: boolean;
+    name?: string;
+    id?: any;
+    required?: boolean;
+    label?: string;
+    checked?: boolean;
+    size?: 'md' | 'sm';
+    labelOn?: 'left' | 'right';
+}


### PR DESCRIPTION
**What does this change?**
Migrates Switch component to Svelte 5 syntax.

**Why?**
To demonstrate new best practice for implementing components and testing them in Storybook with Svelte 5.

**How?**

**Related issues**:

**Does this introduce new dependencies?**

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
Yes

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
