### PR TITLE
disable MultipleActionButton if no actions are enabled

### DIFF
--- a/.changeset/button-no-actions.md
+++ b/.changeset/button-no-actions.md
@@ -1,0 +1,5 @@
+---
+'@ldn-viz/ui': minor
+---
+
+FIXED: `MultipleActionButton` is disabled if it has no options

--- a/packages/ui/src/lib/multipleActionButton/MultipleActionButton.stories.svelte
+++ b/packages/ui/src/lib/multipleActionButton/MultipleActionButton.stories.svelte
@@ -166,6 +166,17 @@
 	{/snippet}
 </Story>
 
+<Story name="No options">
+	{#snippet template(args)}
+		<MultipleActionButton
+			{...args}
+			options={[]}
+			menuTitle="Select image format"
+			onClick={handleClick}
+		/>
+	{/snippet}
+</Story>
+
 <Story name="Outline variant">
 	{#snippet template(args)}
 		<MultipleActionButton

--- a/packages/ui/src/lib/multipleActionButton/MultipleActionButton.svelte
+++ b/packages/ui/src/lib/multipleActionButton/MultipleActionButton.svelte
@@ -69,6 +69,7 @@
 			{variant}
 			{fullWidth}
 			{...restProps}
+			disabled={restProps.disabled ?? options.length === 0}
 			class={`${variant === 'outline' ? 'border-r-0' : ''}`}
 		>
 			<div class="flex items-center">
@@ -83,7 +84,14 @@
 				aria-label={menuTitle ? 'Open popover to ' + menuTitle : 'Open popover'}
 			>
 				{#snippet child({ props })}
-					<Button {...props} class={triggerClasses} variant="square" {size} {...restProps}>
+					<Button
+						{...props}
+						class={triggerClasses}
+						variant="square"
+						{size}
+						{...restProps}
+						disabled={restProps.disabled ?? options.length === 0}
+					>
 						{#if size === 'xs'}
 							<Icon src={ChevronDown} theme="mini" class="h-4 w-4" aria-hidden="true" />
 						{:else}


### PR DESCRIPTION
Currently, if a `MultipleActionButton` has no associated actions then it is still enabled, and clicking on it throws an error.