### PR TITLE
created sv5 NonIdealState and updated LoadingIndicator

### DIFF
--- a/.changeset/forty-cases-rest.md
+++ b/.changeset/forty-cases-rest.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: LoadingIndicator component title and arcColorClass are now correctly typed as optional props

--- a/.changeset/three-planes-serve.md
+++ b/.changeset/three-planes-serve.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+ADDED: NonIdealState component

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -23,6 +23,7 @@ export { default as InputWrapper } from './input/InputWrapper.svelte';
 export { default as Modal } from './modal/Modal.svelte';
 export { default as MultipleActionButton } from './multipleActionButton/MultipleActionButton.svelte';
 export { default as NavigationMenu } from './navigationMenu/NavigationMenu.svelte';
+export { default as NonIdealState } from './nonIdealState/NonIdealState.svelte';
 export { default as Overlay } from './overlay/Overlay.svelte';
 export { default as Trigger } from './overlay/Trigger.svelte';
 export { default as Popover } from './popover/Popover.svelte';

--- a/packages/ui/src/lib/loadingIndicator/LoadingIndicator.svelte
+++ b/packages/ui/src/lib/loadingIndicator/LoadingIndicator.svelte
@@ -10,21 +10,21 @@
 	 * @component
 	 */
 
-	import Spinner from '../spinners/Spinner.svelte';
-	import { prefersReducedMotion } from '../userPreference/userPreference';
 	import { Clock } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
+	import Spinner from '../spinners/Spinner.svelte';
+	import { prefersReducedMotion } from '../userPreference/userPreference';
 
 	interface Props {
 		/**
 		 * Describes the state change (i.e. appearance of Spinner or icon while loading) for screen reader users.
 		 */
-		title: string;
+		title?: string;
 
 		/**
 		 * Customise the styling of the `<Spinner>` arc.
 		 */
-		arcColorClass: string;
+		arcColorClass?: string;
 
 		/**
 		 * Customise the styling by passing tailwind classes.

--- a/packages/ui/src/lib/nonIdealState/NonIdealState.stories.svelte
+++ b/packages/ui/src/lib/nonIdealState/NonIdealState.stories.svelte
@@ -1,0 +1,107 @@
+<script module lang="ts">
+	import { QuestionMarkCircle } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import NonIdealState from './NonIdealState.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Ui/Components/NonIdealState',
+		component: NonIdealState,
+		tags: ['autodocs']
+	});
+</script>
+
+<Story name="Default">
+	{#snippet template(args)}
+		<NonIdealState {...args}>The server did not respond.</NonIdealState>
+	{/snippet}
+</Story>
+
+<Story name="Custom title">
+	{#snippet template(args)}
+		<div class="h-96 w-96">
+			<NonIdealState {...args}>
+				{#snippet title()}
+					Oh no!
+				{/snippet}
+				Something terrible has happened and nothing can be shown!
+			</NonIdealState>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Custom title and icon">
+	{#snippet template(args)}
+		<div class="h-96 w-96">
+			<NonIdealState {...args}>
+				{#snippet icon()}
+					<Icon
+						src={QuestionMarkCircle}
+						theme="solid"
+						class="text-color-ui-primary h-6 w-6"
+						aria-hidden="true"
+					/>
+				{/snippet}
+
+				{#snippet title()}
+					Something has gone wrong
+				{/snippet}
+
+				But who knows what?
+			</NonIdealState>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="
+Spinner"
+>
+	{#snippet template(args)}
+		<div class="h-96 w-96">
+			<NonIdealState spinner={true} {...args}>
+				{#snippet title()}
+					Something is loading
+				{/snippet}
+
+				Hopefully it will be ready soon.
+			</NonIdealState>
+		</div>
+	{/snippet}
+</Story>
+
+<!-- When `prefersReducedMotion` is true and `spinner` is true, a static clock icon will be rendered instead of `Spinner`. To test this in Chrome, open DevTools (`Command+Option+I`), open Commands drawer (`Command+Shift+P`), type `reduce` and press `Enter`.  -->
+<Story name="Reduced motion">
+	{#snippet template(args)}
+		<div class="h-96 w-96">
+			<NonIdealState spinner {...args}>
+				{#snippet title()}
+					Something is loading
+				{/snippet}
+				Hopefully it will be ready soon.
+			</NonIdealState>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Long body">
+	{#snippet template(args)}
+		<div class="h-96 w-full">
+			<NonIdealState {...args}>
+				{#snippet icon()}
+					<Icon src={QuestionMarkCircle} theme="solid" class="h-6 w-6" aria-hidden="true" />
+				{/snippet}
+
+				{#snippet title()}
+					Something has gone wrong
+				{/snippet}
+
+				Quisquam voluptatem qui velit qui pariatur ut. Rerum qui dolor nemo accusamus non quam
+				occaecati. Corrupti est ut sit eos et perspiciatis rerum ducimus. Excepturi blanditiis
+				molestias neque itaque quia ut. Fugiat rerum in quidem rerum esse assumenda nesciunt eum.
+				Sit delectus sed aut excepturi eos atque possimus. Iure vel delectus sequi enim. Est et
+				ipsam totam labore esse consectetur veniam rerum.
+			</NonIdealState>
+		</div>
+	{/snippet}
+</Story>

--- a/packages/ui/src/lib/nonIdealState/NonIdealState.stories.svelte
+++ b/packages/ui/src/lib/nonIdealState/NonIdealState.stories.svelte
@@ -4,6 +4,13 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import NonIdealState from './NonIdealState.svelte';
 
+	/**
+	 * The `<NonIdealState>` component acts as a placeholder for when other components are not ready render, or are prevented from successfully rendering by an error.
+	 * It can include an icon or spinner, and explanatory text.
+	 *
+	 * **Alternatives**: if no explanatory text is required, and a placeholder is not needed to prevent content re-flows, then consider using the [LoadingIndicator](./?path=/docs/ui-components-loadingindicator--documentation) component.
+	 */
+
 	const { Story } = defineMeta({
 		title: 'Ui/Components/NonIdealState',
 		component: NonIdealState,

--- a/packages/ui/src/lib/nonIdealState/NonIdealState.svelte
+++ b/packages/ui/src/lib/nonIdealState/NonIdealState.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	/**
+	 * The `<NonIdealState>` component acts as a placeholder for when other components are not ready render, or are prevented from successfully rendering by an error.
+	 * It can include an icon or spinner, and explanatory text.
+	 *
+	 * **Alternatives**: if no explanatory text is required, and a placeholder is not needed to prevent content re-flows, then consider using the [LoadingIndicator](./?path=/docs/ui-components-loadingindicator--documentation) component.
+	 * @component
+	 */
+
+	import { ExclamationTriangle } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import type { Snippet } from 'svelte';
+	import LoadingIndicator from '../loadingIndicator/LoadingIndicator.svelte';
+
+	export interface NonIdealStateProps {
+		/**
+		 * If `true`, then a spinner is displayed in place of the icon.
+		 */
+		spinner?: boolean;
+		icon?: Snippet;
+		title?: Snippet;
+		children?: Snippet;
+	}
+
+	let { spinner = false, icon, title, children }: NonIdealStateProps = $props();
+</script>
+
+<div
+	class="text-color-text-secondary bg-color-ui-background-neutral border-color-ui-border-secondary flex h-full w-full flex-col items-center justify-center gap-2 border px-2 py-2 text-center"
+>
+	{#if spinner}
+		<LoadingIndicator class="h-12 w-12" />
+	{:else}
+		<!-- contains the icon -->
+		{#if icon}
+			{@render icon()}
+		{:else}
+			<Icon src={ExclamationTriangle} theme="solid" class="h-6 w-6" aria-hidden="true" />
+		{/if}
+	{/if}
+
+	<span class="max-w-xl text-lg font-bold">
+		<!-- contains the title text, displayed below the icon -->
+		{#if title}
+			{@render title()}
+		{:else}
+			Nothing to display
+		{/if}
+	</span>
+
+	<div class="max-w-xl">
+		<!-- inserted into a `<div>` below the description -->
+		{@render children?.()}
+	</div>
+</div>


### PR DESCRIPTION
**What does this change?**
1. Created NonIdealState component in Svelte 5.
2. Changed `title` and `arcColorClass` props in LoadingIndicator so they are considered optional by TypeScript.

**Why?**
1. Required component
2. To make NonIdealState defaults work

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [x] If this adds a new component, is it exported via `index.js`?
