### PR TITLE
add context deprication to warning suppression list

### DIFF
--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -13,12 +13,10 @@ const config = {
 		prerender: { entries: ['*', ...contentIndex.map((d) => d.slugFull)] }
 	},
 	onwarn: (warning, handler) => {
-		const { code } = warning;
-		if (code === 'css_unused_selector') return;
+		if (warning.code === 'css_unused_selector') return;
 		if (warning.code === 'a11y_no_noninteractive_tabindex') return;
-		if (warning.code === 'vite-plugin-svelte-preprocess-many-dependencies') {
-			return; // suppress it
-		}
+		if (warning.code === 'vite-plugin-svelte-preprocess-many-dependencies') return;
+		if (warning.code === 'script_context_deprecated') return;
 		handler(warning);
 	},
 	extensions: ['.svelte', '.svx', '.md']


### PR DESCRIPTION
**What does this change?**
the warning about context=module generated on build is due to the mdsvex package. There is an open issue about it, but it is not going to be addressed before a new version is released and the updates may take a long time (if they do come) in the mean time I have suppressed this warning in the svelte config of the web app.