### PR TITLE
add MapDeckPopovers and MapDeckTooltips components

### DIFF
--- a/.changeset/deckgl-tooltips-popovers.md
+++ b/.changeset/deckgl-tooltips-popovers.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': minor
+---
+
+ADDED: `MapDeckPopovers` and `MapDeckTooltips` to easily add popovers or tooltips to multiple Deck.gl layers

--- a/packages/maps/src/lib/index.js
+++ b/packages/maps/src/lib/index.js
@@ -30,6 +30,9 @@ export { default as MapMarkerFlyToFeature } from './mapMarker/elements/mapMarker
 export { default as MapMarkerPlacement } from './mapMarker/elements/mapMarkerPlacement/MapMarkerPlacement.svelte';
 export { default as MapMarkerStyledContainer } from './mapMarker/elements/mapMarkerStyledContainer/MapMarkerStyledContainer.svelte';
 
+export { default as MapDeckPopovers } from './mapDeckPopovers/MapDeckPopovers.svelte';
+export { default as MapDeckTooltips } from './mapDeckTooltips/MapDeckTooltips.svelte';
+
 export { default as MapPopover } from './mapPopover/MapPopover.svelte';
 
 // Layers

--- a/packages/maps/src/lib/mapDeckOverlay/MapDeckOverlay.stories.svelte
+++ b/packages/maps/src/lib/mapDeckOverlay/MapDeckOverlay.stories.svelte
@@ -2,7 +2,7 @@
 	import MapDeckOverlay from './MapDeckOverlay.svelte';
 
 	export const meta = {
-		title: 'Maps/Components/MapDeckOverlay',
+		title: 'Maps/Components/DeckGL/MapDeckOverlay',
 		component: MapDeckOverlay
 	};
 </script>

--- a/packages/maps/src/lib/mapDeckPopovers/DefaultPopover.svelte
+++ b/packages/maps/src/lib/mapDeckPopovers/DefaultPopover.svelte
@@ -1,0 +1,11 @@
+<script>
+	import MapMarkerStyledContainer from '../mapMarker/elements/mapMarkerStyledContainer/MapMarkerStyledContainer.svelte';
+	import { getContext } from 'svelte';
+	const msg = getContext('mapMarkerString');
+</script>
+
+<MapMarkerStyledContainer>
+	<div>
+		{msg}
+	</div>
+</MapMarkerStyledContainer>

--- a/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.stories.svelte
+++ b/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.stories.svelte
@@ -1,0 +1,144 @@
+<script context="module">
+	import MapDeckPopovers from './MapDeckPopovers.svelte';
+	export const meta = {
+		title: 'Maps/Components/DeckGL/MapDeckPopovers',
+		component: MapDeckPopovers,
+		parameters: {
+			layout: 'full'
+		}
+	};
+</script>
+
+<script lang="ts">
+	import { MVTLayer } from '@deck.gl/geo-layers/typed';
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
+	import MapDeckOverlay from '../mapDeckOverlay/MapDeckOverlay.svelte';
+	import { Checkbox } from '@ldn-viz/ui';
+	import { onClickPopoverHandler } from './stores';
+	import DemoPopoverComponent from './demo/DemoPopoverComponent.svelte';
+	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
+	const TILE_BASE_URL = 'https://d1lfm2zniswzpu.cloudfront.net';
+	const getBoroughLayer = () => {
+		return new MVTLayer({
+			id: 'boroughLayer',
+			data: `${TILE_BASE_URL}/boroughs/{z}/{x}/{y}.mvt`,
+			filled: true,
+			getFillColor: () => [255, 0, 0],
+			opacity: 1,
+			stroked: true,
+			getLineColor: [168, 168, 168, 255],
+			lineWidthScale: 5,
+			lineWidthMinPixels: 4,
+			pickable: true, // not needed?
+			onClick: onClickPopoverHandler
+		});
+	};
+	const getWardsLayer = () => {
+		return new MVTLayer({
+			id: 'wardLayer',
+			data: `${TILE_BASE_URL}/wards-2022-clipped/{z}/{x}/{y}.mvt`,
+			filled: true,
+			getFillColor: () => [0, 255, 0],
+			opacity: 1,
+			stroked: true,
+			getLineColor: [168, 168, 168, 255],
+			lineWidthScale: 2,
+			lineWidthMinPixels: 1,
+			pickable: true,
+			onClick: onClickPopoverHandler
+		});
+	};
+
+	let showWards = false;
+	let showBoroughs = true;
+	let layers = [];
+	$: {
+		layers = [];
+		if (showWards) {
+			layers.push(getWardsLayer());
+		}
+		if (showBoroughs) {
+			layers.push(getBoroughLayer());
+		}
+	}
+</script>
+
+<Template let:args>
+	<MapDeckPopovers {...args} />
+</Template>
+
+<!-- Here every feature in a layer is assigned the same string as a popover. -->
+<Story name="Example - spec as string">
+	<Checkbox label="Show wards" bind:checked={showWards} />
+	<Checkbox label="Show boroughs" bind:checked={showBoroughs} />
+
+	<div class="w-[100dvw] h-[100dvh]">
+		<Map
+			options={{
+				transformRequest: appendOSKeyToUrl(OS_KEY)
+			}}
+		>
+			<MapDeckOverlay {layers} />
+
+			<MapDeckPopovers
+				{layers}
+				spec={{
+					wardLayer: 'This is one of the Wards',
+					boroughLayer: 'This is one of the Boroughs'
+				}}
+			/>
+		</Map>
+	</div>
+</Story>
+
+<!-- Here the popover contents are given by applying a function (which is the same for all features in a layer, but may be different between layers) to the feature. -->
+<Story name="Example - spec as function">
+	<Checkbox label="Show wards" bind:checked={showWards} />
+	<Checkbox label="Show boroughs" bind:checked={showBoroughs} />
+
+	<div class="w-[100dvw] h-[100dvh]">
+		<Map
+			options={{
+				transformRequest: appendOSKeyToUrl(OS_KEY)
+			}}
+		>
+			<MapDeckOverlay {layers} />
+
+			<MapDeckPopovers
+				{layers}
+				spec={{
+					wardLayer: (feature) => feature.properties.wd22nm,
+					boroughLayer: (feature) => feature.properties.name
+				}}
+			/>
+		</Map>
+	</div>
+</Story>
+
+<!-- Here the popover is rendered by a custom component, which ahs access to the feature object.
+  Each layer can use a separate component to render the popovers for its features.
+  -->
+<Story name="Example - spec as components">
+	<Checkbox label="Show wards" bind:checked={showWards} />
+	<Checkbox label="Show boroughs" bind:checked={showBoroughs} />
+
+	<div class="w-[100dvw] h-[100dvh]">
+		<Map
+			options={{
+				transformRequest: appendOSKeyToUrl(OS_KEY)
+			}}
+		>
+			<MapDeckOverlay {layers} />
+
+			<MapDeckPopovers
+				{layers}
+				spec={{
+					wardLayer: DemoPopoverComponent,
+					boroughLayer: DemoPopoverComponent
+				}}
+			/>
+		</Map>
+	</div>
+</Story>

--- a/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.stories.svelte
+++ b/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.stories.svelte
@@ -18,6 +18,8 @@
 	import { Checkbox } from '@ldn-viz/ui';
 	import { onClickPopoverHandler } from './stores';
 	import DemoPopoverComponent from './demo/DemoPopoverComponent.svelte';
+	import type { Layer } from '@deck.gl/core/typed';
+	import type { Feature } from 'geojson';
 	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
 	const TILE_BASE_URL = 'https://d1lfm2zniswzpu.cloudfront.net';
 	const getBoroughLayer = () => {
@@ -53,7 +55,7 @@
 
 	let showWards = false;
 	let showBoroughs = true;
-	let layers = [];
+	let layers: Layer[] = [];
 	$: {
 		layers = [];
 		if (showWards) {
@@ -109,8 +111,8 @@
 			<MapDeckPopovers
 				{layers}
 				spec={{
-					wardLayer: (feature) => feature.properties.wd22nm,
-					boroughLayer: (feature) => feature.properties.name
+					wardLayer: (feature: Feature) => feature.properties.wd22nm,
+					boroughLayer: (feature: Feature) => feature.properties.name
 				}}
 			/>
 		</Map>

--- a/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.stories.svelte
+++ b/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.stories.svelte
@@ -19,7 +19,6 @@
 	import { onClickPopoverHandler } from './stores';
 	import DemoPopoverComponent from './demo/DemoPopoverComponent.svelte';
 	import type { Layer } from '@deck.gl/core/typed';
-	import type { Feature } from 'geojson';
 	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
 	const TILE_BASE_URL = 'https://d1lfm2zniswzpu.cloudfront.net';
 	const getBoroughLayer = () => {

--- a/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.stories.svelte
+++ b/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.stories.svelte
@@ -111,8 +111,8 @@
 			<MapDeckPopovers
 				{layers}
 				spec={{
-					wardLayer: (feature: Feature) => feature.properties.wd22nm,
-					boroughLayer: (feature: Feature) => feature.properties.name
+					wardLayer: (feature) => feature.properties.wd22nm,
+					boroughLayer: (feature) => feature.properties.name
 				}}
 			/>
 		</Map>

--- a/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.svelte
+++ b/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.svelte
@@ -5,19 +5,20 @@
 	 * For each layer, the output can be specified as a string constant, a function that is passed a feature and returns a string, or a custom Svelte component.
 	 * @component
 	 */
+	import type { Layer } from '@deck.gl/core/typed';
 	import { clickedFeature, clickedLayer } from './stores';
 	import DefaultPopover from './DefaultPopover.svelte';
 	import MapPopover from '../mapPopover/MapPopover.svelte';
-	export let spec = {};
+	export let spec: Record<string, any> = {};
 	/**
 	 * List of layers, as provided to deck.gl.
 	 */
-	export let layers = [];
+	export let layers: Layer[] = [];
 	let tooltipSpec: any;
 	$: {
 		tooltipSpec = spec[$clickedLayer];
 	}
-	function isConstructor(obj) {
+	function isConstructor(obj: any) {
 		return !!obj.prototype && !!obj.prototype.constructor.name;
 	}
 	$: layerObj = layers.find((l) => l.id === $clickedLayer);
@@ -32,7 +33,7 @@
 	});
 </script>
 
-{#if layerObj && layerObj.visible !== false}
+{#if layerObj && layerObj.visible !== false && $clickedFeature && $clickedLayer}
 	{#if typeof tooltipSpec === 'string'}
 		<MapPopover
 			feature={$clickedFeature}

--- a/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.svelte
+++ b/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	/**
+	 * The `MapDeckPopovers` component renders a popover for features rendered by Deck.gl, when they are clicked on.
+	 * It accepts a configuration object, the keys are the layer ids for which Popovers should be rendered, and the  values specify how they should be rendered.
+	 * For each layer, the output can be specified as a string constant, a function that is passed a feature and returns a string, or a custom Svelte component.
+	 * @component
+	 */
+	import { clickedFeature, clickedLayer } from './stores';
+	import DefaultPopover from './DefaultPopover.svelte';
+	import MapPopover from '../mapPopover/MapPopover.svelte';
+	export let spec = {};
+	/**
+	 * List of layers, as provided to deck.gl.
+	 */
+	export let layers = [];
+	let tooltipSpec: any;
+	$: {
+		tooltipSpec = spec[$clickedLayer];
+	}
+	function isConstructor(obj) {
+		return !!obj.prototype && !!obj.prototype.constructor.name;
+	}
+	$: layerObj = layers.find((l) => l.id === $clickedLayer);
+	// layers.find(l => l.id === $clickedLayer)?.visible;
+
+	$: console.log({
+		tooltipSpec,
+		layerObj,
+		clickedLayer: $clickedLayer,
+		layers,
+		feat: $clickedFeature
+	});
+</script>
+
+{#if layerObj && layerObj.visible !== false}
+	{#if typeof tooltipSpec === 'string'}
+		<MapPopover
+			feature={$clickedFeature}
+			layer={$clickedLayer}
+			popup={DefaultPopover}
+			msgString={tooltipSpec}
+		>
+			{tooltipSpec}
+		</MapPopover>
+	{:else if tooltipSpec && isConstructor(tooltipSpec)}
+		<MapPopover feature={$clickedFeature} layer={$clickedLayer} popup={tooltipSpec} />
+	{:else if typeof tooltipSpec === 'function'}
+		<MapPopover
+			feature={$clickedFeature}
+			layer={$clickedLayer}
+			popup={DefaultPopover}
+			msgString={tooltipSpec($clickedFeature)}
+		/>
+	{/if}
+{/if}

--- a/packages/maps/src/lib/mapDeckPopovers/demo/DemoPopoverComponent.svelte
+++ b/packages/maps/src/lib/mapDeckPopovers/demo/DemoPopoverComponent.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import MapMarkerStyledContainer from '../../mapMarker/elements/mapMarkerStyledContainer/MapMarkerStyledContainer.svelte';
+	const feature = getContext('mapMarkerFeature');
+</script>
+
+<MapMarkerStyledContainer>
+	<div>
+		<p>This feature has properties:</p>
+		<pre>{JSON.stringify(feature.properties, null, 2)}</pre>
+	</div>
+</MapMarkerStyledContainer>

--- a/packages/maps/src/lib/mapDeckPopovers/stores.ts
+++ b/packages/maps/src/lib/mapDeckPopovers/stores.ts
@@ -1,8 +1,8 @@
 import { type Writable, writable } from 'svelte/store';
 import type { Feature } from 'geojson';
 
-export const clickedFeature: Writable<Feature  | undefined> = writable();
-export const clickedLayer = writable("");
+export const clickedFeature: Writable<Feature | undefined> = writable();
+export const clickedLayer = writable('');
 export const onClickPopoverHandler = (ev: { object: any; layer: { id: any } }) => {
 	clickedFeature.set(ev.object);
 	clickedLayer.set(ev.layer.id);

--- a/packages/maps/src/lib/mapDeckPopovers/stores.ts
+++ b/packages/maps/src/lib/mapDeckPopovers/stores.ts
@@ -1,8 +1,8 @@
-import { writable } from 'svelte/store';
+import { type Writable, writable } from 'svelte/store';
 import type { Feature } from 'geojson';
 
-export const clickedFeature = writable();
-export const clickedLayer = writable();
+export const clickedFeature: Writable<Feature  | undefined> = writable();
+export const clickedLayer = writable("");
 export const onClickPopoverHandler = (ev: { object: any; layer: { id: any } }) => {
 	clickedFeature.set(ev.object);
 	clickedLayer.set(ev.layer.id);

--- a/packages/maps/src/lib/mapDeckPopovers/stores.ts
+++ b/packages/maps/src/lib/mapDeckPopovers/stores.ts
@@ -1,0 +1,9 @@
+import { writable } from 'svelte/store';
+import type { Feature } from 'geojson';
+
+export const clickedFeature = writable();
+export const clickedLayer = writable();
+export const onClickPopoverHandler = (ev: { object: any; layer: { id: any } }) => {
+	clickedFeature.set(ev.object);
+	clickedLayer.set(ev.layer.id);
+};

--- a/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.stories.svelte
+++ b/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.stories.svelte
@@ -1,0 +1,163 @@
+<script context="module">
+	import MapDeckTooltips from './MapDeckTooltips.svelte';
+
+	export const meta = {
+		title: 'Maps/Components/DeckGL/MapDeckTooltips',
+		component: MapDeckTooltips,
+		parameters: {
+			layout: 'full'
+		}
+	};
+</script>
+
+<script lang="ts">
+	import { MVTLayer } from '@deck.gl/geo-layers/typed';
+
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+
+	import Map from '../map/Map.svelte';
+	import { appendOSKeyToUrl } from '../map/util';
+
+	import MapDeckOverlay from '../mapDeckOverlay/MapDeckOverlay.svelte';
+	import { Checkbox } from '@ldn-viz/ui';
+	import { onMouseOverTooltipHandler } from './stores';
+	import DemoTooltipComponent from './demo/DemoTooltipComponent.svelte';
+
+	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
+
+	const TILE_BASE_URL = 'https://d1lfm2zniswzpu.cloudfront.net';
+
+	const getBoroughLayer = () => {
+		return new MVTLayer({
+			id: 'boroughLayer',
+			data: `${TILE_BASE_URL}/boroughs/{z}/{x}/{y}.mvt`,
+
+			filled: true,
+			getFillColor: () => [255, 0, 0],
+			opacity: 1,
+
+			stroked: true,
+			getLineColor: [168, 168, 168, 255],
+
+			lineWidthScale: 5,
+			lineWidthMinPixels: 4,
+
+			pickable: true, // not needed?
+			//	onClick: onClickTooltipHandler
+			onHover: onMouseOverTooltipHandler
+		});
+	};
+
+	const getWardsLayer = () => {
+		return new MVTLayer({
+			id: 'wardLayer',
+			data: `${TILE_BASE_URL}/wards-2022-clipped/{z}/{x}/{y}.mvt`,
+
+			filled: true,
+			getFillColor: () => [0, 255, 0],
+			opacity: 1,
+
+			stroked: true,
+			getLineColor: [168, 168, 168, 255],
+
+			lineWidthScale: 2,
+			lineWidthMinPixels: 1,
+
+			pickable: true,
+			//onClick: onClickTooltipHandler,
+			onHover: onMouseOverTooltipHandler
+		});
+	};
+
+	let showWards = false;
+	let showBoroughs = true;
+
+	let layers = [];
+	$: {
+		layers = [];
+		if (showWards) {
+			layers.push(getWardsLayer());
+		}
+		if (showBoroughs) {
+			layers.push(getBoroughLayer());
+		}
+	}
+</script>
+
+<Template let:args>
+	<MapDeckTooltips {...args} />
+</Template>
+
+<!-- Here every feature in a layer is assigned the same string as a Tooltip. -->
+<Story name="Example - spec as string">
+	<Checkbox label="Show wards" bind:checked={showWards} />
+	<Checkbox label="Show boroughs" bind:checked={showBoroughs} />
+
+	<div class="w-[100dvw] h-[100dvh]">
+		<Map
+			options={{
+				transformRequest: appendOSKeyToUrl(OS_KEY)
+			}}
+		>
+			<MapDeckOverlay {layers} />
+
+			<MapDeckTooltips
+				{layers}
+				spec={{
+					wardLayer: 'This is one of the Wards',
+					boroughLayer: 'This is one of the Boroughs'
+				}}
+			/>
+		</Map>
+	</div>
+</Story>
+
+<!-- Here the Tooltip contents are given by applying a function (which is the same for all features in a layer, but may be different between layers) to the feature. -->
+<Story name="Example - spec as function">
+	<Checkbox label="Show wards" bind:checked={showWards} />
+	<Checkbox label="Show boroughs" bind:checked={showBoroughs} />
+
+	<div class="w-[100dvw] h-[100dvh]">
+		<Map
+			options={{
+				transformRequest: appendOSKeyToUrl(OS_KEY)
+			}}
+		>
+			<MapDeckOverlay {layers} />
+
+			<MapDeckTooltips
+				{layers}
+				spec={{
+					wardLayer: (feature) => feature.properties.wd22nm,
+					boroughLayer: (feature) => feature.properties.name
+				}}
+			/>
+		</Map>
+	</div>
+</Story>
+
+<!-- Here the Tooltip is rendered by a custom component, which ahs access to the feature object.
+  Each layer can use a separate component to render the Tooltips for its features.
+  -->
+<Story name="Example - spec as components">
+	<Checkbox label="Show wards" bind:checked={showWards} />
+	<Checkbox label="Show boroughs" bind:checked={showBoroughs} />
+
+	<div class="w-[100dvw] h-[100dvh]">
+		<Map
+			options={{
+				transformRequest: appendOSKeyToUrl(OS_KEY)
+			}}
+		>
+			<MapDeckOverlay {layers} />
+
+			<MapDeckTooltips
+				{layers}
+				spec={{
+					wardLayer: DemoTooltipComponent,
+					boroughLayer: DemoTooltipComponent
+				}}
+			/>
+		</Map>
+	</div>
+</Story>

--- a/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.svelte
+++ b/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.svelte
@@ -7,6 +7,7 @@
 	 */
 
 	import { mousedOverObject } from './stores';
+	import type { Layer } from '@deck.gl/core/typed';
 
 	import { arrow } from 'svelte-floating-ui';
 	import type { ClientRectObject } from 'svelte-floating-ui/core';
@@ -73,14 +74,14 @@
 	/**
 	 * List of layers. We need this so that we can remove a popover when the correpsodning layer is removed.
 	 */
-	export let layers = [];
+	export let layers: Layer[] = [];
 
-	export let spec = {};
+	export let spec: Record<string, any> = {};
 
 	let tooltipSpec: any;
 	let layerObj: any;
 	$: {
-		if ($mousedOverObject && $mousedOverObject.feature) {
+		if ($mousedOverObject && $mousedOverObject.feature && $mousedOverObject.layer) {
 			tooltipSpec = spec[$mousedOverObject.layer.id];
 			layerObj = layers.find((l) => l.id === $mousedOverObject?.layer?.id);
 		} else {
@@ -92,8 +93,6 @@
 	function isConstructor(obj: any) {
 		return !!obj.prototype && !!obj.prototype.constructor.name;
 	}
-
-	$: console.log({ layerObj, layers, feat: $mousedOverObject });
 </script>
 
 <svelte:window on:mousemove={mousemove} />

--- a/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.svelte
+++ b/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+	/**
+	 * The `MapDeckTooltips` component renders a tooltip for features rendered by Deck.gl, when they are hovered over.
+	 * It accepts a configuration object, the keys are the layer ids for which Popovers should be rendered, and the  values specify how they should be rendered.
+	 * For each layer, the output can be specified as a string constant, a function that is passed a feature and returns a string, or a custom Svelte component.
+	 * @component
+	 */
+
+	import { mousedOverObject } from './stores';
+
+	import { arrow } from 'svelte-floating-ui';
+	import type { ClientRectObject } from 'svelte-floating-ui/core';
+	import { offset, flip, shift } from 'svelte-floating-ui/dom';
+	import { createFloatingActions } from 'svelte-floating-ui';
+	import { type Writable, writable } from 'svelte/store';
+
+	const [floatingRef, floatingContent] = createFloatingActions({
+		strategy: 'fixed', //or absolute
+		middleware: [offset(0), flip(), shift()]
+	});
+
+	let x = 0;
+	let y = 0;
+
+	const mousemove = (ev: MouseEvent) => {
+		x = ev.clientX;
+		y = ev.clientY;
+	};
+
+	$: getBoundingClientRect = (): ClientRectObject => {
+		return {
+			x,
+			y,
+			top: y,
+			left: x,
+			bottom: y,
+			right: x,
+			width: 0,
+			height: 0
+		};
+	};
+
+	const virtualElement = writable({ getBoundingClientRect });
+
+	$: virtualElement.set({ getBoundingClientRect });
+
+	floatingRef(virtualElement);
+
+	const arrowRef: Writable<HTMLElement> = writable();
+
+	let dynamicOptions = {
+		middleware: [offset(10), flip(), shift(), arrow({ element: arrowRef })],
+		onComputed({ placement, middlewareData }: { placement: string; middlewareData }) {
+			const { x, y } = middlewareData.arrow || {};
+			const staticSide = {
+				top: 'bottom',
+				right: 'left',
+				bottom: 'top',
+				left: 'right'
+			}[placement.split('-')[0]];
+
+			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+			$arrowRef &&
+				Object.assign($arrowRef.style, {
+					left: x != null ? `${x}px` : '',
+					top: y != null ? `${y}px` : '',
+					[staticSide!.toString()]: '-8px'
+				});
+		}
+	};
+
+	///
+	/**
+	 * List of layers. We need this so that we can remove a popover when the correpsodning layer is removed.
+	 */
+	export let layers = [];
+
+	export let spec = {};
+
+	let tooltipSpec: any;
+	let layerObj: any;
+	$: {
+		if ($mousedOverObject && $mousedOverObject.feature) {
+			tooltipSpec = spec[$mousedOverObject.layer.id];
+			layerObj = layers.find((l) => l.id === $mousedOverObject?.layer?.id);
+		} else {
+			tooltipSpec = undefined;
+			layerObj = undefined;
+		}
+	}
+
+	function isConstructor(obj: any) {
+		return !!obj.prototype && !!obj.prototype.constructor.name;
+	}
+
+	$: console.log({ layerObj, layers, feat: $mousedOverObject });
+</script>
+
+<svelte:window on:mousemove={mousemove} />
+
+{#if layerObj && layerObj.visible !== false && $mousedOverObject && tooltipSpec}
+	<div
+		use:floatingContent={dynamicOptions}
+		class:width={'100px'}
+		style:z-index={9999}
+		class="bg-core-grey-800 text-white p-3.5 pointer-events-none"
+	>
+		{#if typeof tooltipSpec === 'string'}
+			{tooltipSpec}
+		{:else if tooltipSpec && isConstructor(tooltipSpec)}
+			<svelte:component this={tooltipSpec} feature={$mousedOverObject.feature} />
+		{:else if typeof tooltipSpec === 'function'}
+			{tooltipSpec($mousedOverObject.feature)}
+		{/if}
+	</div>
+{/if}

--- a/packages/maps/src/lib/mapDeckTooltips/demo/DemoTooltipComponent.svelte
+++ b/packages/maps/src/lib/mapDeckTooltips/demo/DemoTooltipComponent.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import type { Feature } from 'geojson';
+
+	export let feature: undefined | Feature = undefined;
+</script>
+
+{#if feature}
+	<div>
+		<p>This feature has properties:</p>
+		<pre>{JSON.stringify(feature.properties, null, 2)}</pre>
+	</div>
+{/if}

--- a/packages/maps/src/lib/mapDeckTooltips/stores.ts
+++ b/packages/maps/src/lib/mapDeckTooltips/stores.ts
@@ -1,0 +1,12 @@
+import { writable } from 'svelte/store';
+import type { Feature } from 'geojson';
+
+type MousedOver = {
+	layer: undefined | { id: string };
+	feature: Feature;
+};
+export const mousedOverObject = writable<MousedOver | undefined>();
+
+export const onMouseOverTooltipHandler = (ev: any) => {
+	mousedOverObject.set({ feature: ev.object, layer: { id: ev.layer.id } });
+};

--- a/packages/maps/src/lib/mapPopover/MapPopover.svelte
+++ b/packages/maps/src/lib/mapPopover/MapPopover.svelte
@@ -31,9 +31,9 @@
 	 */
 	export let popup: ComponentType | null = null;
 
-  /**
-   * Optional message to be passed to child popop component via `mapMarkerString` context.
-   */
+	/**
+	 * Optional message to be passed to child popop component via `mapMarkerString` context.
+	 */
 	export let msgString: string | null = null;
 
 	/**

--- a/packages/maps/src/lib/mapPopover/MapPopover.svelte
+++ b/packages/maps/src/lib/mapPopover/MapPopover.svelte
@@ -31,6 +31,9 @@
 	 */
 	export let popup: ComponentType | null = null;
 
+  /**
+   * Optional message to be passed to child popop component via `mapMarkerString` context.
+   */
 	export let msgString: string | null = null;
 
 	/**

--- a/packages/maps/src/lib/mapPopover/MapPopover.svelte
+++ b/packages/maps/src/lib/mapPopover/MapPopover.svelte
@@ -31,6 +31,8 @@
 	 */
 	export let popup: ComponentType | null = null;
 
+	export let msgString: string | null = null;
+
 	/**
 	 * Feature to which the popover should be attached.
 	 * This is used to position the popover, and is also passed to the popover component via the `mapMarkerFeature` context.
@@ -79,7 +81,8 @@
 				...contexts,
 				['mapMarkerMaplibrePopup', maplibrePopup],
 				['mapMarkerFeature', feature],
-				['mapMarkerLayer', layer]
+				['mapMarkerLayer', layer],
+				['mapMarkerString', msgString]
 			])
 		});
 


### PR DESCRIPTION
This adds `MapDeckPopovers` and `MapDeckTooltips` components to easily add popovers or tooltips to multiple Deck.gl layers.