### PR TITLE
add backgroundColor prop to BarDivergingCell

### DIFF
--- a/.changeset/diverging-cell-backgrounds.md
+++ b/.changeset/diverging-cell-backgrounds.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/tables': minor
+---
+
+CHANGED: `BarDivergingCell` now has a `backgroundColor` prop

--- a/packages/tables/src/lib/core/renderers/BarDivergingCell.stories.svelte
+++ b/packages/tables/src/lib/core/renderers/BarDivergingCell.stories.svelte
@@ -55,6 +55,16 @@
 	{/snippet}
 </Story>
 
+<Story name="Changing background colors">
+	{#snippet template(args)}
+		<div class="flex w-36 flex-col">
+			<BarDivergingCell {...args} value={-1} extent={[-2, +2]} backgroundColor="lightGrey" />
+			<BarDivergingCell {...args} value={-1} extent={[-2, +2]} backgroundColor="aliceblue" />
+			<BarDivergingCell {...args} value={-1} extent={[-2, +2]} backgroundColor="cornsilk" />
+		</div>
+	{/snippet}
+</Story>
+
 <Story name="Custom text size">
 	{#snippet template({ args })}
 		<div class="flex w-36 flex-col">

--- a/packages/tables/src/lib/core/renderers/BarDivergingCell.svelte
+++ b/packages/tables/src/lib/core/renderers/BarDivergingCell.svelte
@@ -16,6 +16,7 @@
 		textSize = 16,
 		positiveColor = 'blue',
 		negativeColor = 'red',
+		backgroundColor = 'lightgrey',
 		extent = [0, 1],
 		width = 100,
 		..._rest
@@ -40,7 +41,7 @@
 			{width}
 			y={barVerticalPadding}
 			height={height - 2 * barVerticalPadding}
-			fill="lightgrey"
+			fill={backgroundColor}
 		/>
 
 		<!-- data bar -->

--- a/packages/tables/src/lib/core/renderers/BarDivergingCellProps.ts
+++ b/packages/tables/src/lib/core/renderers/BarDivergingCellProps.ts
@@ -21,6 +21,12 @@ export interface BarDivergingCellProps {
 	 * Color to be applied to bars corresponding to negative values.
 	 */
 	negativeColor?: string | ((value: number) => string);
+
+	/**
+	 * Color to be applied to the background 'track'.
+	 */
+	backgroundColor?: string;
+
 	extent?: any; // used to pass automatically extracted val
 	/**
 	 * Width of cell (in pixels).


### PR DESCRIPTION
This change was originally made in the HSDS Hub, where the background color was set to `theme.currentTheme.color.chart.grid`.