### PR TITLE
Sv5 fix radiogroup label

### DIFF
--- a/.changeset/pretty-phones-brake.md
+++ b/.changeset/pretty-phones-brake.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: RadioButtonGroups show labels if icons don't exist

--- a/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.svelte
+++ b/packages/ui/src/lib/radioButtonSolid/RadioButtonSolid.svelte
@@ -40,16 +40,16 @@
 </script>
 
 {#snippet iconComponent()}
-    {#if icon}
-	<Icon
-            src={icon}
-            theme="mini"
-            class={iconOrientationClasses[iconPlacement]}
-            aria-hidden="true"
-	/>
-    {:else if rawIcon}
-        <rawIcon class={iconOrientationClasses[iconPlacement]} aria-hidden="true" />
-    {/if}
+	{#if icon}
+		<Icon
+			src={icon}
+			theme="mini"
+			class={iconOrientationClasses[iconPlacement]}
+			aria-hidden="true"
+		/>
+	{:else if rawIcon}
+		<rawIcon class={iconOrientationClasses[iconPlacement]} aria-hidden="true" />
+	{/if}
 {/snippet}
 
 <div class="flex w-full">
@@ -66,11 +66,13 @@
 	<label for={inputID} class={labelClasses}>
 		<!-- contents of the radio button (name and/or icon) -->
 		{#if (icon || rawIcon) && iconPlacement === 'above'}
-                    {@render iconComponent()}
-                    {label}
-                {:else if (icon || rawIcon) && iconPlacement === 'below'}
-                    {label}
-                    {@render iconComponent()}
-                {/if}
+			{@render iconComponent()}
+			{label}
+		{:else if (icon || rawIcon) && iconPlacement === 'below'}
+			{label}
+			{@render iconComponent()}
+		{:else}
+			{label}
+		{/if}
 	</label>
 </div>


### PR DESCRIPTION
**What does this change?**
Fixes regression where label isn't rendered if icons don't exist.

<img width="1000" height="182" alt="image" src="https://github.com/user-attachments/assets/456e682e-ee59-4fc5-90b3-1c514d13b58d" />
