### PR TITLE
export store and onHover function from mapDeckTooltips

### DIFF
--- a/packages/maps/src/lib/index.ts
+++ b/packages/maps/src/lib/index.ts
@@ -32,6 +32,7 @@ export { default as MapMarker } from './mapMarker/MapMarker.svelte';
 
 export { default as MapDeckPopovers } from './mapDeckPopovers/MapDeckPopovers.svelte';
 export { default as MapDeckTooltips } from './mapDeckTooltips/MapDeckTooltips.svelte';
+export * from './mapDeckTooltips/stores';
 
 export { default as MapPopover } from './mapPopover/MapPopover.svelte';
 


### PR DESCRIPTION
Exporting store and functions from MapDeckTooltips store file:
- mousedOverObject store
- onMouseOverTooltipHandler

for use in projects
