### PR TITLE
add some exports form maps package

### DIFF
--- a/.changeset/maps-exports.md
+++ b/.changeset/maps-exports.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': patch
+---
+
+FIXED: export functions needed to use `MapDeckPopovers` and `MapDeckTooltips` components

--- a/packages/maps/src/lib/index.js
+++ b/packages/maps/src/lib/index.js
@@ -31,10 +31,10 @@ export { default as MapMarkerPlacement } from './mapMarker/elements/mapMarkerPla
 export { default as MapMarkerStyledContainer } from './mapMarker/elements/mapMarkerStyledContainer/MapMarkerStyledContainer.svelte';
 
 export { default as MapDeckPopovers } from './mapDeckPopovers/MapDeckPopovers.svelte';
-export { onClickPopoverHandler, clickedLayer, clickedFeature } from './mapDeckPopovers/stores'
+export { onClickPopoverHandler, clickedLayer, clickedFeature } from './mapDeckPopovers/stores';
 
 export { default as MapDeckTooltips } from './mapDeckTooltips/MapDeckTooltips.svelte';
-export { onMouseOverTooltipHandler, mousedOverObject,  } from './mapDeckTooltips/stores';
+export { onMouseOverTooltipHandler, mousedOverObject } from './mapDeckTooltips/stores';
 
 export { default as MapPopover } from './mapPopover/MapPopover.svelte';
 

--- a/packages/maps/src/lib/index.js
+++ b/packages/maps/src/lib/index.js
@@ -31,7 +31,10 @@ export { default as MapMarkerPlacement } from './mapMarker/elements/mapMarkerPla
 export { default as MapMarkerStyledContainer } from './mapMarker/elements/mapMarkerStyledContainer/MapMarkerStyledContainer.svelte';
 
 export { default as MapDeckPopovers } from './mapDeckPopovers/MapDeckPopovers.svelte';
+export { onClickPopoverHandler, clickedLayer, clickedFeature } from './mapDeckPopovers/stores'
+
 export { default as MapDeckTooltips } from './mapDeckTooltips/MapDeckTooltips.svelte';
+export { onMouseOverTooltipHandler, mousedOverObject,  } from './mapDeckTooltips/stores';
 
 export { default as MapPopover } from './mapPopover/MapPopover.svelte';
 


### PR DESCRIPTION
This adds some exports needed to use the `MapDeckPopovers` and `MapDeckTooltips` components