### PR TITLE
make selectedId prop of RadioButtonGroup optional, so that it can be undefined if nothing selected (fix #1210)

### DIFF
--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.svelte
@@ -16,7 +16,7 @@
 		/**
 		 * the `id` of the entry in the `options` array that is currently selected (state).
 		 */
-		selectedId: string;
+		selectedId?: string;
 
 		/**
 		 * Each element of this array defines a radio button, and is an object with the properties:


### PR DESCRIPTION
This fixes #1210 