### PR TITLE
Added note about Cookie Settings to story

### DIFF
--- a/packages/ui/src/lib/footer/Footer.stories.svelte
+++ b/packages/ui/src/lib/footer/Footer.stories.svelte
@@ -1,10 +1,12 @@
 <script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
-	import Footer from './Footer.svelte';
 	import LogoMayor from '../logos/LogoMayor.svelte';
+	import Footer from './Footer.svelte';
 
 	/**
 	 * The `<Footer>` component appears at the bottom of a page.
+	 *
+	 * Note, if `<AnalyticsAndCookieConsent />` is not in your app or configured incorrectly, 'Cookie Settings' will not appear in the footer even when `showCookieMenu` is true.
 	 */
 
 	let { Story } = defineMeta({


### PR DESCRIPTION
**What does this change?**
I updated the `Footer.stories.svelte` to reflect a known issue where Cookie Settings do not appear in the Footer during development:
- If `<AnalyticsAndCookieConsent>` is not configured correctly, it will not appear even if `showCookieMenu` prop is passed into `<Footer>`