### PR TITLE
refactored RadioButton structure and id prop

### DIFF
--- a/.changeset/shaggy-peaches-give.md
+++ b/.changeset/shaggy-peaches-give.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: RadioButton does not prepend id with input- to ensure consistent behaviour with Checkbox and allow external labels to describe input

--- a/packages/ui/src/lib/radioButton/RadioButton.svelte
+++ b/packages/ui/src/lib/radioButton/RadioButton.svelte
@@ -34,13 +34,11 @@
 		hintLabel = '',
 		customOverlay = undefined
 	}: Props = $props();
-
-	let inputID = $derived(`input-${id}`);
 </script>
 
-<label class="flex items-center">
+<div class="flex items-center">
 	<input
-		id={inputID}
+		{id}
 		class="form-radio"
 		type="radio"
 		bind:group={selectedId}
@@ -53,7 +51,7 @@
 			: ''}
 	/>
 	{#if label}
-		<span class="form-label ml-2 font-normal">{label}</span>
+		<label class="form-label ml-2 font-normal" for={id}>{label}</label>
 	{/if}
 
 	{#if hint}
@@ -68,7 +66,7 @@
 	{#if customOverlay}
 		{@render customOverlay()}
 	{/if}
-</label>
+</div>
 
 <style>
 	.form-radio:before {


### PR DESCRIPTION
**What does this change?**
Inside the `RadioButton` component:
- Changed `label` to `div` wrapper element
- Changed `span` to `label` element for conditional rendering of a label
- Refactored to remove prepending of `input-` to id

**Why?**
Previously, `RadioButton` inside [LayerControlGroup mutually exclusive layers](https://greater-london-authority.github.io/ldn-viz-tools/?path=/story/ui-components-layer-controls-layercontrolgroup--mutually-exclusive-layers) was not being described correctly by screen readers.

Even though the label string was empty, the input was wrapped in a label, so it was perceived as independent from the other controls and label in `LayerControl`.

Additionally, the `RadioButton` mutated the id, prepending `input-` to id, meaning external label elements were not pointing to the correct element and so the screen reader couldn't find the label.

This also ensures consistency with the `Checkbox` component, which follows the pattern in this PR.

**Related issues**:
Resolves #1312 

**Does this introduce new dependencies?**
No

**How is it tested?**
Storybook

**How is it documented?**
Storybook

**Are light and dark themes considered?**

**Is it complete?**

- [x] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?