### PR TITLE
MapLegend

### DIFF
--- a/.changeset/hip-monkeys-itch.md
+++ b/.changeset/hip-monkeys-itch.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: ColorLegend label now has a font-size of 12px

--- a/.changeset/rare-trees-write.md
+++ b/.changeset/rare-trees-write.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': major
+---
+
+ADDED: `MapLegend` component

--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -1,6 +1,12 @@
 import type { StorybookConfig } from '@storybook/sveltekit';
 
+import { createRequire } from 'node:module';
 import { dirname, join } from 'path';
+
+/**
+ * Define Node `require` to fix storybook compatibility issues with Node v24
+ */
+const require = createRequire(import.meta.url);
 
 /**
  * This function is used to resolve the absolute path of a package.

--- a/packages/maps/src/lib/index.js
+++ b/packages/maps/src/lib/index.js
@@ -12,29 +12,32 @@ export { default as MapControlRefresh } from './mapControlRefresh/MapControlRefr
 export { default as MapControlZoom } from './mapControlZoom/MapControlZoom.svelte';
 
 // Location Search
-export * from './mapControlLocationSearch/MapGeocoderAdapterMapBox';
 export { default as MapControlGeocoder } from './mapControlLocationSearch/MapControlGeocoder.svelte';
 export { default as MapControlGeolocator } from './mapControlLocationSearch/MapControlGeolocator.svelte';
 export { default as MapControlLocationSearch } from './mapControlLocationSearch/MapControlLocationSearch.svelte';
+export * from './mapControlLocationSearch/MapGeocoderAdapterMapBox';
 
 // Borough Selector
 export { default as MapControlBorough } from './mapControlBorough/MapControlBorough.svelte';
+
+// Legend
+export { default as MapLegend } from './mapLegend/MapLegend.svelte';
 
 // Events
 export { default as MapCursorEvent } from './mapCursorEvent/MapCursorEvent.svelte';
 
 // Popups
-export { default as MapMarker } from './mapMarker/MapMarker.svelte';
 export { default as MapMarkerContainer } from './mapMarker/elements/mapMarkerContainer/MapMarkerContainer.svelte';
 export { default as MapMarkerFlyToFeature } from './mapMarker/elements/mapMarkerFlyToFeature/MapMarkerFlyToFeature.svelte';
 export { default as MapMarkerPlacement } from './mapMarker/elements/mapMarkerPlacement/MapMarkerPlacement.svelte';
 export { default as MapMarkerStyledContainer } from './mapMarker/elements/mapMarkerStyledContainer/MapMarkerStyledContainer.svelte';
+export { default as MapMarker } from './mapMarker/MapMarker.svelte';
 
 export { default as MapPopover } from './mapPopover/MapPopover.svelte';
 
 // Layers
-export { default as MapLayerSource } from './mapLayerSource/MapLayerSource.svelte';
 export { default as GeoJSONMapLayerSource } from './mapLayerSource/adaptations/geojsonMapLayerSource/GeoJSONMapLayerSource.svelte';
+export { default as MapLayerSource } from './mapLayerSource/MapLayerSource.svelte';
 export { default as MapLayerView } from './mapLayerView/MapLayerView.svelte';
 
 // Context Layers
@@ -47,7 +50,7 @@ export { default as MapDeckOverlay } from './mapDeckOverlay/MapDeckOverlay.svelt
 export * from './themes/animations';
 export * from './themes/bounds';
 
-export * as theme_os_dark_grey_muted_buildings from './themes/os_dark_grey_muted_buildings.json';
 export * as theme_os_dark from './themes/os_dark.json';
+export * as theme_os_dark_grey_muted_buildings from './themes/os_dark_grey_muted_buildings.json';
 export * as theme_os_greyscale from './themes/os_greyscale.json';
 export * as theme_os_light_vts from './themes/os_light_vts.json';

--- a/packages/maps/src/lib/mapLegend/MapLegend.stories.svelte
+++ b/packages/maps/src/lib/mapLegend/MapLegend.stories.svelte
@@ -1,0 +1,67 @@
+<script context="module">
+	import MapLegend from './MapLegend.svelte';
+
+	export const meta = {
+		title: 'Maps/Components/MapLegend',
+		component: MapLegend
+	};
+</script>
+
+<script lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+
+	import { scaleSequential } from 'd3-scale';
+	import { interpolateViridis } from 'd3-scale-chromatic';
+	import ColorLegend from '../../../../ui/src/lib/colorLegends/ColorLegend.svelte';
+	import { currentThemeMode } from '../../../../ui/src/lib/theme/themeStore';
+
+	import Map from '../map/Map.svelte';
+	import type { MapLibreStore } from '../map/types';
+	import { appendOSKeyToUrl } from '../map/util';
+	import MapControlGroup from '../mapControlGroup/MapControlGroup.svelte';
+
+	import { writable } from 'svelte/store';
+
+	const transformRequest = appendOSKeyToUrl('vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP');
+
+	let mapStore: MapLibreStore = writable();
+
+	let width: number;
+
+	const layers = [
+		{
+			id: 'temperature',
+			title: 'Temperature (°F)',
+			light: scaleSequential([0, 100], interpolateViridis),
+			dark: scaleSequential([0, 100], interpolateViridis),
+			visible: true
+		}
+	];
+</script>
+
+<Template let:args>
+	<MapLegend {...args} />
+</Template>
+
+<Story name="Legend on map" let:args>
+	<div class="w-[100dvw] h-[100dvh]">
+		<Map
+			options={{
+				transformRequest
+			}}
+			bind:mapStore
+		>
+			<MapControlGroup position="BottomRight" classes="bottom-16 left-6 sm:bottom-11">
+				<MapLegend {...args} bind:width>
+					{#key width}
+						{#each layers as layer}
+							{#if layer.visible}
+								<ColorLegend color={layer[$currentThemeMode]} title={layer.title} {width} />
+							{/if}
+						{/each}
+					{/key}
+				</MapLegend>
+			</MapControlGroup>
+		</Map>
+	</div>
+</Story>

--- a/packages/maps/src/lib/mapLegend/MapLegend.svelte
+++ b/packages/maps/src/lib/mapLegend/MapLegend.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { XMark } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import Button from '../../../../ui/src/lib/button/Button.svelte';
+
+	/**
+	 * The `<MapLegend>` component wraps around a `Legend` for display on maps.
+	 */
+
+	/**
+	 * Boolean to display or hide legend
+	 */
+	export let isOpen: boolean = false;
+
+	/**
+	 * Value for width to pass into `ColorLegend` component
+	 */
+	export let width: number;
+
+	const handleClick = () => (isOpen = !isOpen);
+</script>
+
+{#if isOpen}
+	<div
+		class="w-full sm:max-w-96 flex flex-col gap-3 py-3 px-4 bg-color-container-level-0 pointer-events-auto"
+		bind:clientWidth={width}
+	>
+		<div class="flex justify-between align-middle">
+			<p class="font-bold text-color-text-primary">Legend</p>
+			<Button
+				variant="text"
+				size="sm"
+				class="bg-color-container-level-0 text-color-text-primary cursor-pointer absolute right-1 top-1"
+				on:click={handleClick}
+				ariaLabel="Close legend"
+			>
+				<Icon src={XMark} theme="mini" class="w-5 h-5" />
+			</Button>
+		</div>
+		<!-- Pass in `ColorLegend` or other components in the default slot -->
+		<slot />
+	</div>
+{:else}
+	<Button
+		size="md"
+		emphasis="secondary"
+		class="pointer-events-auto h-8"
+		on:click={handleClick}
+		ariaLabel="Show legend"
+	>
+		Legend
+	</Button>
+{/if}

--- a/packages/ui/src/lib/colorLegends/ColorLegend.svelte
+++ b/packages/ui/src/lib/colorLegends/ColorLegend.svelte
@@ -220,7 +220,8 @@
 						.attr('y', marginTop + marginBottom - height - 6)
 						.attr('fill', 'currentColor')
 						.attr('text-anchor', 'start')
-						.attr('font-weight', 'bold')
+						.attr('font-weight', '500')
+						.attr('font-size', '12px')
 						.attr('class', 'title')
 						.text(title)
 				);


### PR DESCRIPTION
**What does this change?**
I've added a MapLegend component that wraps around legend components and displays over a map.

**Why?**
This is useful for maps that use colour ramps to encode data but it can also be used to contain controls for maps that don't have a sidebar.

**Related issues**:

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
Yes

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
