### PR TITLE
add script to copy @component docstrings into stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"lint": "turbo run lint",
 		"publish-packages": "turbo run build && changeset version && changeset publish",
 		"publish-packages-svelte5": "turbo run build && changeset version && changeset publish",
+		"sync-docstrings": "turbo run sync-docstrings",
 		"test": "turbo run test",
 		"test-storybook": "npm run test-storybook -w apps/docs",
 		"test:coverage": "turbo run test:coverage",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -32,6 +32,7 @@
 		"prepack": "svelte-kit sync && svelte-package && publint",
 		"prepare": "svelte-kit sync || echo ''",
 		"preview": "vite preview",
+		"sync-docstrings": "node ../../scripts/sync-docstrings.mjs packages/charts/",
 		"test": "npm run test:unit && npm run test:e2e",
 		"test:coverage": "vitest run --coverage",
 		"test:e2e": "playwright test",

--- a/packages/charts/src/lib/chartContainer/ChartContainer.stories.svelte
+++ b/packages/charts/src/lib/chartContainer/ChartContainer.stories.svelte
@@ -1,10 +1,18 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import ChartContainer from './ChartContainer.svelte';
 
 	import { Select } from '@ldn-viz/ui';
 
+	/**
+	 * The `ChartContainer` is a wrapper around a plot that adds additional information such as a title, subtitle, and description.
+	 * It also provides controls such as data/image download buttons.
+	 *
+	 * **Note**: You must provide a `chartDescription` for accessibility.
+	 *
+	 * **Alternatives**: normally the [ObservablePlot](./?path=/docs/charts-components-observableplot--documentation) or other plot component would be used rather than using `ChartContainer` directly.
+	 */
 	const { Story } = defineMeta({
 		title: 'Charts/Components/ChartContainer',
 		component: ChartContainer,

--- a/packages/charts/src/lib/observablePlot/ObservablePlot.stories.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlot.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import ObservablePlot from './ObservablePlot.svelte';

--- a/packages/charts/src/lib/observablePlot/ObservablePlotInner.stories.svelte
+++ b/packages/charts/src/lib/observablePlot/ObservablePlotInner.stories.svelte
@@ -1,7 +1,8 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import ObservablePlotInner from './ObservablePlotInner.svelte';
+
 	/**
 	 * The `ObservablePlotInner` component allows the rendering of visualisations using the [Observable Plot](https://observablehq.com/plot/) library.
 	 * It does *not* apply the  [ChartContainer](./?path=/docs/charts-components-chartcontainer--documentation) as a wrapper:

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -32,6 +32,7 @@
 		"prepack": "svelte-kit sync && svelte-package && publint",
 		"prepare": "svelte-kit sync || echo ''",
 		"preview": "vite preview",
+		"sync-docstrings": "node ../../scripts/sync-docstrings.mjs packages/maps/",
 		"test": "npm run test:unit && npm run test:e2e",
 		"test:coverage": "vitest run --coverage",
 		"test:e2e": "playwright test",

--- a/packages/maps/src/lib/map/Map.stories.svelte
+++ b/packages/maps/src/lib/map/Map.stories.svelte
@@ -6,6 +6,21 @@
 
 	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
 
+	/**
+	 * The `<Map>` component wraps a MapLibre map and manages the style (based
+	 * on the current theme mode) and cursor event handling for quicker and
+	 * easier map creation and management.
+	 *
+	 * It also:
+	 * - provides stores for `Map` and `MapCursor` instances;
+	 * - sets context for `Map` and `MapCursor` instances;
+	 *
+	 * The map's container has a relative CSS position so slotted content can
+	 * position itself accordingly. Map controls and other overlay components
+	 * should be wrapped and positioned using a `MapControlGroup` instance.
+	 *
+	 * (see [MapLibre Map](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/)).
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/Map',
 		component: Map,

--- a/packages/maps/src/lib/mapContextLayers/boroughsContextLayer/BoroughsContextLayer.stories.svelte
+++ b/packages/maps/src/lib/mapContextLayers/boroughsContextLayer/BoroughsContextLayer.stories.svelte
@@ -31,6 +31,10 @@
 		}
 	};
 
+	/**
+	 * The `<BoroughsContextLayer>` component is slotted into a `<Map>` to show
+	 * boroughs and their boundaries.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapContextLayers/BoroughsContextLayer',
 		component: BoroughsContextLayer,

--- a/packages/maps/src/lib/mapControlBorough/MapControlBorough.stories.svelte
+++ b/packages/maps/src/lib/mapControlBorough/MapControlBorough.stories.svelte
@@ -1,8 +1,11 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import MapControlBorough from './MapControlBorough.svelte';
 
+	/**
+	 * The `MapControlBorough` component lets the user select a borough, and zooms the map to the selected borough.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapControls/MapControlBorough',
 		component: MapControlBorough,

--- a/packages/maps/src/lib/mapControlGroup/MapControlGroup.stories.svelte
+++ b/packages/maps/src/lib/mapControlGroup/MapControlGroup.stories.svelte
@@ -4,6 +4,10 @@
 
 	const OS_KEY = 'vmRzM4mAA1Ag0hkjGh1fhA2hNLEM6PYP';
 
+	/**
+	 * The `<MapControlGroup>` component wraps map controls and other overlays
+	 * to provide positioning relative to a parent `<Map>` component instance.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapControls/MapControlGroup',
 		component: MapControlGroup,

--- a/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
+++ b/packages/maps/src/lib/mapControlLocationSearch/MapControlLocationSearch.stories.svelte
@@ -1,8 +1,18 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import MapControlLocationSearch from './MapControlLocationSearch.svelte';
 
+	/**
+	 * The `<MapControlLocationSearch>` component wraps both the
+	 * `<MapControlGeocoder>` and `<MapControlGeolocator>` components to create
+	 * single and easy to use map search control. It is typically placed in the
+	 * top left hand corner.
+	 *
+	 * The selected location is indicated by a MapLibre layer of type `symbol`,
+	 * with id `gla/context/location-search/map-point-symbol`, created by `initMapLayer`.
+	 *
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapControls/MapControlLocationSearch',
 		component: MapControlLocationSearch,

--- a/packages/maps/src/lib/mapCursorEvent/MapCursorEvent.stories.svelte
+++ b/packages/maps/src/lib/mapCursorEvent/MapCursorEvent.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import MapCursorEvent from './MapCursorEvent.svelte';
 
@@ -26,6 +26,25 @@
 		}
 	};
 
+	/**
+	 * The `<MapCursorEvent>` component exposes the map cursor capability, for a
+	 * specific map layer, as a Svelte component.
+	 *
+	 * However, this component maybe slotted anywhere within `<Map>` providing
+	 * a layer ID is passed and guards are put in place so the layer is added to
+	 * MapLibre before this component is initialised.
+	 *
+	 * Cursor movement events in order they are called when a mouse movement occurs:
+	 * 1. `leaveFeature`
+	 * 2. `leaveTopFeature`
+	 * 3. `enterFeature`
+	 * 4. `enterTopFeature`
+	 *
+	 * Click or touch events in order they are called per click:
+	 * 1. `clickMap`
+	 * 2. `clickFeature`
+	 *
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapCursorEvent',
 		component: MapCursorEvent,

--- a/packages/maps/src/lib/mapDeckOverlay/MapDeckOverlay.stories.svelte
+++ b/packages/maps/src/lib/mapDeckOverlay/MapDeckOverlay.stories.svelte
@@ -2,6 +2,10 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import MapDeckOverlay from './MapDeckOverlay.svelte';
 
+	/**
+	 * The `MapDeckOverlay` component renders Deck.gl layers in an overlay on top of a MapLibre map.
+	 * It must be used inside a `Map` component, so that it can access the MapLibre map object from the `mapStore` context.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/DeckGL/MapDeckOverlay',
 		component: MapDeckOverlay,

--- a/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.stories.svelte
+++ b/packages/maps/src/lib/mapDeckPopovers/MapDeckPopovers.stories.svelte
@@ -1,6 +1,12 @@
 <script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import MapDeckPopovers from './MapDeckPopovers.svelte';
+
+	/**
+	 * The `MapDeckPopovers` component renders a popover for features rendered by Deck.gl, when they are clicked on.
+	 * It accepts a configuration object, the keys are the layer ids for which Popovers should be rendered, and the  values specify how they should be rendered.
+	 * For each layer, the output can be specified as a string constant, a function that is passed a feature and returns a string, or a custom Svelte component.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/DeckGL/MapDeckPopovers',
 		component: MapDeckPopovers,

--- a/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.stories.svelte
+++ b/packages/maps/src/lib/mapDeckTooltips/MapDeckTooltips.stories.svelte
@@ -2,6 +2,11 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import MapDeckTooltips from './MapDeckTooltips.svelte';
 
+	/**
+	 * The `MapDeckTooltips` component renders a tooltip for features rendered by Deck.gl, when they are hovered over.
+	 * It accepts a configuration object, the keys are the layer ids for which Popovers should be rendered, and the  values specify how they should be rendered.
+	 * For each layer, the output can be specified as a string constant, a function that is passed a feature and returns a string, or a custom Svelte component.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/DeckGL/MapDeckTooltips',
 		component: MapDeckTooltips,

--- a/packages/maps/src/lib/mapLayerSource/MapLayerSource.stories.svelte
+++ b/packages/maps/src/lib/mapLayerSource/MapLayerSource.stories.svelte
@@ -16,6 +16,18 @@
 
 	 */
 
+	/**
+	 * The `<MapLayerSource>` component is slotted within a `<Map>` component to
+	 * specify a data source. The slot primarily accepts one or many
+	 * `<MapLayerView>` instances to present the data.
+	 *
+	 * By design, `<MapLayerSource>` is very simple with minimal features but
+	 * extendable by wrapping the component and using patterns such as:
+	 * [Adapter](https://en.wikipedia.org/wiki/Adapter_pattern),
+	 * [Decorator](https://en.wikipedia.org/wiki/Decorator_pattern),
+	 * and [Facade](https://en.wikipedia.org/wiki/Facade_pattern). E.g.
+	 * `<GeoJSONMapLayerSource>`.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapLayerSource',
 		component: MapLayerSource,

--- a/packages/maps/src/lib/mapLayerSource/adaptations/geojsonMapLayerSource/GeoJSONMapLayerSource.stories.svelte
+++ b/packages/maps/src/lib/mapLayerSource/adaptations/geojsonMapLayerSource/GeoJSONMapLayerSource.stories.svelte
@@ -1,6 +1,13 @@
 <script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import GeoJSONMapLayerSource from './GeoJSONMapLayerSource.svelte';
+	/**
+	 * The `<MapLayerSourceGeoJSON>` component is a specialised
+	 * `<MapLayerSource>` for local or remote GeoJSON data.
+	 *
+	 * If `url` is set, result of a data fetch will be passed to the
+	 * `onLoad` function, otherwise the value of `initialData` will be passed.
+	 */
 
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapLayerSource/adaptations/GeoJSONMapLayerSource',

--- a/packages/maps/src/lib/mapLayerView/MapLayerView.stories.svelte
+++ b/packages/maps/src/lib/mapLayerView/MapLayerView.stories.svelte
@@ -22,6 +22,17 @@
 		}
 	};
 
+	/**
+	 * The `<MapLayerView>` component is slotted within a `<MapLayerSource>`
+	 * component, or derived version, to specify how to present data on the
+	 * map.
+	 *
+	 * By design, `<MapLayerView>` is very simple with minimal features but
+	 * extendable by wrapping the component and using patterns such as:
+	 * [Adapter](https://en.wikipedia.org/wiki/Adapter_pattern),
+	 * [Decorator](https://en.wikipedia.org/wiki/Decorator_pattern),
+	 * and [Facade](https://en.wikipedia.org/wiki/Facade_pattern).
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapLayerView',
 		component: MapLayerView,

--- a/packages/maps/src/lib/mapMarker/MapMarker.stories.svelte
+++ b/packages/maps/src/lib/mapMarker/MapMarker.stories.svelte
@@ -12,6 +12,24 @@
 		}
 	};
 
+	/**
+	 * The `<MapMarker>` component allows tooltips and popups to easily be added
+	 * for feature hover and clicks respectively. This component may be slotted
+	 * anywhere provided the `<Map>` component context is available.
+	 *
+	 * To ensure the correct behaviour for overlapping tooltips that aren't
+	 * sourced via ESRI servers, set `generateId` to true in your
+	 * [MapLibre Source Specifications](https://maplibre.org/maplibre-style-spec/sources/).
+	 * This will set the value of the `feature.id` property to be equal to the
+	 * index of the corresponding feature, rather than leaving it undefined.
+	 *
+	 * The `tooltip` and `popup` components are client side rendered. This
+	 * component's context is passed to them along with three additional
+	 * values:
+	 * - `mapMarkerMaplibrePopup` is the instance of `maplibre_gl.Popup` that contains the rendered tooltip component.
+	 * - `mapMarkerLayerId` is the ID of the map layer the feature belongs to.
+	 * - `mapMarkerFeature` is the target GeoJSON feature. Note that MapLibre adds additional fields, e.g. `layer`.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapMarker',
 		component: MapMarker,

--- a/packages/maps/src/lib/mapMarker/elements/mapMarkerContainer/MapMarkerContainer.stories.svelte
+++ b/packages/maps/src/lib/mapMarker/elements/mapMarkerContainer/MapMarkerContainer.stories.svelte
@@ -2,6 +2,11 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import MapMarkerContainer from './MapMarkerContainer.svelte';
 
+	/**
+	 * The `<MapMarkerContainer>` component is a wrapping container for use
+	 * within markers components. It encapsulates the standardised map
+	 * styling and behaviour.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapMarker/elements/MapMarkerContainer',
 		component: MapMarkerContainer,

--- a/packages/maps/src/lib/mapMarker/elements/mapMarkerFlyToFeature/MapMarkerFlyToFeature.stories.svelte
+++ b/packages/maps/src/lib/mapMarker/elements/mapMarkerFlyToFeature/MapMarkerFlyToFeature.stories.svelte
@@ -2,6 +2,11 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import MapMarkerFlyToFeature from './MapMarkerFlyToFeature.svelte';
 
+	/**
+	 * The `<MapMarkerFlyToFeature>` component is a wrapping container for use
+	 * within tooltip and marker components. It moves the map so it centers
+	 * the popup on the screen. This is activated soon after mounting.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapMarker/elements/MapMarkerFlyToFeature',
 		component: MapMarkerFlyToFeature,

--- a/packages/maps/src/lib/mapMarker/elements/mapMarkerPlacement/MapMarkerPlacement.stories.svelte
+++ b/packages/maps/src/lib/mapMarker/elements/mapMarkerPlacement/MapMarkerPlacement.stories.svelte
@@ -2,6 +2,11 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import MapMarkerPlacement from './MapMarkerPlacement.svelte';
 
+	/**
+	 * The `<MapMarkerPlacement>` component is a wrapping container for use
+	 * within marker components. It determines how a map marker is placed
+	 * relative to its associated feature.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapMarker/elements/MapMarkerPlacement',
 		component: MapMarkerPlacement,

--- a/packages/maps/src/lib/mapMarker/elements/mapMarkerStyledContainer/MapMarkerStyledContainer.stories.svelte
+++ b/packages/maps/src/lib/mapMarker/elements/mapMarkerStyledContainer/MapMarkerStyledContainer.stories.svelte
@@ -2,6 +2,11 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import MapMarkerStyledContainer from './MapMarkerStyledContainer.svelte';
 
+	/**
+	 * The `<MapMarkerStyledContainer>` component is a wrapping container for use
+	 * within marker components. It provides standardised styling that is
+	 * suitable for the vast majority of map tooltips and popups.
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapMarker/elements/MapMarkerStyledContainer',
 		component: MapMarkerStyledContainer,

--- a/packages/maps/src/lib/mapPopover/MapPopover.stories.svelte
+++ b/packages/maps/src/lib/mapPopover/MapPopover.stories.svelte
@@ -12,6 +12,20 @@
 		}
 	};
 
+	/**
+	 * The `MapPopover` component allows the creation of a popover using MapLibre, without creating a MapLibre marker.
+	 * This can be useful if the popover corresponds to a point rendered using Deck.gl (rather than MapLibre),
+	 * or to a location on a basemap that has no associated marker at all.
+	 *
+	 * Note that each instance of the component renders only a single popover.
+	 * If multiple popovers should be present simultaneously, you could create an array of features that should be labelled,
+	 * and create the popovers using an `{#each}` block.
+	 *
+	 * You can use the components defined in`mapMarker/elements` within the popover component.
+	 *
+	 * **Alternatives**: if the popover is meant to be attached to a Maplibre marker, use the [MapMarker](./?path=/docs/maps-mapmarker--documentation) instead.
+	 *
+	 */
 	const { Story } = defineMeta({
 		title: 'Maps/Components/MapPopover',
 		component: MapPopover,

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -32,6 +32,7 @@
 		"prepack": "svelte-kit sync && svelte-package && publint",
 		"prepare": "svelte-kit sync || echo ''",
 		"preview": "vite preview",
+		"sync-docstrings": "node ../../scripts/sync-docstrings.mjs packages/tables/",
 		"test": "npm run test:unit && npm run test:e2e",
 		"test:coverage": "vitest run --coverage",
 		"test:e2e": "playwright test",

--- a/packages/tables/src/lib/core/aggregateRenderers/BarChart.stories.svelte
+++ b/packages/tables/src/lib/core/aggregateRenderers/BarChart.stories.svelte
@@ -4,6 +4,9 @@
 	import { scaleBand, scaleOrdinal } from 'd3-scale';
 	import BarChart from './BarChart.svelte';
 
+	/**
+	 * The `BarChart` component renders a set of values as a bar chart.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/AggregateRenderers/BarChart',
 		component: BarChart,

--- a/packages/tables/src/lib/core/aggregateRenderers/BoxPlot.stories.svelte
+++ b/packages/tables/src/lib/core/aggregateRenderers/BoxPlot.stories.svelte
@@ -1,7 +1,10 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import BoxPlot from './BoxPlot.svelte';
+	/**
+	 * The `BoxPlot` component renders a set of values as a BoxPlot.
+	 */
 
 	const { Story } = defineMeta({
 		title: 'Tables/Components/AggregateRenderers/BoxPlot',

--- a/packages/tables/src/lib/core/aggregateRenderers/Dots.stories.svelte
+++ b/packages/tables/src/lib/core/aggregateRenderers/Dots.stories.svelte
@@ -1,8 +1,12 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import Dots from './Dots.svelte';
 
+	/**
+	 * The `Dots` component renders a set of values as something like a beeswarm plot or jittered Cleveland dot plot.
+	 * Different plots in the same column have a consistent x-axis based on computed extent of column.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/AggregateRenderers/Dots',
 		component: Dots,

--- a/packages/tables/src/lib/core/aggregateRenderers/Histogram.stories.svelte
+++ b/packages/tables/src/lib/core/aggregateRenderers/Histogram.stories.svelte
@@ -1,7 +1,11 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import Histogram from './Histogram.svelte';
+
+	/**
+	 * The `Histogram` component renders a set of values as a histogram.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/AggregateRenderers/Histogram',
 		component: Histogram,

--- a/packages/tables/src/lib/core/aggregateRenderers/Mean.stories.svelte
+++ b/packages/tables/src/lib/core/aggregateRenderers/Mean.stories.svelte
@@ -1,7 +1,11 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import Mean from './Mean.svelte';
+
+	/**
+	 * The `Mean` component renders the (arithmetic) mean of a set of values.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/AggregateRenderers/Mean',
 		component: Mean,

--- a/packages/tables/src/lib/core/aggregateRenderers/StackedBar.stories.svelte
+++ b/packages/tables/src/lib/core/aggregateRenderers/StackedBar.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import { scaleOrdinal } from 'd3-scale';

--- a/packages/tables/src/lib/core/aggregateRenderers/Summary.stories.svelte
+++ b/packages/tables/src/lib/core/aggregateRenderers/Summary.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import Summary from './Summary.svelte';

--- a/packages/tables/src/lib/core/aggregateRenderers/ViolinPlot.stories.svelte
+++ b/packages/tables/src/lib/core/aggregateRenderers/ViolinPlot.stories.svelte
@@ -1,7 +1,11 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import ViolinPlot from './ViolinPlot.svelte';
+
+	/**
+	 * The `ViolinPlot` component renders a set of values as a violin plot.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/AggregateRenderers/ViolinPlot',
 		component: ViolinPlot,

--- a/packages/tables/src/lib/core/renderers/BarCell.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/BarCell.stories.svelte
@@ -1,8 +1,11 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import BarCell from './BarCell.svelte';
 
+	/**
+	 * The `BarCell` component renders a table cell representing a numerical value as a bar, where the length of the bar encodes the value.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/BarCell',
 		component: BarCell,

--- a/packages/tables/src/lib/core/renderers/BarDivergingCell.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/BarDivergingCell.stories.svelte
@@ -1,8 +1,12 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import BarDivergingCell from './BarDivergingCell.svelte';
 
+	/**
+	 * The `BarDivergingCell` component renders a table cell representing a numerical value as a bar, where the length of the bar encodes the value.
+	 * There is a vertical line at x=0, and the bar color indicates whether the value is greater than or less than 0.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/BarDivergingCell',
 		component: BarDivergingCell,

--- a/packages/tables/src/lib/core/renderers/CategoricalTick.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/CategoricalTick.stories.svelte
@@ -1,9 +1,12 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import { scaleBand, scaleOrdinal } from 'd3-scale';
 	import CategoricalTick from './CategoricalTick.svelte';
 
+	/**
+	 * The `CategoricalTick` component encodes a single categorical value redundantly as both the position and color of a tick.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/CategoricalTick',
 		component: CategoricalTick,

--- a/packages/tables/src/lib/core/renderers/ColorAndLabel.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/ColorAndLabel.stories.svelte
@@ -1,8 +1,12 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import ColorAndLabel from './ColorAndLabel.svelte';
 
+	/**
+	 * The `ColorAndLabel` component renders a table cell representing a numerical value as a label, next to a small square with a background color encoding the value.
+	 * See also [ColoredCell](./?path=/docs/tables-components-renderers-coloredcell--documentation).
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/ColorAndLabel',
 		component: ColorAndLabel,

--- a/packages/tables/src/lib/core/renderers/ColoredCell.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/ColoredCell.stories.svelte
@@ -1,8 +1,12 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import ColoredCell from './ColoredCell.svelte';
 
+	/**
+	 * The `ColoredCell` component renders a table cell representing a numerical value as a label, with the background color encoding the value.
+	 * See also [ColorAndLabel](./?path=/docs/tables-components-renderers-colorandlabel--documentation).
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/ColoredCell',
 		component: ColoredCell,

--- a/packages/tables/src/lib/core/renderers/DateCell.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/DateCell.stories.svelte
@@ -1,7 +1,11 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import DateCell from './DateCell.svelte';
+
+	/**
+	 * The `DateCell` component renders a table cell representing a single date or datetime as text.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/DateCell',
 		component: DateCell,

--- a/packages/tables/src/lib/core/renderers/Dot.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/Dot.stories.svelte
@@ -1,8 +1,13 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import Dot from './Dot.svelte';
 
+	/**
+	 * The `Dot` component renders a table cell representing a numerical value as a tick;
+	 * the horizontal position of the dot encodes the value.
+	 * See also: [Tick](./?path=/docs/tables-components-renderers-tick--documentation)
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/Dot',
 		component: Dot,

--- a/packages/tables/src/lib/core/renderers/GoodOrBad.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/GoodOrBad.stories.svelte
@@ -1,8 +1,11 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import GoodOrBad from './GoodOrBad.svelte';
 
+	/**
+	 * The `GoodOrBad` component renders a table cell comparing a single value to a reference or benchmark value.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/GoodOrBad',
 		component: GoodOrBad,

--- a/packages/tables/src/lib/core/renderers/Header.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/Header.stories.svelte
@@ -1,11 +1,11 @@
-<script module>
-	/**
-	 * The `Header` component displays the heading for a column, optionally with arrows to indicate sort order.
-	 */
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import Header from './Header.svelte';
 
+	/**
+	 * The `Header` component displays the heading for a column, optionally with arrows to indicate sort order.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/Header',
 		component: Header,

--- a/packages/tables/src/lib/core/renderers/PairArrowCell.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/PairArrowCell.stories.svelte
@@ -1,8 +1,12 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import PairArrowCell from './PairArrowCell.svelte';
 
+	/**
+	 * The `PairArrowCell` component renders a table cell containing an arrow pointing from a context value to the cell's value.
+	 * The color of the arrow indicates whether it is increasing or decreasing
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/PairArrowCell',
 		component: PairArrowCell,

--- a/packages/tables/src/lib/core/renderers/ProportionalSymbol.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/ProportionalSymbol.stories.svelte
@@ -1,7 +1,10 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import ProportionalSymbol from './ProportionalSymbol.svelte';
+	/**
+	 * The `ProportionalSymbol` component renders a table cell encoding a single value as a circle, with the radius encoding the value.
+	 */
 
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/ProportionalSymbol',

--- a/packages/tables/src/lib/core/renderers/TextCell.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/TextCell.stories.svelte
@@ -1,7 +1,11 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import TextCell from './TextCell.svelte';
+
+	/**
+	 * The `TextCell` component formats a single value as text and displays it in a table cell.
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/TextCell',
 		component: TextCell,

--- a/packages/tables/src/lib/core/renderers/TextCellWithUncertainty.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/TextCellWithUncertainty.stories.svelte
@@ -1,7 +1,12 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import TextCellWithUncertainty from './TextCellWithUncertainty.svelte';
+
+	/**
+	 * The `TextCellWithUncertainty` component formats a single value as text and displays it in a table cell.
+	 * The first entry of `contextVals` is interpreted as indicating whether the value is uncertain;
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/TextCellWithUncertainty',
 		component: TextCellWithUncertainty,

--- a/packages/tables/src/lib/core/renderers/Tick.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/Tick.stories.svelte
@@ -1,8 +1,13 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import Tick from './Tick.svelte';
 
+	/**
+	 * The `Tick` component renders a table cell representing a numerical value as a tick;
+	 * the horizontal position of the tick encodes the value.
+	 * See also: [Dot](./?path=/docs/tables-components-renderers-dot--documentation)
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/Renderers/Tick',
 		component: Tick,

--- a/packages/tables/src/lib/table/Table.stories.svelte
+++ b/packages/tables/src/lib/table/Table.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import { Select } from '@ldn-viz/ui';

--- a/packages/tables/src/lib/table/TableColWidths.stories.svelte
+++ b/packages/tables/src/lib/table/TableColWidths.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import Table from './Table.svelte';

--- a/packages/tables/src/lib/table/TableComplex.stories.svelte
+++ b/packages/tables/src/lib/table/TableComplex.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import Table from './Table.svelte';

--- a/packages/tables/src/lib/table/TableHSDS.stories.svelte
+++ b/packages/tables/src/lib/table/TableHSDS.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import Table from './Table.svelte';

--- a/packages/tables/src/lib/table/TableHeader.stories.svelte
+++ b/packages/tables/src/lib/table/TableHeader.stories.svelte
@@ -1,8 +1,20 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import TableHeader from './TableHeader.svelte';
 
+	/**
+	 * The `TableHeader` component renders the header above the table body.
+	 * There are several tracks that may be included, depending on the table specification and the props provided to the `Table` component:
+	 * * A horizontal rule delimiting the top of the header(if `showHeaderTopRule` is `true` in the spec)
+	 * * Labels for column groups (if these are defined in the `colGroups` section of the spec)
+	 * * The headings for each column (determined by the value of the `label` for each entry of `column` in the spec)
+	 * * Controls for filtering and changing the visual encoding (if `showColumnControls` is `true` in the spec)
+	 * * Summaries of the values in each column (if `showColSummaries` is `true` in the spec)
+	 * * A labelled axis, if one exists for the column's cell renderer
+	 * * A horizontal rule delimiting the bottom of the header (if `colGroupGap` is set in the spec, then a gap of this size will be left between columns in different groups)
+	 * Font size is inherited from the table
+	 */
 	const { Story } = defineMeta({
 		title: 'Tables/Components/TableHeader',
 		component: TableHeader,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,6 +32,7 @@
 		"prepack": "svelte-kit sync && svelte-package && publint",
 		"prepare": "svelte-kit sync || echo ''",
 		"preview": "vite preview",
+		"sync-docstrings": "node ../../scripts/sync-docstrings.mjs packages/ui/",
 		"test": "npm run test:unit && npm run test:e2e",
 		"test:coverage": "vitest run --coverage",
 		"test:e2e": "playwright test",

--- a/packages/ui/src/lib/analytics/CookieControlSettings.stories.svelte
+++ b/packages/ui/src/lib/analytics/CookieControlSettings.stories.svelte
@@ -1,9 +1,8 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import CookieControlSettings from './CookieControlSettings.svelte';
 	/**
 	 * The `CookieControlSettings` component provides a button which can be clicked on to open the cookie settings modal.
-	 * @component
 	 * */
 
 	const { Story } = defineMeta({

--- a/packages/ui/src/lib/appShell/AppShell.stories.svelte
+++ b/packages/ui/src/lib/appShell/AppShell.stories.svelte
@@ -6,7 +6,12 @@
 	import AppShell from './AppShell.svelte';
 	import DemoSidebarOpener from './DemoSidebarOpener.svelte';
 
-	let { Story } = defineMeta({
+	/**
+	 * The `<AppShell>` is responsible for positioning and orchestrating page content.
+	 * It currently mainly coordinate the [Sidebar](./?path=/docs/ui-components-layout-and-themes-sidebar--documentation) and the other page content.
+	 *
+	 */
+	const { Story } = defineMeta({
 		title: 'Ui/Components - Layout And Themes/AppShell',
 		component: AppShell,
 		tags: ['autodocs'],

--- a/packages/ui/src/lib/auth/AuthMenu.stories.svelte
+++ b/packages/ui/src/lib/auth/AuthMenu.stories.svelte
@@ -1,8 +1,13 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import AuthMenu from './AuthMenu.svelte';
 
+	/**
+	 * The `AuthMenu` component is intended to be used in a Header.
+	 * Depending on whether the user is already logged-in, it displays either a login link,
+	 * or the current username and a log-out button.
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Auth/Auth Menu',
 		component: AuthMenu,

--- a/packages/ui/src/lib/auth/HandleRedirectFromAuth.stories.svelte
+++ b/packages/ui/src/lib/auth/HandleRedirectFromAuth.stories.svelte
@@ -1,8 +1,15 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import HandleRedirectFromAuth from './HandleRedirectFromAuth.svelte';
 
+	/**
+	 * The `HandleRedirectComponent` is a headless component, which should be included in the `layout.svelte` file.
+	 * It recognises when the user has been redirected from the authorization server
+	 * (the initial redirect from the app to the OAuth provider is triggered by `redirectToAuthorizationEndpoint()`).
+	 * It exchanges an Authorization code for an Access Token and Refresh Token, which are stored in Svelte stores.
+	 *
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Auth/HandleRedirectFromAuth',
 		component: HandleRedirectFromAuth,

--- a/packages/ui/src/lib/auth/LoginLink.stories.svelte
+++ b/packages/ui/src/lib/auth/LoginLink.stories.svelte
@@ -1,8 +1,12 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import LoginLink from './LoginLink.svelte';
 
+	/**
+	 * The `LoginLink` component renders a link to log in with the authorization server.
+	 *
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Auth/Login Link',
 		component: LoginLink,

--- a/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
+++ b/packages/ui/src/lib/checkBox/CheckboxGroup.stories.svelte
@@ -36,6 +36,11 @@
 		...option,
 		color: theme.tokenNameToValue(colors[option.id])
 	}));
+	/**
+	 * The `<CheckboxGroup>` component provides a way to create a set of `<Checkbox>` components defined by an array of objects.
+	 *
+	 * **Alternatives**: if representing a set of options that are mutually exclusive, use the [RadioButton](./?path=/docs/ui-components-radiobuttons-radiobutton--documentation)/[RadioButtonGroup](./?path=/docs/ui-components-radiobuttons-radiobuttongroup--documentation) component rather than the [Checkbox](./?path=/docs/ui-components-checkboxes-checkbox--documentation)/[CheckboxGroup](./?path=/docs/ui-components-checkboxes-checkboxgroup--documentation).
+	 */
 
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Checkboxes/CheckboxGroup',

--- a/packages/ui/src/lib/checkboxSolid/CheckboxGroupSolid.stories.svelte
+++ b/packages/ui/src/lib/checkboxSolid/CheckboxGroupSolid.stories.svelte
@@ -6,13 +6,6 @@
 	import CheckboxGroupSolidDemo from './CheckboxGroupSolidDemo.svelte';
 	import type { CheckboxSolidProps } from './types';
 
-	/**
-	 * The `<CheckboxGroupSolid>` component provides a way to create a set of `<CheckboxSolid>` components defined by an array of objects.
-	 *
-	 * **Alternatives**: if representing a set of options that are mutually exclusive, use the [CheckboxSolid](./?path=/docs/ui-components-Checkboxs-Checkboxgroupsolid--documentation).
-	 * Consider using the [Checkbox](./?path=/docs/ui-components--checkboxes-checkbox--documentation)/[CheckboxGroupSolid](./?path=/docs/ui-components-checkboxes-checkboxgroup--documentation).
-	 */
-
 	let selectedOptions: string[] = $state(['bus', 'underground']);
 	let selectedOptions2: string[] = $state([]);
 	let selectedOptions3: string[] = $state([]);
@@ -59,6 +52,12 @@
 		}
 	];
 
+	/**
+	 * The `<CheckboxGroupSolid>` component provides a way to create a set of `<CheckboxSolid>` components defined by an array of objects.
+	 *
+	 * **Alternatives**: if representing a set of options that are mutually exclusive, use the [RadioButtonSolid](./?path=/docs/ui-components-radiobuttons-radiobuttongroupsolid--documentation).
+	 * Consider using the [Checkbox](./?path=/docs/ui-components--checkboxes-checkbox--documentation)/[CheckboxGroup](./?path=/docs/ui-components-checkboxes-checkboxgroup--documentation).
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Checkboxes/CheckboxGroupSolid',
 		component: CheckboxGroupSolid,

--- a/packages/ui/src/lib/colorLegends/ColorLegend.stories.svelte
+++ b/packages/ui/src/lib/colorLegends/ColorLegend.stories.svelte
@@ -38,6 +38,10 @@
 
 	import Button from '../button/Button.svelte';
 
+	/**
+	 * The `<ColorLegend>` component draws a legend for a D3 color scale.
+	 *
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Legends/ColorLegend',
 		component: ColorLegend,

--- a/packages/ui/src/lib/colorLegends/ColorLegendOrdinalChips.stories.svelte
+++ b/packages/ui/src/lib/colorLegends/ColorLegendOrdinalChips.stories.svelte
@@ -2,6 +2,11 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import ColorLegendOrdinalChips from './ColorLegendOrdinalChips.svelte';
 
+	/**
+	 * The `<ColorLegendOrdinalHorizontal>` component draws a legend for an ordinal D3 color scale.
+	 *
+	 * **Alternatives**: [ColorLegend](./?path=/docs/ui-components-legends-colorlegend--documentation) can draw a legend for an ordinal scale, but with a different appearance.
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Legends/ColorLegendOrdinalChips',
 		component: ColorLegendOrdinalChips,

--- a/packages/ui/src/lib/copyButton/CopyButton.stories.svelte
+++ b/packages/ui/src/lib/copyButton/CopyButton.stories.svelte
@@ -9,6 +9,7 @@
 	 * for specific content. The button has a copied state to indicate the copy
 	 * was successful. The button will revert back to an uncopied state if
 	 * another copy button is clicked or after several seconds.
+	 *
 	 */
 
 	const { Story } = defineMeta({

--- a/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.stories.svelte
+++ b/packages/ui/src/lib/dataDownloadButton/DataDownloadButton.stories.svelte
@@ -4,11 +4,17 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import DataDownloadButton from './DataDownloadButton.svelte';
 
+	/**
+	 * The `<DataDownloadButton>` component renders a button which, when clicked on, triggers the download of a file containing data that was passed as a prop.
+	 */
 	const data = [
 		{ A: 1, B: 2, C: 3 },
 		{ A: 4, B: 5, C: 6 },
 		{ A: 7, B: 8, C: 9 }
 	];
+	/**
+	 * The `<DataDownloadButton>` component renders a button which, when clicked on, triggers the download of a file containing data that was passed as a prop.
+	 */
 
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Buttons/DataDownloadButton',

--- a/packages/ui/src/lib/header/Header.stories.svelte
+++ b/packages/ui/src/lib/header/Header.stories.svelte
@@ -10,8 +10,9 @@
 	/**
 	 * The `<Header>` component appears at the top of a page.
 	 * It typically includes the app name, links to other pages (if the app has multiple pages), and a login/logout control (if the app requires authentication).
+	 *
 	 */
-	let { Story } = defineMeta({
+	const { Story } = defineMeta({
 		title: 'Ui/Components - Layout And Themes/Header',
 		component: Header as any,
 		tags: ['autodocs'],

--- a/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControl.stories.svelte
@@ -4,6 +4,9 @@
 	import LayerControl from './LayerControl.svelte';
 	import { colorNames } from './layerControlUtils';
 
+	/**
+	 * The `LayerControl` component combines a checkbox with color and opacity controls.
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Layer Controls/LayerControl',
 		component: LayerControl,

--- a/packages/ui/src/lib/layerControl/LayerControlGroup.stories.svelte
+++ b/packages/ui/src/lib/layerControl/LayerControlGroup.stories.svelte
@@ -3,6 +3,10 @@
 	import LayerControlGroup from './LayerControlGroup.svelte';
 	import { colorNames } from './layerControlUtils';
 
+	/**
+	 * The `<LayerControlGroup>` component provides a way to create a set of `<LayerControl>` components defined by an array of objects.
+	 *
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Layer Controls/LayerControlGroup',
 		component: LayerControlGroup,

--- a/packages/ui/src/lib/loadingIndicator/LoadingIndicator.stories.svelte
+++ b/packages/ui/src/lib/loadingIndicator/LoadingIndicator.stories.svelte
@@ -9,6 +9,7 @@
 	 *
 	 * In cases where the user prefers reduced motion, the `<Spinner>` is replaced with
 	 * a clock icon.
+	 *
 	 */
 
 	const { Story } = defineMeta({

--- a/packages/ui/src/lib/multipleActionButton/MultipleActionButton.stories.svelte
+++ b/packages/ui/src/lib/multipleActionButton/MultipleActionButton.stories.svelte
@@ -28,6 +28,10 @@
 		}
 	];
 
+	/**
+	 * The `MultipleActionButton` combines a button and popover menu, so that the user can select which action
+	 * (or variation on an action) will be performed when the button is pressed.
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Buttons/MultipleActionButton',
 		component: MultipleActionButton,

--- a/packages/ui/src/lib/overlay/Overlay.stories.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.stories.svelte
@@ -6,6 +6,12 @@
 	import { Cog6Tooth } from '@steeze-ui/heroicons';
 	import Button from '../button/Button.svelte';
 
+	/**
+	 * The `<Overlay>` component provides additional explanatory or help text when a user interacts with a trigger.
+	 * You can choose whether this is a modal, popover or tooltip, depending on your needs.
+	 *
+	 * The trigger can either be the built in `<Trigger>` component or a custom trigger provided as a snippet.
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Overlays/Overlay',
 		component: Overlay,

--- a/packages/ui/src/lib/pageMetadata/PageMetadata.stories.svelte
+++ b/packages/ui/src/lib/pageMetadata/PageMetadata.stories.svelte
@@ -3,6 +3,15 @@
 
 	import PageMetadata from './PageMetadata.svelte';
 
+	/**
+	 * The `<PageMetadata>` component adds metadata (`<meta>`) tags to the `<head>` of the page.
+	 * These tags are used for indexing by search engines, and for constructing preview links on search engine results pages (e.g. Google, DuckDuckGo), social media platforms (e.g. X/Twitter, Facebook), and communication platforms (e.g. MS Teams, WhatsApp).
+	 *
+	 * The `title`, `description` and `url` are required - if any of them are missing, then the component will throw an `Error` that prevents the site from building.
+	 *
+	 * The definitions of properties below are taken from [https://ogp.me](https://ogp.me).
+	 *
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components - Layout And Themes/Meta, Analytics And Cookies/PageMetadata',
 		component: PageMetadata,

--- a/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButtonGroup.stories.svelte
@@ -5,9 +5,10 @@
 	import RadioButtonGroup from './RadioButtonGroup.svelte';
 
 	/**
-	 * This provides a (round) radio-button component that can also be coloured and act as both a categorical color legend, and a control for which categories of things are displayed on a map or visualization.
+	 * The `<RadioButtonGroup>` provides a way to create a set of `<RadioButton>` components defined by an array of objects.
 	 *
 	 * **Alternatives**: if representing a set of options that are not mutually exclusive, use the [Checkbox](./?path=/docs/ui-components-checkboxes-checkbox--documentation)/[CheckboxGroup](./?path=/docs/ui-components-checkboxes-checkboxgroup--documentation) rather than the [RadioButton](./?path=/docs/ui-components-radiobuttons-radiobutton--documentation)/[RadioButtonGroup](./?path=/docs/ui-components-radiobuttons-radiobuttongroup--documentation).
+	 * If the number of alternatives is small and one must be selected, consider using the [RadioButtonSolid](./?path=/docs/ui-components-radiobuttons-radiobuttongroupsolid--documentation).
 	 */
 
 	const { Story } = defineMeta({

--- a/packages/ui/src/lib/select/Select.stories.svelte
+++ b/packages/ui/src/lib/select/Select.stories.svelte
@@ -4,6 +4,13 @@
 	import Overlay from '../overlay/Overlay.svelte';
 	import Select from './Select.svelte';
 
+	/**
+	 * The `Select` component allows users to select an option from a drop-down list of alternatives.
+	 * Our select element is a wrapper around ['svelecte'](https://github.com/mskocik/svelecte).
+	 * Many of the props exposed by this component are provided by `svelecte`, so you may find it helpful to consult its [documentation](https://svelecte.vercel.app/).
+	 *
+	 * Notably, this wrapper applies the `InputWrapper` chrome (label, description, tooltip, error, etc.), and adds a Boolean `reorderable` prop.
+	 */
 	const options: Option[] = [
 		{ label: 'One', value: 1 },
 		{ label: 'Two', value: 2 },
@@ -46,7 +53,11 @@
 	];
 
 	/**
-	 * The `<Select>` component wraps a 'Svelecte' instance. Check the documentation: [here](https://svelecte.vercel.app).
+	 * The `Select` component allows users to select an option from a drop-down list of alternatives.
+	 * Our select element is a wrapper around ['svelecte'](https://github.com/mskocik/svelecte).
+	 * Many of the props exposed by this component are provided by `svelecte`, so you may find it helpful to consult its [documentation](https://svelecte.vercel.app/).
+	 *
+	 * Notably, this wrapper applies the `InputWrapper` chrome (label, description, tooltip, error, etc.), and adds a Boolean `reorderable` prop.
 	 */
 
 	const { Story } = defineMeta({

--- a/packages/ui/src/lib/sidebar/elements/sidebarFooter/SidebarFooter.stories.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarFooter/SidebarFooter.stories.svelte
@@ -12,7 +12,8 @@
 
 	const { Story } = defineMeta({
 		title: 'Ui/Components - Layout And Themes/Sidebar/elements/SidebarFooter',
-		component: SidebarFooter
+		component: SidebarFooter,
+		tags: ['autodocs']
 	});
 </script>
 

--- a/packages/ui/src/lib/sidebar/elements/sidebarHeader/SidebarHeader.stories.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarHeader/SidebarHeader.stories.svelte
@@ -1,11 +1,15 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import Overlay from '../../../overlay/Overlay.svelte';
 	import SidebarHeader from './SidebarHeader.svelte';
 
+	/**
+	 * The `<SidebarHeader>` creates a header at the top of a `<Sidebar>`.
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components - Layout And Themes/Sidebar/elements/SidebarHeader',
-		component: SidebarHeader
+		component: SidebarHeader,
+		tags: ['autodocs']
 	});
 </script>
 

--- a/packages/ui/src/lib/sidebar/elements/sidebarToggle/SidebarToggle.stories.svelte
+++ b/packages/ui/src/lib/sidebar/elements/sidebarToggle/SidebarToggle.stories.svelte
@@ -6,6 +6,9 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import SidebarToggle from './SidebarToggle.svelte';
 
+	/**
+	 * The `<SidebarToggle>` component is the button that can be clicked on to open or close the `<Sidebar>`.
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components - Layout And Themes/Sidebar/elements/SidebarToggle',
 		component: SidebarToggle,

--- a/packages/ui/src/lib/tabs/TabList.svelte
+++ b/packages/ui/src/lib/tabs/TabList.svelte
@@ -1,11 +1,13 @@
-<script lang="ts">
+<script module lang="ts">
 	/**
 	 * The `<TabList>` component allows users to select a tab from a list of options.
 	 *
 	 * **Alternatives**: if the user's choice doesn't replace what is rendered below (or, for vertical tabs, to the side of) the control then use the [RadioButton](./?path=/docs/uicomponents-radiobuttons-radiobutton--documentation)/[RadioButtonGroup](./?path=/docs/ui-components-radiobuttons-radiobuttongroup--documentation) or [RadioButtonSolid](./?path=/docs/ui-components-radiobuttons-radiobuttongroupsolid--documentation).
 	 * @component
 	 */
+</script>
 
+<script lang="ts">
 	import { Icon } from '@steeze-ui/svelte-icon';
 	import { classNames } from '../utils/classNames';
 	import { tabFocus } from './actions';

--- a/packages/ui/src/lib/tabs/Tabs.stories.svelte
+++ b/packages/ui/src/lib/tabs/Tabs.stories.svelte
@@ -11,6 +11,10 @@
 	import { First, Fourth, Second, Third } from './demoSections';
 	import type { Tab } from './types';
 
+	/**
+	 * The `<Tabs>` component creates an accessible set of tabs comprised of a `<TabList>` containing a set of `<TabLabel>`. Selecting a tab will make the relevant content in the associated `<TabPanel>` visible.
+	 *
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Tabs',
 		component: Tabs,

--- a/packages/ui/src/lib/theme/ThemeSwitcher.stories.svelte
+++ b/packages/ui/src/lib/theme/ThemeSwitcher.stories.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import ThemeSwitcher from './ThemeSwitcher.svelte';
 
@@ -6,6 +6,7 @@
 	 * The `<ThemeSwitcher>` component provides a select for the current theme - light, dark or system.
 	 *
 	 * **Important**: Requires the inclusion of the sibling "Theme" component. This should be implemented in the top level Layout component of the app. The theme switcher can then live at any level(s)
+	 *
 	 */
 
 	const { Story } = defineMeta({

--- a/packages/ui/src/lib/toaster/Toaster.stories.svelte
+++ b/packages/ui/src/lib/toaster/Toaster.stories.svelte
@@ -1,8 +1,36 @@
-<script module>
+<script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	import Toaster from './Toaster.svelte';
 
+	/**
+	 * The `<Toaster>` component acts as a container for short messages that appear temporarily ("toasts").
+	 * It can be included in the `+layout.svelte` file to avoid needing to add it to each route separately.
+	 *
+	 * On a page that includes a `<Toaster>` component, you can create a toast using the `newToastMessage()` function,
+	 * then display it by calling `.post()` on the object it returns; calling `.post()` repeatedly will refresh the toast.
+	 * You can remove a toast by calling `.remove()`.
+	 *
+	 * ```js
+	 *  // there should be an at-sign in the package name, but JSDoc chokes on it
+	 * import { newToastMessage, ToastType, ToastMessageOptions } from 'ldn-viz/ui';
+	 *
+	 * const staticToast = newToastMessage('This is a warning!', {
+	 *	// Type: ToastMessageOptions
+	 *	// An id is rarely needed but prevents HMR duplicates.
+	 *	id: 'a-warning-toast',
+	 *	type: ToastType.Warning,
+	 *	closeButton: true,
+	 * timeToLive: 10 * 1000, // in ms, so this is 10 seconds
+	 *});
+	 *
+	 * // calling .post() repeatedly on same toast object will refresh it, rather than creating duplicate toasts
+	 * staticToast.post();
+	 * staticToast.post();
+	 *
+	 *```
+	 *
+	 */
 	const { Story } = defineMeta({
 		title: 'Ui/Components/Toaster',
 		component: Toaster,

--- a/scripts/sync-docstrings.mjs
+++ b/scripts/sync-docstrings.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+/**
+ * This script copies @component docstrings from Svelte component files
+ * to their corresponding .stories.svelte files.
+ *
+ * This is necessary because at somme point during the Svelte 5 migration,
+ * Storybook stopped extracting these comments from components itself.
+ *
+ * The @component tag is removed when copying to stories files, and the rest of
+ * the docstring is placed after the defineMeta() in a context=module script tag.
+ *
+ * Treating the sources files as strings (rather than parsing them into a tree)
+ * is potentially slightly brittle, but this should be ok as the script will be
+ * run manually and the changes it makes checked with 'git diff'.
+ *
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import process from 'node:process';
+
+import { glob } from 'glob';
+import { dirname, basename, join } from 'path';
+
+const componentFiles = await glob(process.argv.slice(-1)[0] + 'src/lib/**/*.svelte', {
+  cwd: new URL('..', import.meta.url).pathname,
+  absolute: true,
+  ignore: ['**/*.stories.svelte']
+});
+
+
+let updated = 0;
+let skipped = 0;
+let noDocstring = 0;
+let noStories = 0;
+
+for (const componentPath of componentFiles) {
+  const componentContent = readFileSync(componentPath, 'utf-8');
+
+  // Match the pattern: /** ... @component ... */
+  const docstringMatch = componentContent.match(/\/\*\*[\s\S]*?@component[\s\S]*?\*\//m);
+
+  if (!docstringMatch) {
+    noDocstring++;
+    continue;
+  }
+
+  const docstring = docstringMatch[0];
+
+  // Remove the line like: " * @component" or "\t * @component"
+  let storiesDocstring = docstring.replace(/^[\t ]*\*[\t ]*@component[\t ]*\n?/m, '');
+
+  // Normalize indentation
+  const docLines = storiesDocstring.split('\n');
+  const normalizedLines = docLines.map((line) => {
+    // Remove leading tab(s) but preserve space before * in continuation lines (" * ") to align nicely with "/**" and "*/"
+    const content = line.replace(/^\t+/, '');
+
+    // Add single tab for non-empty lines
+    return content ? '\t' + content : '';
+  });
+  storiesDocstring = normalizedLines.join('\n');
+
+  // Find the corresponding stories file
+  const dir = dirname(componentPath);
+  const name = basename(componentPath, '.svelte');
+  const storiesPath = join(dir, `${name}.stories.svelte`);
+
+  if (!existsSync(storiesPath)) {
+    noStories++;
+    console.log(`No stories file for: ${componentPath}`);
+    continue;
+  }
+
+  let storiesContent = readFileSync(storiesPath, 'utf-8');
+
+  const moduleScriptMatch = storiesContent.match(/<script\s+module\s+lang="ts">/);
+  if (!moduleScriptMatch) {
+    console.log(`No module script in: ${storiesPath}`);
+    skipped++;
+    continue;
+  }
+
+
+  // Find the module <script> tag and extracts its contents
+  const scriptStartIndex = storiesContent.indexOf('<script module lang="ts">');
+  const scriptEndIndex = storiesContent.indexOf('</script>', scriptStartIndex);
+  const scriptContent = storiesContent.slice(
+    scriptStartIndex + '<script module lang="ts">'.length,
+    scriptEndIndex
+  );
+  const lines = scriptContent.split('\n');
+
+
+// Find the defineMeta line
+  let defineMetaLineIndex = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes('const { Story } = defineMeta(')) {
+      defineMetaLineIndex = i;
+      break;
+    }
+  }
+
+  if (defineMetaLineIndex === -1) {
+    console.log(`No defineMeta found in: ${storiesPath}`);
+    skipped++;
+    continue;
+  }
+
+  let existingDocstringStart = -1;
+  let existingDocstringEnd = -1;
+
+  // Search backwards from defineMeta to find end of existing docstring ("*/")
+  for (let i = defineMetaLineIndex - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line === '') continue; // skip blank lines
+    if (line.endsWith('*/')) {
+      existingDocstringEnd = i;
+      // Now find the start
+      for (let j = i; j >= 0; j--) {
+        if (lines[j].trim().startsWith('/**')) {
+          existingDocstringStart = j;
+          break;
+        }
+      }
+      break;
+    } else {
+      // No existing docstring before defineMeta
+      break;
+    }
+  }
+
+  let newScriptContent;
+
+  if (existingDocstringStart !== -1 && existingDocstringEnd !== -1) {
+    // Replace existing docstring
+    const beforeDocstring = lines.slice(0, existingDocstringStart).join('\n');
+    const afterDocstring = lines.slice(existingDocstringEnd + 1).join('\n');
+    newScriptContent = beforeDocstring + '\n' + storiesDocstring + '\n' + afterDocstring;
+  } else {
+    // Insert new docstring immediately before defineMeta
+    const beforeInsert = lines.slice(0, defineMetaLineIndex).join('\n');
+    const afterInsert = lines.slice(defineMetaLineIndex).join('\n');
+    newScriptContent = beforeInsert + storiesDocstring + '\n\n' + afterInsert;
+  }
+
+  const newStoriesContent =
+    storiesContent.slice(0, scriptStartIndex + '<script module lang="ts">'.length) +
+    newScriptContent +
+    storiesContent.slice(scriptEndIndex);
+
+  if (newStoriesContent !== storiesContent) {
+    writeFileSync(storiesPath, newStoriesContent);
+    console.log(`Updated: ${storiesPath}`);
+    updated++;
+  } else {
+    skipped++;
+  }
+}
+
+console.log(`\nSummary:`);
+console.log(`  Updated: ${updated}`);
+console.log(`  Skipped (no changes): ${skipped}`);
+console.log(`  No @component docstring: ${noDocstring}`);
+console.log(`  No stories file: ${noStories}`);

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,9 @@
 		"lint": {
 			"dependsOn": ["^lint"]
 		},
+		"sync-docstrings": {
+			"dependsOn": ["^sync-docstrings"]
+		},
 		"check-types": {
 			"dependsOn": ["^check-types"]
 		},


### PR DESCRIPTION
 This adds a script to copy @component docstrings from Svelte component files to their corresponding .stories.svelte files.
 
 This is necessary because at somme point during the Svelte 5 migration, Storybook stopped extracting these comments from components itself so they were effectively hidden from our online documentation.