### PR TITLE
SV5: MapLibre - fix map flickering on resize

### DIFF
--- a/.changeset/icy-lies-relax.md
+++ b/.changeset/icy-lies-relax.md
@@ -2,4 +2,4 @@
 '@ldn-viz/maps': minor
 ---
 
-FIXED: replace side effect with onresize event listener to stop map flickering on window resize
+FIXED: update MapLibre.svelte, replacing side effect with onresize event listener to stop map flickering on window resize

--- a/.changeset/icy-lies-relax.md
+++ b/.changeset/icy-lies-relax.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': minor
+---
+
+FIXED: replace side effect with onresize event listener to stop map flickering on window resize

--- a/.changeset/icy-lies-relax.md
+++ b/.changeset/icy-lies-relax.md
@@ -2,4 +2,4 @@
 '@ldn-viz/maps': minor
 ---
 
-FIXED: update MapLibre.svelte, replacing side effect with onresize event listener to stop map flickering on window resize
+FIXED: update MapLibre.svelte, removed side effect resizing to fix map flicker

--- a/packages/maps/src/lib/map/MapLibre.svelte
+++ b/packages/maps/src/lib/map/MapLibre.svelte
@@ -8,9 +8,9 @@
 	 * @component
 	 */
 
-	import { onMount, onDestroy } from 'svelte';
 	import maplibre_gl from 'maplibre-gl';
 	import 'maplibre-gl/dist/maplibre-gl.css';
+	import { onDestroy, onMount } from 'svelte';
 
 	import {
 		GREATER_LONDON_BOUNDS,
@@ -18,7 +18,7 @@
 		theme_os_light_vts
 	} from '@ldn-viz/maps';
 
-	import type { MapLibre, MapLibreStyle, WhenMapLoads, MapLibreBounds } from './types';
+	import type { MapLibre, MapLibreBounds, MapLibreStyle, WhenMapLoads } from './types';
 
 	type MapLibreOptions = Omit<maplibre_gl.MapOptions, 'container'>;
 
@@ -109,27 +109,17 @@
 		};
 	});
 
-	// client width and height because on:resize won't always trigger refresh.
-	let clientWidth = $state(0);
-	let clientHeight = $state(0);
-
 	$effect(() => {
-		if (clientWidth && clientHeight) {
-			maplibre?.resize();
-		}
-	});
-
-	$effect(() => {
-		if (maplibre){
+		if (maplibre) {
 			maplibre.setStyle(style);
 		}
-	})
+	});
 </script>
+
+<svelte:window onresize={() => maplibre?.resize()} />
 
 <section
 	bind:this={container}
-	bind:clientWidth
-	bind:clientHeight
 	class:w-full={true}
 	class:h-full={true}
 	class:relative={true}

--- a/packages/maps/src/lib/map/MapLibre.svelte
+++ b/packages/maps/src/lib/map/MapLibre.svelte
@@ -116,8 +116,6 @@
 	});
 </script>
 
-<svelte:window onresize={() => maplibre?.resize()} />
-
 <section
 	bind:this={container}
 	class:w-full={true}


### PR DESCRIPTION
**What does this change?**
Replaces side effect with onresize event listener, to resize MapLibre instance without flickering.

**Why?**
Fix flickering

**How?**

**Related issues**: #1129 

**Does this introduce new dependencies?**
No

**How is it tested?**
[Storybook](https://dev.ldn-gis.co.uk/storybook-sv5-stopMapFlicker/?path=/story/maps-components-mapcontextlayers-boroughscontextlayer--default)
compared to [svelte5 branch](https://dev.ldn-gis.co.uk/storybook-svelte5/?path=/story/maps-components-mapcontextlayers-boroughscontextlayer--default)

**How is it documented?**
[Storybook](https://dev.ldn-gis.co.uk/storybook-sv5-stopMapFlicker/?path=/story/maps-components-mapcontextlayers-boroughscontextlayer--default)

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
