### PR TITLE
stop the geocoder re-opening when a suggestion location is clicked on

### DIFF
--- a/.changeset/geocoder-reopening.md
+++ b/.changeset/geocoder-reopening.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: the `Geocoder` no longer re-opens itself when a `GeocoderSelection` in the `GeocoderSuggestionList` is clicked on

--- a/packages/ui/src/lib/geolocation/Geocoder.svelte
+++ b/packages/ui/src/lib/geolocation/Geocoder.svelte
@@ -299,16 +299,17 @@
 		onSearchClear();
 	};
 
-	// TODO: check this state change inside effect is ok
-	$effect(() => {
-		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-		query;
+	const updateQuery = (ev: KeyboardEvent) => {
+		query = ev.target?.value;
+
 		if (!silentQueryTextUpdate) {
 			scheduleUpdate();
 		} else {
 			silentQueryTextUpdate = false;
 		}
-	});
+
+		reshowSuggestionList(ev)
+	}
 </script>
 
 <svelte:window onmousedown={hideSuggestionList} onkeyup={hideSuggestionList} />
@@ -327,10 +328,10 @@
 		{placeholder}
 		class="form-input bg-color-input-background border-color-input-border placeholder-color-input-placeholder text-color-valuetext h-full w-64 min-w-0 max-w-[100%] shrink grow border pl-10 {inputClasses}"
 		class:pr-8={showClearButton}
-		bind:value={query}
+		value={query}
 		onfocus={reshowSuggestionList}
 		onclick={reshowSuggestionList}
-		onkeyup={reshowSuggestionList}
+		onkeyup={updateQuery}
 	/>
 
 	{#if showClearButton || query?.length > 0}


### PR DESCRIPTION
This addresses one of the 2 bugs listed in https://github.com/Greater-London-Authority/ldn-viz-tools/issues/1145