### PR TITLE
A11y: fixed modal auto focus

### DIFF
--- a/.changeset/tasty-words-shake.md
+++ b/.changeset/tasty-words-shake.md
@@ -1,0 +1,6 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: Modal sets focus to description
+ADDED: Modal example of setting focus when description doesn't exist

--- a/packages/ui/src/lib/modal/Modal.stories.svelte
+++ b/packages/ui/src/lib/modal/Modal.stories.svelte
@@ -22,6 +22,8 @@
 	let isOpenLightTheme = $state(false);
 	let isOpenWide = $state(false);
 	let isOpenButtons = $state(false);
+
+	let contentEl = $state<HTMLElement>();
 </script>
 
 <Story name="Default">
@@ -250,6 +252,28 @@
 			{#snippet description()}
 				This demonstrates how to use the Trigger component.
 			{/snippet}
+		</Modal>
+	{/snippet}
+</Story>
+
+<!-- If the modal has no description, ensure you set the auto focus to the first interactive element or (if the first interactive element is too far down) the first element. See [WAI ARIA Modal Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) -->
+
+<Story name="No Description">
+	{#snippet template(args)}
+		<Modal
+			{...args}
+			hintLabel="Open Dialog"
+			onOpenAutoFocus={(e) => {
+				e.preventDefault();
+				contentEl?.focus();
+			}}
+		>
+			{#snippet title()}
+				Account settings
+			{/snippet}
+
+			<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+			<p bind:this={contentEl} tabindex={-1}>No description here, just contents!</p>
 		</Modal>
 	{/snippet}
 </Story>

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -31,6 +31,7 @@
 		headerTheme?: 'light' | 'dark';
 
 		contentProps?: WithoutChild<Dialog.ContentProps>;
+		onOpenAutoFocus?: Dialog.ContentProps['onOpenAutoFocus'];
 		// ...other component props if you wish to pass them
 	};
 
@@ -62,6 +63,11 @@
 		 */
 		headerTheme = 'dark',
 
+		onOpenAutoFocus = (e) => {
+			e.preventDefault();
+			descriptionEl?.focus();
+		},
+
 		...restProps
 	}: Props = $props();
 
@@ -87,7 +93,7 @@
 		)
 	);
 
-	let descriptionEl: Element;
+	let descriptionEl = $state<HTMLElement>();
 </script>
 
 {#snippet modalTrigger()}
@@ -112,14 +118,7 @@
 	<Dialog.Portal>
 		<Dialog.Overlay class="fixed inset-0 z-40 bg-black/60" />
 		<div class="pointer-events-none fixed inset-2 z-50 flex items-center justify-center sm:inset-8">
-			<Dialog.Content
-				{...contentProps}
-				class={modalClass}
-				onOpenAutoFocus={(e) => {
-					e.preventDefault();
-					descriptionEl?.focus();
-				}}
-			>
+			<Dialog.Content {...contentProps} class={modalClass} {onOpenAutoFocus}>
 				<div
 					class={`relative flex items-center justify-between border-l-[5px] border-color-static-brand bg-color-container-level-1 p-3 pr-4 text-color-text-primary ${headerTheme}`}
 				>
@@ -138,9 +137,12 @@
 
 				<div class="overflow-y-auto">
 					<div class="px-4 py-6">
-						<Dialog.Description>
-							<span bind:this={descriptionEl}>{@render description?.()}</span>
-						</Dialog.Description>
+						{#if description}
+							<Dialog.Description>
+								<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+								<p bind:this={descriptionEl} tabindex={-1}>{@render description?.()}</p>
+							</Dialog.Description>
+						{/if}
 						{@render children?.()}
 					</div>
 				</div>


### PR DESCRIPTION
**What does this change?**
- Updates `descriptionEl` type from `Element` to `HTMLElement` and sets it as a `$state` variable.
- Adds a `tabindex={-1}` to the description element.
- Exposes an `onOpenAutoFocus` prop for modifying the focus when a description snippet doesn't exist and adds a story demonstrating this use
     Note: TypeScript complains about the onOpenAutoFocus prop in Modal.stories.svelte but it's wrong

**Why?**
- Ensure keyboard users can access modal content

**How?**

**Related issues**:

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**
N/A

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
