### PR TITLE
sv5: MapDeckTooltips z-index

### DIFF
--- a/.changeset/proud-suits-appear.md
+++ b/.changeset/proud-suits-appear.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': minor
+---
+
+FIXED: reduced MapDeckTooltips z-index to 40 to avoid drawing over overlays

--- a/.changeset/proud-suits-appear.md
+++ b/.changeset/proud-suits-appear.md
@@ -1,5 +1,0 @@
----
-'@ldn-viz/maps': minor
----
-
-FIXED: reduced MapDeckTooltips z-index to 40 to avoid drawing over overlays

--- a/.changeset/sv5-mapDeckTooltips.md
+++ b/.changeset/sv5-mapDeckTooltips.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/maps': minor
+---
+
+CHANGED: Removed custom z-index and applied `.maplibregl-popup` class to `MapDeckTooltips` to make z-index consistent with other popups.

--- a/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.svelte
+++ b/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.svelte
@@ -106,7 +106,7 @@
 	<div
 		use:floatingContent={dynamicOptions}
 		class:width={'100px'}
-		style:z-index={9999}
+		style:z-index={40}
 		class="pointer-events-none"
 	>
 		<MapMarkerStyledContainer>

--- a/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.svelte
+++ b/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.svelte
@@ -106,8 +106,7 @@
 	<div
 		use:floatingContent={dynamicOptions}
 		class:width={'100px'}
-		style:z-index={40}
-		class="pointer-events-none"
+		class="maplibregl-popup pointer-events-none"
 	>
 		<MapMarkerStyledContainer>
 			{#if typeof tooltipSpec === 'string'}


### PR DESCRIPTION
**What does this change?**
Replaces custom z-index on `MapDeckTooltips` with `.maplibregl-popup` class (which applies z-index: 10, aligning it with MapControlGroup components).

**Why?**
Fix tooltips appearing over Modals

**How?**

**Related issues**:

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
