### PR TITLE
Created CheckboxSolid and CheckboxGroupSolid components

### DIFF
--- a/.changeset/shiny-ties-wonder.md
+++ b/.changeset/shiny-ties-wonder.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+ADDED: `CheckboxSolid` and `CheckboxGroupSolid` components

--- a/packages/ui/src/lib/checkboxSolid/CheckboxGroupSolid.stories.svelte
+++ b/packages/ui/src/lib/checkboxSolid/CheckboxGroupSolid.stories.svelte
@@ -1,0 +1,170 @@
+<script context="module">
+	import Button from '../button/Button.svelte';
+	import CheckboxGroupSolid from './CheckboxGroupSolid.svelte';
+	import CheckboxSolid from './CheckboxSolid.svelte';
+
+	export const meta = {
+		title: 'Ui/Components/Checkboxes/CheckboxGroupSolid',
+		component: CheckboxGroupSolid,
+		subcomponents: { CheckboxSolid }
+	};
+</script>
+
+<script lang="ts">
+	import { Story, Template } from '@storybook/addon-svelte-csf';
+
+	let selectedOptions: string[] = ['bus', 'underground'];
+
+	let optionsForGroup = [
+		{ id: 'bus', name: 'bus', label: 'Bus stops', color: '#00AEEF' },
+		{
+			id: 'train',
+			name: 'train',
+			label: 'Train stations',
+			color: '#008D48',
+			hint: 'Excluding underground stations'
+		},
+		{ id: 'underground', name: 'underground', label: 'Underground stations', color: '#9E0059' },
+		{ id: 'taxi', name: 'taxi', label: 'Taxi ranks', color: 'firebrick', disabled: true }
+	];
+
+	let ariaLabel = 'Select transport methods';
+
+	// Variables to show correct filtering functionality
+	let selectedFilters: string[] = [];
+
+	const data = ['bus', 'train', 'underground', 'taxi'];
+
+	const filterData = (filters: string[], data: string[]) => {
+		return filters.length ? data.filter((x) => filters.includes(x)) : data;
+	};
+
+	$: filteredData = filterData(selectedFilters, data);
+</script>
+
+<Template let:args>
+	<CheckboxGroupSolid options={optionsForGroup} bind:selectedOptions {...args} {ariaLabel} />
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Template>
+
+<Story name="Default" source />
+
+<Story name="with title">
+	<CheckboxGroupSolid
+		options={optionsForGroup}
+		bind:selectedOptions
+		label="Transport method"
+		{ariaLabel}
+	/>
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<Story name="with hint">
+	<CheckboxGroupSolid
+		options={optionsForGroup}
+		bind:selectedOptions
+		label="Transport method"
+		hint="contextual hint text"
+		{ariaLabel}
+	/>
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<Story name="with description">
+	<CheckboxGroupSolid
+		options={optionsForGroup}
+		bind:selectedOptions
+		label="Transport method"
+		description="Pick your preferred method of transport - taxis are currently not available"
+		{ariaLabel}
+	/>
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<Story name="disabled buttons">
+	<CheckboxGroupSolid options={optionsForGroup} bind:selectedOptions {ariaLabel} />
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<Story name="externally updated">
+	<Button on:click={() => (selectedOptions = ['bus', 'train'])}>Select bus and train!</Button>
+
+	<div class="my-4">
+		<CheckboxGroupSolid options={optionsForGroup} bind:selectedOptions {ariaLabel} />
+	</div>
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<Story name="Disabled (global)">
+	<CheckboxGroupSolid
+		options={optionsForGroup}
+		bind:selectedOptions
+		label="Preferred mode of transport"
+		hint="Contextual Hint"
+		description="This is a description"
+		disabled
+		{ariaLabel}
+	/>
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<Story name="With error">
+	<CheckboxGroupSolid
+		options={optionsForGroup}
+		bind:selectedOptions
+		label="Preferred mode of transport"
+		hint="Contextual Hint"
+		description="Deselect all to see an error state!"
+		error={!selectedOptions.length ? 'You must select an option' : undefined}
+		{ariaLabel}
+	/>
+	<p class="mt-4 text-color-text-secondary">
+		selectedOptions: {JSON.stringify(selectedOptions)}
+	</p>
+</Story>
+
+<!--
+When `CheckboxGroupSolid` is used as a filter and nothing is selected, all options should be visible.
+
+```
+	let selectedFilters: string[] = [];
+	
+	const data = ['bus', 'train', 'underground', 'taxi'];
+
+	const filterOptions = (filters: string[], data: string[]) => {
+		return filters.length ? data.filter((x) => filters.includes(x)) : data;
+	};
+
+	$: filteredData = filterOptions(selectedFilters, data);
+```
+-->
+<Story name="As filter">
+	<CheckboxGroupSolid
+		options={optionsForGroup}
+		bind:selectedOptions={selectedFilters}
+		{ariaLabel}
+	/>
+	<p class="mt-4 text-color-text-secondary">
+		selectedFilters: {JSON.stringify(selectedFilters)}
+	</p>
+	<div class="pt-2">
+		<p class="font-semibold">Visible data:</p>
+		{#each filteredData as d}
+			<p>{d}</p>
+		{/each}
+	</div>
+</Story>

--- a/packages/ui/src/lib/checkboxSolid/CheckboxGroupSolid.svelte
+++ b/packages/ui/src/lib/checkboxSolid/CheckboxGroupSolid.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	/**
+	 * The `<CheckboxGroupSolid>` component provides a way to create a set of `<CheckboxSolid>` components defined by an array of objects.
+	 *
+	 * This should only be used when the number of options is small. Alternatively, use [CheckboxGroup](?path=/docs/ui-components-checkboxes-checkboxgroup--documentation).
+	 * @component
+	 */
+
+	import InputWrapper from '../input/InputWrapper.svelte';
+	import { randomId } from '../utils/randomId';
+	import CheckboxSolid from './CheckboxSolid.svelte';
+
+	/**
+	 * The `id` of the `<input>` element: defaults to a randomly-generated value.
+	 */
+	export let id = randomId();
+
+	/**
+	 * Text displayed above the `<input>` element.
+	 */
+	export let label = '';
+
+	/**
+	 * Accessible name of group to be read by screen reader.
+	 */
+	export let ariaLabel = '';
+
+	/**
+	 * Text that appears below the `<input>` element, in smaller font than the `label`.
+	 */
+	export let description = '';
+
+	/**
+	 * Determines which edge of the `<input>` the description is aligned with.
+	 */
+	export let descriptionAlignment: 'left' | 'right' = 'left';
+
+	/**
+	 * Help text to be displayed in tooltip
+	 */
+	export let hint = '';
+
+	/**
+	 * Text to be displayed next to icon in tooltip trigger.
+	 */
+	export let hintLabel: undefined | string = undefined;
+
+	/**
+	 * If `false`, then `required` attribute is applied to `<input>`.
+	 */
+	export let optional = false;
+
+	/**
+	 * If `true`, then user is prevented from interacting with the `<input>`.
+	 */
+	export let disabled = false;
+
+	/**
+	 * Message to be displayed below `<input>` in red text (replacing description).
+	 * If set, then the border of the `<input>` is also red.
+	 */
+	export let error = '';
+
+	/**
+	 * Only generate `descriptionId` and/or `errorId` when `description` and/or `error` exist.
+	 * `descriptionId` is static but `errorId` is reactive as error state could change.
+	 */
+	const descriptionId = description ? `${id}-description` : undefined;
+	$: errorId = error ? `${id}-error` : undefined;
+
+	/**
+	 * Each element of this array defines a checkbox, and is an object with the properties:
+	 * * `id` (string)
+	 * * `name` (string, optional) - used to set the `name` attribute of the `<input>` element
+	 * * `label` (string) - the text displayed next to the checkbox
+	 * * `disabled` (boolean, optional) - if `true`, users cannot change whether the checkbox is checked
+	 * * `color` (string, optional) - CSS color of the checkbox
+	 * * `hint` (string, optional) - help text to be displayed in tooltip
+	 * * `hintLabel` (string, optional) - text to be displayed next to icon in tooltip trigger
+	 */
+	export let options: {
+		id: string;
+		name?: string;
+		label: string;
+		disabled?: boolean;
+		color?: string;
+		hint?: string;
+		hintLabel?: string;
+	}[] = [];
+
+	/**
+	 * An array containing the `id` of each entry in the `options` array for which the corresponding checkbox is selected.
+	 */
+	export let selectedOptions: string[] = [];
+	let selectionState: Record<string, boolean> = {};
+
+	$: selectedOptions = options.map((o) => o.id).filter((id) => selectionState[id]);
+
+	const updateSelectionStateFromSelectedOptions = (selectedOptions: string[]) => {
+		const so = options.map((o) => o.id).filter((id) => selectionState[id]);
+		if (JSON.stringify(selectedOptions) !== JSON.stringify(so)) {
+			selectionState = Object.fromEntries(
+				options.map((o) => [o.id, selectedOptions.includes(o.id)])
+			);
+		}
+	};
+
+	updateSelectionStateFromSelectedOptions(selectedOptions);
+
+	$: updateSelectionStateFromSelectedOptions(selectedOptions);
+</script>
+
+<InputWrapper
+	{label}
+	{id}
+	{descriptionId}
+	{description}
+	{descriptionAlignment}
+	{hintLabel}
+	{hint}
+	{errorId}
+	{error}
+	{disabled}
+	{optional}
+>
+	{#if $$slots.hint}
+		<slot name="hint" />
+	{/if}
+	<ul {id} role="group" aria-label={ariaLabel} class="flex gap-[2px]">
+		{#each options as option (option.id)}
+			<li class="w-full flex">
+				<CheckboxSolid
+					id={option.id}
+					name={option.name}
+					label={option.label}
+					disabled={option.disabled || disabled}
+					bind:checked={selectionState[option.id]}
+				/>
+			</li>
+		{/each}
+	</ul>
+</InputWrapper>

--- a/packages/ui/src/lib/checkboxSolid/CheckboxSolid.svelte
+++ b/packages/ui/src/lib/checkboxSolid/CheckboxSolid.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	/**
+	 * The `CheckboxSolid` component provides a set of buttons for selecting multiple options from a small list.
+	 * @component
+	 */
+
+	import { classNames } from '../utils/classNames';
+	import { randomId } from '../utils/randomId';
+
+	/**
+	 * String appearing next to checkbox.
+	 */
+	export let label: string;
+
+	/**
+	 * Value set as the `id` attribute of the `<input>` element (defaults to randomly generated value).
+	 */
+	export let id = randomId();
+
+	/**
+	 * Value set as the `name` attribute of the `<input>` element (optional, but required if providing value with a form submission)
+	 */
+	export let name: string | undefined;
+
+	/**
+	 * If true, then the user cannot interact with this button to change whether it is *checked*.
+	 */
+	export let disabled = false;
+
+	/**
+	 * Boolean indicating whether the checkbox is currently *checked*.
+	 * Can be bound to and modified from outside the component.
+	 */
+	export let checked = false;
+</script>
+
+<div class="w-full flex">
+	<input
+		{id}
+		{name}
+		type="checkbox"
+		bind:checked
+		aria-disabled={disabled}
+		{disabled}
+		on:change
+		class="peer absolute top-0 left-0 opacity-0"
+		{...$$restProps}
+	/>
+
+	<label
+		for={id}
+		class={classNames(
+			disabled
+				? 'cursor-not-allowed !bg-color-input-background-disabled !text-color-text-disabled '
+				: 'cursor-pointer bg-color-input-background-off text-color-text-primary',
+			'form-label flex flex-col justify-center items-center text-center p-2 min-h-11 w-full ring-1 ring-color-container-level-1 hover:bg-color-input-background-hover peer-checked:text-color-static-white peer-checked:bg-color-input-background-on',
+			'peer-focus:ring-inset peer-focus:ring-offset-2 peer-focus:ring-offset-color-action-primary-focussed peer-focus:ring-2 peer-focus:outline-none peer-focus:ring-color-ui-background-primary'
+		)}
+	>
+		<!-- contents of the checkbox button (name and/or icon) -->
+		<slot>{label}</slot>
+	</label>
+</div>

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -6,6 +6,8 @@ export { default as Callout } from './callout/Callout.svelte';
 
 export { default as Checkbox } from './checkBox/Checkbox.svelte';
 export { default as CheckboxGroup } from './checkBox/CheckboxGroup.svelte';
+export { default as CheckboxGroupSolid } from './checkboxSolid/CheckboxGroupSolid.svelte';
+export { default as CheckboxSolid } from './checkboxSolid/CheckboxSolid.svelte';
 export { default as ColorLegend } from './colorLegends/ColorLegend.svelte';
 export { default as ColorLegendOrdinalChips } from './colorLegends/ColorLegendOrdinalChips.svelte';
 export { default as ColorLegendOrdinalHorizontalAlt } from './colorLegends/ColorLegendOrdinalHorizontalAlt.svelte';
@@ -61,10 +63,10 @@ export { default as LoadingIndicator } from './loadingIndicator/LoadingIndicator
 
 export { default as Spinner } from './spinners/Spinner.svelte';
 
-export { default as Tabs } from './tabs/Tabs.svelte';
 export { default as TabLabel } from './tabs/TabLabel.svelte';
 export { default as TabList } from './tabs/TabList.svelte';
 export { default as TabPanel } from './tabs/TabPanel.svelte';
+export { default as Tabs } from './tabs/Tabs.svelte';
 
 export { default as ListMenu } from './listMenu/ListMenu.svelte';
 export { default as ListMenuItem } from './listMenu/ListMenuItem.svelte';


### PR DESCRIPTION
**What does this change?**
Created `CheckboxSolid` and `CheckboxGroupSolid` components.

**Why?**
There are some use cases where solid checkbox buttons are more useful than standard `CheckboxGroup`, e.g. map sidebars as too many checkbox groups can bloat the UI.

<img width="407" height="165" alt="image" src="https://github.com/user-attachments/assets/f7b6da8d-6f34-4fd1-983b-52044e18d0f5" />

**Related issues**: N/A

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
