### PR TITLE
Footer without children

### DIFF
--- a/.changeset/cute-moles-dig.md
+++ b/.changeset/cute-moles-dig.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: `Footer` does not render a div when it has no children.

--- a/packages/ui/src/lib/footer/Footer.stories.svelte
+++ b/packages/ui/src/lib/footer/Footer.stories.svelte
@@ -1,7 +1,7 @@
 <script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
-	import Footer from './Footer.svelte';
 	import LogoMayor from '../logos/LogoMayor.svelte';
+	import Footer from './Footer.svelte';
 
 	/**
 	 * The `<Footer>` component appears at the bottom of a page.
@@ -40,6 +40,12 @@
 <Story name="With Custom logos">
 	{#snippet template()}
 		<Footer {logos}><p>Footer Children</p></Footer>
+	{/snippet}
+</Story>
+
+<Story name="Without children">
+	{#snippet template()}
+		<Footer {logos} />
 	{/snippet}
 </Story>
 

--- a/packages/ui/src/lib/footer/Footer.svelte
+++ b/packages/ui/src/lib/footer/Footer.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+	import { classNames } from '@ldn-viz/ui';
 	import type { Snippet } from 'svelte';
-	import FooterCookieMenu from './FooterCookieMenu.svelte';
 	import LogoCIU from '../logos/LogoCIU.svelte';
+	import FooterCookieMenu from './FooterCookieMenu.svelte';
 
 	interface Props {
 		/**
@@ -23,29 +24,34 @@
 		logos,
 		children
 	}: Props = $props();
+
+	const logoClasses = $derived(
+		classNames(
+			'flex bg-color-container-level-0 px-4 pb-4 text-color-text-primary sm:flex-row-reverse md:px-8',
+			!children ? 'pt-4' : ''
+		)
+	);
 </script>
 
 <footer class="{theme} mt-auto">
-	<div
-		class="border-t border-color-ui-border-secondary bg-color-container-level-0 px-4 py-4 text-color-text-primary sm:flex sm:space-x-4 md:px-8"
-	>
-		<!-- Contents of the footer -->
-		{@render children?.()}
-	</div>
+	{#if children}
+		<div
+			class="border-t border-color-ui-border-secondary bg-color-container-level-0 px-4 py-4 text-color-text-primary sm:flex sm:space-x-4 md:px-8"
+		>
+			<!-- Contents of the footer -->
+			{@render children?.()}
+		</div>
+	{/if}
 
 	{#if showCiuLogo}
-		<div
-			class="flex bg-color-container-level-0 px-4 pb-4 text-color-text-primary sm:flex-row-reverse md:px-8"
-		>
+		<div class={logoClasses}>
 			<div>
 				<p class="mb-1 text-xs tracking-wide">Designed and developed by</p>
 				<LogoCIU class="h-4" />
 			</div>
 		</div>
 	{:else if logos}
-		<div
-			class="flex bg-color-container-level-0 px-4 pb-4 text-color-text-primary sm:flex-row-reverse md:px-8"
-		>
+		<div class={logoClasses}>
 			{@render logos()}
 		</div>
 	{/if}


### PR DESCRIPTION
**What does this change?**
Refactored `<Footer>` so that it does not render an empty div when no children has been passed to it.

Added `logoClasses` that add a `pt-4` class when Footer has no children. 

<img width="650" height="84" alt="Screenshot 2026-02-03 at 10 08 48" src="https://github.com/user-attachments/assets/d7e943de-d3b7-42b4-a8a8-f0c9cff7d891" />

**Related issues**:

**Does this introduce new dependencies?**
No

**How is it tested?**
[Storybook](https://dev.ldn-gis.co.uk/storybook-footer-withoutChildren/?path=/story/ui-components-layout-and-themes-footer--without-children)

**How is it documented?**
[Storybook](https://dev.ldn-gis.co.uk/storybook-footer-withoutChildren/?path=/story/ui-components-layout-and-themes-footer--without-children)

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
