### PR TITLE
Changed to d3 normal distribution in histogram and fixed color in tre…

### DIFF
--- a/packages/charts/src/lib/examples/histograms/Histogram.stories.svelte
+++ b/packages/charts/src/lib/examples/histograms/Histogram.stories.svelte
@@ -1,12 +1,17 @@
 <script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
-	import { randomVals as chartData } from '../../../data/demoData';
+	// import { randomVals as chartData } from '../../../data/demoData';
+	import { randomNormal } from 'd3';
 	import ObservablePlot from '../../observablePlot/ObservablePlot.svelte';
 	import { Plot } from '../../observablePlotFragments/plot';
 
 	const { Story } = defineMeta({
 		title: 'Charts/Examples/Histograms'
 	});
+
+	const getRandomNormal = randomNormal(0.5, 0.2);
+	const randomVals = [...Array(1000)].map(() => ({ x: getRandomNormal() }));
+	const chartData = randomVals;
 
 	// Spec and data for histogram example (default)
 	let spec = $derived({
@@ -29,13 +34,13 @@
 		<ObservablePlot
 			{spec}
 			data={chartData}
-			title="Using the RectY mark to create a histogram that shows Math.random samples from a uniform distribution"
+			title="Using the RectY mark to create a histogram that shows random samples from a normal distribution"
 			subTitle="1000 randomly generated and binned values"
 			alt="Histogram chart of 1000 randomly generated values"
 			byline="GLA City Intelligence"
 			source="LDN Viz Tools Demo Data"
 			note="Data for demonstration only"
-			chartDescription="The histogram chart shows 1000 randomly generated and binned values in a uniform distribution. The x axis ranges in value from 0 to 1.0 and the y axis ranges in frequency from 0 to a randomly defined number."
+			chartDescription="The histogram chart shows 1000 randomly generated and binned values in a normal distribution. The x axis ranges in value from around 0 to 1.0 and the y axis ranges in frequency from 0 to a randomly defined number."
 		/>
 	{/snippet}
 </Story>

--- a/packages/charts/src/lib/examples/treemaps/CentreTextTreemap.stories.svelte
+++ b/packages/charts/src/lib/examples/treemaps/CentreTextTreemap.stories.svelte
@@ -56,9 +56,9 @@
 		y: { axis: null },
 		color: {
 			range: [
-				theme.currentTheme.color.data.primary,
-				theme.currentTheme.color.data.secondary,
-				theme.currentTheme.color.data.tertiary
+				theme.tokenNameToValue('data.primary'),
+				theme.tokenNameToValue('data.secondary'),
+				theme.tokenNameToValue('data.tertiary')
 			]
 		},
 		marks: [

--- a/packages/charts/src/lib/examples/treemaps/TopLeftTextTreemapSimple.stories.svelte
+++ b/packages/charts/src/lib/examples/treemaps/TopLeftTextTreemapSimple.stories.svelte
@@ -74,9 +74,9 @@
 		y: { axis: null },
 		color: {
 			range: [
-				theme.currentTheme.color.data.primary,
-				theme.currentTheme.color.data.secondary,
-				theme.currentTheme.color.data.tertiary
+				theme.tokenNameToValue('data.primary'),
+				theme.tokenNameToValue('data.secondary'),
+				theme.tokenNameToValue('data.tertiary')
 			]
 		},
 		marks: [

--- a/packages/charts/src/lib/examples/treemaps/TopLeftTextTreemapVariable.stories.svelte
+++ b/packages/charts/src/lib/examples/treemaps/TopLeftTextTreemapVariable.stories.svelte
@@ -87,9 +87,9 @@
 		y: { axis: null },
 		color: {
 			range: [
-				theme.currentTheme.color.data.primary,
-				theme.currentTheme.color.data.secondary,
-				theme.currentTheme.color.data.tertiary
+				theme.tokenNameToValue('data.primary'),
+				theme.tokenNameToValue('data.secondary'),
+				theme.tokenNameToValue('data.tertiary')
 			]
 		},
 		marks: [


### PR DESCRIPTION
…emaps

**What does this change?**

- Histogram now uses d3.randomNormal as more appropriate dataset to illustrate distribution in a histgram.
- Treemaps were broken, because they were refering to colour tokens incorreclty. They now use theme.tokenNameToValue('data.primary') etc

**Why?**

**How?**

**Related issues**:

**Does this introduce new dependencies?**
No (d3)

**How is it tested?**

**How is it documented?**

**Are light and dark themes considered?**
yes 

**Is it complete?**
Yes

- [ ] Have you included changeset file?
- [ ] If this adds a new component, is it exported via `index.js`?
