### PR TITLE
Modal focus

### DIFF
--- a/.changeset/modal-focus.md
+++ b/.changeset/modal-focus.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: focus modal description, rather than close button

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -85,7 +85,7 @@
 		widthClasses[width]
 	);
 
-	let descriptionEl;
+	let descriptionEl: Element;
 </script>
 
 {#snippet modalTrigger()}

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -84,6 +84,8 @@
 		'inline-block w-full max-h-full flex flex-col text-left align-middle transition-all transform bg-color-container-level-0 shadow-xl pointer-events-auto',
 		widthClasses[width]
 	);
+
+	let descriptionEl;
 </script>
 
 {#snippet modalTrigger()}
@@ -108,7 +110,14 @@
 	<Dialog.Portal>
 		<Dialog.Overlay class="fixed inset-0 z-40 bg-black/60" />
 		<div class="pointer-events-none fixed inset-2 z-50 flex items-center justify-center sm:inset-8">
-			<Dialog.Content {...contentProps} class={modalClass}>
+			<Dialog.Content
+				{...contentProps}
+				class={modalClass}
+				onOpenAutoFocus={(e) => {
+					e.preventDefault();
+					descriptionEl?.focus();
+				}}
+			>
 				<div
 					class={`border-color-static-brand bg-color-container-level-1 text-color-text-primary relative flex items-center justify-between border-l-[5px] p-3 pr-4 ${headerTheme}`}
 				>
@@ -128,7 +137,7 @@
 				<div class="overflow-y-auto">
 					<div class="px-4 py-6">
 						<Dialog.Description>
-							{@render description?.()}
+							<span bind:this={descriptionEl}>{@render description?.()}</span>
 						</Dialog.Description>
 						{@render children?.()}
 					</div>


### PR DESCRIPTION
Focus on the description in a modal (rather than defaulting to the close button as the first element) - fix #1190