### PR TITLE
Sv5 - Added default plot fragments

### DIFF
--- a/.changeset/angry-pens-sort.md
+++ b/.changeset/angry-pens-sort.md
@@ -1,0 +1,7 @@
+---
+'@ldn-viz/charts': minor
+---
+
+ADDED: defaultRect and defaultBar plot fragments
+
+CHANGED: plot function now checks for options.facet to apply defaultSizeFacet fragment

--- a/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
+++ b/packages/charts/src/lib/observablePlotFragments/observablePlotFragments.ts
@@ -27,7 +27,9 @@ export const defaultPlotStyleFunctions: DefaultPlotStyleFunctions = {
 	defaultTip: () => defaultTip(),
 	defaultAnnotationTip: () => defaultAnnotationTip(),
 	defaultAnnotationText: () => defaultAnnotationText(),
-	defaultAnnotationRange: () => defaultAnnotationRange()
+	defaultAnnotationRange: () => defaultAnnotationRange(),
+	defaultBar: () => defaultBar(),
+	defaultRect: () => defaultRect()
 };
 
 export const getDefaultPlotStyles = () => {
@@ -182,6 +184,16 @@ const defaultAnnotationText = () => ({
 const defaultAnnotationRange = () => ({
 	fill: theme.currentTheme.color.chart.label, // this reactive var not updating reactively in chart itself (unless variable included in chart)
 	opacity: 0.1
+});
+
+const defaultBar = () => ({
+	fill: theme.currentTheme.color.data.primary,
+	stroke: theme.currentTheme.color.chart.background
+});
+
+const defaultRect = () => ({
+	fill: theme.currentTheme.color.data.primary,
+	stroke: theme.currentTheme.color.chart.background
 });
 
 /**

--- a/packages/charts/src/lib/observablePlotFragments/plot.ts
+++ b/packages/charts/src/lib/observablePlotFragments/plot.ts
@@ -4,6 +4,8 @@ import type {
 	AreaYOptions,
 	AxisXOptions,
 	AxisYOptions,
+	BarXOptions,
+	BarYOptions,
 	Data,
 	DotOptions,
 	DotXOptions,
@@ -14,6 +16,9 @@ import type {
 	LineXOptions,
 	LineYOptions,
 	PlotOptions,
+	RectOptions,
+	RectXOptions,
+	RectYOptions,
 	RuleXOptions,
 	RuleYOptions,
 	TextOptions,
@@ -35,7 +40,7 @@ export const plot = (options: PlotOptions = {}) => {
 	const { style, color, x, y, height, marginTop, marginBottom, marginLeft, marginRight, ...rest } =
 		options;
 
-	const sizeDefault = options.fx || options.fy ? defaultSizeFacet : defaultSize;
+	const sizeDefault = options.fx || options.fy || options.facet ? defaultSizeFacet : defaultSize;
 	const defaultStyleString = Object.entries(defaultStyle)
 		.map(([k, v]) => `${k}:${v}`)
 		.join(';');
@@ -167,5 +172,18 @@ export const Plot = {
 	textY: (data?: Data, options?: TextOptions) => ObservablePlot.textY(data, { ...options }),
 	tip: (data?: Data, options?: TipOptions) => {
 		return ObservablePlot.tip(data, { ...getDefault('defaultTip'), ...options });
+	},
+	barX: (data?: Data, options?: BarXOptions) =>
+		ObservablePlot.barX(data, { ...getDefault('defaultBar'), ...options }),
+	barY: (data?: Data, options?: BarYOptions) =>
+		ObservablePlot.barY(data, { ...getDefault('defaultBar'), ...options }),
+	rect: (data?: Data, options?: RectOptions) => {
+		return ObservablePlot.rect(data, { ...getDefault('defaultRect'), ...options });
+	},
+	rectX: (data?: Data, options?: RectXOptions) => {
+		return ObservablePlot.rectX(data, { ...getDefault('defaultRect'), ...options });
+	},
+	rectY: (data?: Data, options?: RectYOptions) => {
+		return ObservablePlot.rectY(data, { ...getDefault('defaultRect'), ...options });
 	}
 };


### PR DESCRIPTION
**What does this change?**
Added:
- defaultRect and defaultBar plot fragments (as per Mike's request in #882)

Changed:
- plot function now checks for `options.facet` as well as `options.fy/fx` to apply default facet styling

**Related issues**: Resolves #882 

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
