### PR TITLE
make open prop optional for Overlay/Popover/Tooltip

### DIFF
--- a/.changeset/overlay-props.md
+++ b/.changeset/overlay-props.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+CHANGED: made `open` prop optional for `Overlay`/`Popover`/`Tooltip`

--- a/packages/ui/src/lib/overlay/Overlay.svelte
+++ b/packages/ui/src/lib/overlay/Overlay.svelte
@@ -32,7 +32,7 @@
 			| 'full';
 		children: Snippet;
 		trigger?: Snippet<[Record<string, any>]>;
-		open: boolean;
+		open?: boolean;
 	}
 
 	let {

--- a/packages/ui/src/lib/popover/Popover.svelte
+++ b/packages/ui/src/lib/popover/Popover.svelte
@@ -11,7 +11,7 @@
 		hintLabel?: string;
 		title?: Snippet;
 		trigger?: Snippet<[Record<string, any>]>;
-		open: boolean;
+		open?: boolean;
 	};
 
 	let {

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -6,7 +6,7 @@
 	type Props = Tooltip.RootProps & {
 		hintLabel?: string;
 		trigger?: Snippet<[Record<string, any>]>;
-		open: boolean;
+		open?: boolean;
 
 		/**
 		 * Defaults to `true`, which causes the Tooltip to close as the user


### PR DESCRIPTION
This prop should be optional, as it only neds to be bound to when the overlay is being externally controlled. Currently apps have type errors due to not providing it when it is not needed.