### PR TITLE
reduce modal inset for mobile viewports

### DIFF
--- a/.changeset/sv5-modal-inset.md
+++ b/.changeset/sv5-modal-inset.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: reduced `Modal` inset from 2rem to 0.5rem on small screens

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import type { Snippet } from 'svelte';
-	import { Dialog, type WithoutChild } from 'bits-ui';
-	import { classNames } from '../utils/classNames.js';
-	import Button from '../button/Button.svelte';
-	import { Icon } from '@steeze-ui/svelte-icon';
 	import { XMark } from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import { Dialog, type WithoutChild } from 'bits-ui';
+	import type { Snippet } from 'svelte';
+	import Button from '../button/Button.svelte';
 	import Trigger from '../overlay/Trigger.svelte';
+	import { classNames } from '../utils/classNames.js';
 
 	type Props = Dialog.RootProps & {
 		hintLabel?: string;
@@ -107,7 +107,7 @@
 
 	<Dialog.Portal>
 		<Dialog.Overlay class="fixed inset-0 z-40 bg-black/60" />
-		<div class="pointer-events-none fixed inset-8 z-50 flex items-center justify-center">
+		<div class="pointer-events-none fixed inset-2 z-50 flex items-center justify-center sm:inset-8">
 			<Dialog.Content {...contentProps} class={modalClass}>
 				<div
 					class={`border-color-static-brand bg-color-container-level-1 text-color-text-primary relative flex items-center justify-between border-l-[5px] p-3 pr-4 ${headerTheme}`}


### PR DESCRIPTION
**What does this change?**
Matches svelte 4 PR to reduce modal inset for mobile viewports from 2 rem to 0.5 rem

**Related issues**: Closes #1137 

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
