### PR TITLE
Fix storybook node compatibility

### DIFF
--- a/.changeset/proud-worms-follow.md
+++ b/.changeset/proud-worms-follow.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/docs': minor
+---
+
+FIXED: explicitly define `require` to fix storybook not launching when using Node v24

--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -1,6 +1,12 @@
 import type { StorybookConfig } from '@storybook/sveltekit';
 
+import { createRequire } from 'node:module';
 import { dirname, join } from 'path';
+
+/**
+ * Define Node `require` to fix storybook compatibility issues with Node v24
+ */
+const require = createRequire(import.meta.url);
 
 /**
  * This function is used to resolve the absolute path of a package.
@@ -32,14 +38,8 @@ const config: StorybookConfig = {
 		getAbsolutePath('@storybook/addon-interactions'),
 		getAbsolutePath('@storybook/addon-a11y')
 	],
-	framework: {
-		name: '@storybook/sveltekit',
-		options: {}
-	},
-	docs: {
-		autodocs: true,
-		defaultName: 'Documentation'
-	},
+	framework: { name: '@storybook/sveltekit', options: {} },
+	docs: { autodocs: true, defaultName: 'Documentation' },
 	staticDirs: ['../static']
 };
 export default config;


### PR DESCRIPTION
**What does this change?**
Inside `main.ts`, `require` is explicitly defined to fix [this error](https://github.com/storybookjs/storybook/issues/31415), which is caused by incompatibility between Storybook and Node v24 making Storybook crash.

I have tested with Node versions 24 and 22 and this works as expected.

**How is it tested?**
- Run `npm run docs` inside your terminal
- Storybook should launch as normal
- Update your node version to 24 and run again to test

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
